### PR TITLE
Use 4 spaces indent (instead of 2)

### DIFF
--- a/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -47,6 +47,7 @@ class KWordEnumGenerate extends DefaultTask {
 
     private writeFile(ClassName generatedClassName, TypeSpec.Builder enumBuilder) {
         FileSpec.builder(generatedClassName.packageName, generatedClassName.simpleName)
+            .indent("    ")
             .addType(enumBuilder.build())
             .build()
             .writeTo(getGeneratedDir())


### PR DESCRIPTION
Reference: https://github.com/mirego/trikot.kword/pull/34

## Description
The generated `KWordTranslation` file causes ktlint errors because `kotlinpoet` uses 2 spaces as the default indent size (https://github.com/square/kotlinpoet/issues/659).

This pull request changes the indentation to 4 spaces in order to respect the [Kotlin conventions](https://kotlinlang.org/docs/coding-conventions.html#indentation)

## How Has This Been Tested?
This change has been tested in a project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
