### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Trikot is a framework that helps building kotlin multiplatform apps. iOS, androi
 | [trikot.datasources](./trikot-datasources)                       | Cascading data access layers abstraction.                           |
 | [trikot.http](./trikot-http)                                     | Multiplatform http client with native platform implementations.     |
 | [trikot.graphql](./trikot-graphql)                               | GraphQL query client built over trikot.http and trikot.datasources. |
-| [trikot.analytics](./trikot-analytics)                           | AAndroid and iOS analytics providers.                               |
+| [trikot.analytics](./trikot-analytics)                           | Android and iOS analytics providers.                               |
 | [trikot.bluetooth](./trikot-bluetooth)                           | Android and iOS bluetooth.                                          |
 | [trikot.kword](./trikot-kword)                                   | i18N with code generation for string keys.                          |
 | [trikot.viewmodels](./trikot-viewmodels)                         | ViewModels for imperative frameworks (Android views and UIKit).     |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Trikot is a framework that helps building kotlin multiplatform apps. iOS, androi
 | [trikot.datasources](./trikot-datasources)                       | Cascading data access layers abstraction.                           |
 | [trikot.http](./trikot-http)                                     | Multiplatform http client with native platform implementations.     |
 | [trikot.graphql](./trikot-graphql)                               | GraphQL query client built over trikot.http and trikot.datasources. |
-| [trikot.analytics](./trikot-analytics)                           | Android and iOS analytics providers.                               |
+| [trikot.analytics](./trikot-analytics)                           | Android and iOS analytics providers.                                |
 | [trikot.bluetooth](./trikot-bluetooth)                           | Android and iOS bluetooth.                                          |
 | [trikot.kword](./trikot-kword)                                   | i18N with code generation for string keys.                          |
 | [trikot.viewmodels](./trikot-viewmodels)                         | ViewModels for imperative frameworks (Android views and UIKit).     |


### PR DESCRIPTION
## Description

There was a typo in the `trikot.analytics` module description.

## Motivation and Context

Details matter. 😉 