### PR TITLE
Fix clash between viewmodels and viewmodels.declarative swift extensions classes

### DIFF
--- a/trikot-viewmodels-declarative/swift/uikit/VMDUIImageViewExtensions.swift
+++ b/trikot-viewmodels-declarative/swift/uikit/VMDUIImageViewExtensions.swift
@@ -15,12 +15,12 @@ extension ViewModelDeclarativeWrapper where Base : UIImageView {
         }
     }
 
-    public static var imageViewModelHandler: ImageViewModelHandler {
+    public static var imageViewModelHandler: VMDImageViewModelHandler {
         get {
-            if let customHandler = objc_getAssociatedObject(self, IMAGE_VIEW_MODEL_HANDLER_KEY) as? ImageViewModelHandler {
+            if let customHandler = objc_getAssociatedObject(self, IMAGE_VIEW_MODEL_HANDLER_KEY) as? VMDImageViewModelHandler {
                 return customHandler
             } else {
-                return DefaultImageViewModelHandler.shared
+                return VMDDefaultImageViewModelHandler.shared
             }
         }
         set(value) {
@@ -58,13 +58,13 @@ extension ViewModelDeclarativeWrapper where Base : UIImageView {
     }
 }
 
-public protocol ImageViewModelHandler {
+public protocol VMDImageViewModelHandler {
     func handleImage(imageViewModel: VMDImageViewModel?, on imageView: UIImageView)
     func handleImageDescriptor(imageDescriptor: VMDImageDescriptor?, on imageView: UIImageView)
 }
 
-private class DefaultImageViewModelHandler: ImageViewModelHandler {
-    static let shared = DefaultImageViewModelHandler()
+private class VMDDefaultImageViewModelHandler: VMDImageViewModelHandler {
+    static let shared = VMDDefaultImageViewModelHandler()
 
     private init() { }
 

--- a/trikot-viewmodels-declarative/swift/uikit/VMDUISwitchExtensions.swift
+++ b/trikot-viewmodels-declarative/swift/uikit/VMDUISwitchExtensions.swift
@@ -13,17 +13,17 @@ extension ViewModelDeclarativeWrapper where Base : UISwitch {
 
 fileprivate extension UISwitch {
     func bindViewModel(_ viewModel: VMDToggleViewModel<VMDNoContent>?) {
-        removeTarget(self, action: #selector(UISwitch.onValueChanged), for: .valueChanged)
+        removeTarget(self, action: #selector(UISwitch.onSwitchValueChanged), for: .valueChanged)
         if let toggleViewModel = viewModel {
             observe(toggleViewModel.publisher(for: \VMDToggleViewModel<VMDNoContent>.isOn)) { [weak self] isOn in
                 self?.isOn = isOn
             }
-            self.addTarget(self, action: #selector(UISwitch.onValueChanged), for: .valueChanged)
+            self.addTarget(self, action: #selector(UISwitch.onSwitchValueChanged), for: .valueChanged)
         }
     }
 
     @objc
-    private func onValueChanged(sender: UISwitch) {
+    private func onSwitchValueChanged(sender: UISwitch) {
         vmd.toggleViewModel?.onValueChange(isOn: isOn)
     }
 }


### PR DESCRIPTION
## Description
This fixes naming clashes between viewmodels and viewmodels declarative classes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
