### PR TITLE
Add Android 12 bluetooth scan and connect permission

### DIFF
--- a/trikot-bluetooth/bluetooth/src/main/AndroidManifest.xml
+++ b/trikot-bluetooth/bluetooth/src/main/AndroidManifest.xml
@@ -1,6 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.mirego.trikot.bluetooth.android">
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:ignore="UnusedAttribute" />
+
 </manifest>


### PR DESCRIPTION
## Description
Since Android 12:
-  It is now required to get permissions to scan or connect via bluetooth (reference: https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#declare-android12-or-higher).
- The user can force an approximate location (reference: https://developer.android.com/training/location/permissions#approximate-request)

## How Has This Been Tested?
This change has been tested in an app.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
