### PR TITLE
Rename clashing Objective-C textfield selector

### DIFF
--- a/trikot-viewmodels-declarative/swift/uikit/VMDUITextFieldExtensions.swift
+++ b/trikot-viewmodels-declarative/swift/uikit/VMDUITextFieldExtensions.swift
@@ -13,9 +13,9 @@ extension ViewModelDeclarativeWrapper where Base : UITextField {
 
 fileprivate extension UITextField {
     func bindViewModel(_ textFieldViewModel: VMDTextFieldViewModel?) {
-        removeTarget(self, action: #selector(onEditingChanged), for: .editingChanged)
+        removeTarget(self, action: #selector(vmd_editingChanged), for: .editingChanged)
         if let textFieldViewModel = textFieldViewModel {
-            addTarget(self, action: #selector(onEditingChanged), for: .editingChanged)
+            addTarget(self, action: #selector(vmd_editingChanged), for: .editingChanged)
             vmd.observe(textFieldViewModel.publisher(for: \VMDTextFieldViewModel.text)) { [weak self] text in
                 guard let self = self else { return }
                 if self.text != text {
@@ -54,7 +54,7 @@ fileprivate extension UITextField {
     }
 
     @objc
-    private func onEditingChanged() {
+    private func vmd_editingChanged() {
         guard let textFieldViewModel = vmd.textFieldViewModel else { return }
         textFieldViewModel.onValueChange(text: textFieldViewModel.formatText(text ?? ""))
     }


### PR DESCRIPTION
## Description

We had a name clashing for Objective-C selectors between **trikot-viewmodel** & **trikot.viewmodel-declarative** using UIKit.

## Motivation and Context

We bring back the fix that was lost when bringing trikot to mono repo https://github.com/mirego/trikot.viewmodels.declarative/pull/40

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
