### PR TITLE
Remove duplicate lifecycle-reactivestreams-ktx dependency in samples.

### DIFF
--- a/trikot-viewmodels-declarative/sample/android/build.gradle.kts
+++ b/trikot-viewmodels-declarative/sample/android/build.gradle.kts
@@ -61,7 +61,6 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.4.0")
     implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:${Versions.ANDROIDX_LIFECYCLE}")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.ANDROIDX_LIFECYCLE}")
-    implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:${Versions.ANDROIDX_LIFECYCLE}")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.ANDROIDX_LIFECYCLE}")
     implementation("androidx.lifecycle:lifecycle-common-java8:${Versions.ANDROIDX_LIFECYCLE}")
     implementation("androidx.activity:activity-compose:1.4.0")


### PR DESCRIPTION
## Description
Remove duplicate lifecycle-reactivestreams-ktx dependency in viewmodels-declarative sample for Android.

## Motivation and Context
I noticed a duplicate dependency in trickot-viewmodels-declarative sample for Android, seems to be a copy/paste error.