### PR TITLE
Fix tvOS exclude files (for real)

### DIFF
--- a/Trikot.podspec
+++ b/Trikot.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |spec|
   spec.subspec 'viewmodels' do |subspec|
     subspec.source_files  = "trikot-viewmodels/swift-extensions/*.swift"
     subspec.tvos.source_files = "trikot-viewmodels/swift-extensions/*.swift"
-    subspec.tvos.exclude_files = ["trikot-viewmodels/swift-extensions/UISliderExtensions.swift", "swift-extensions/UISwitchExtensions.swift", "swift-extensions/UIPickerExtensions.swift"]
+    subspec.tvos.exclude_files = "trikot-viewmodels/swift-extensions/UISliderExtensions.swift", "trikot-viewmodels/swift-extensions/UISwitchExtensions.swift", "trikot-viewmodels/swift-extensions/UIPickerExtensions.swift"
     subspec.ios.deployment_target = '9.0'
     subspec.tvos.deployment_target = '9.0'
     subspec.dependency 'Trikot/streams'


### PR DESCRIPTION
## Description

Take 2! This time, the fix is real! 👯‍♂️ 

During the integration of Trikot mono repo in our project, we were unable to build tvOS as it was exposing extensions that were supposed to be excluded. As we can see in the screenshot, only UISliderExentions.swift was excluded.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
