### PR TITLE
Workaround to fix a crash on iOS 14

### DIFF
--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDTextField.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDTextField.swift
@@ -45,34 +45,39 @@ public struct VMDTextField<Label>: View where Label: View {
 
     public var body: some View {
         if #available(iOS 15.0, *) {
-            if let labelBuilder = labelBuilder {
-                TextField(text: text, prompt: prompt, label: labelBuilder)
-                    .onSubmit {
-                        viewModel.onReturnKeyTap()
+            // Workaround to avoid a crash on iOS 14 in Release. Ref: https://github.com/gongzhang/swiftui-availability-check-crash
+            Group {
+                if #available(iOS 15.0, *) {
+                    if let labelBuilder = labelBuilder {
+                        TextField(text: text, prompt: prompt, label: labelBuilder)
+                            .onSubmit {
+                                viewModel.onReturnKeyTap()
+                            }
+                            .focusMe($isFocused)
+                            .onChange(of: isFocused) { isFocused in
+                                self.onFocusChange?(isFocused)
+                            }
+                            .keyboardType(viewModel.keyboardType.uiKeyboardType)
+                            .submitLabel(viewModel.keyboardReturnKeyType.submitLabel)
+                            .textContentType(viewModel.contentType?.uiTextContentType)
+                            .autocapitalization(viewModel.autoCapitalization.uiTextAutocapitalizationType)
+                            .disableAutocorrection(!viewModel.autoCorrect)
+                    } else {
+                        TextField(viewModel.placeholder, text: text, prompt: prompt)
+                            .onSubmit {
+                                viewModel.onReturnKeyTap()
+                            }
+                            .focusMe($isFocused)
+                            .onChange(of: isFocused) { isFocused in
+                                self.onFocusChange?(isFocused)
+                            }
+                            .keyboardType(viewModel.keyboardType.uiKeyboardType)
+                            .submitLabel(viewModel.keyboardReturnKeyType.submitLabel)
+                            .textContentType(viewModel.contentType?.uiTextContentType)
+                            .autocapitalization(viewModel.autoCapitalization.uiTextAutocapitalizationType)
+                            .disableAutocorrection(!viewModel.autoCorrect)
                     }
-                    .focusMe($isFocused)
-                    .onChange(of: isFocused) { isFocused in
-                        self.onFocusChange?(isFocused)
-                    }
-                    .keyboardType(viewModel.keyboardType.uiKeyboardType)
-                    .submitLabel(viewModel.keyboardReturnKeyType.submitLabel)
-                    .textContentType(viewModel.contentType?.uiTextContentType)
-                    .autocapitalization(viewModel.autoCapitalization.uiTextAutocapitalizationType)
-                    .disableAutocorrection(!viewModel.autoCorrect)
-            } else {
-                TextField(viewModel.placeholder, text: text, prompt: prompt)
-                    .onSubmit {
-                        viewModel.onReturnKeyTap()
-                    }
-                    .focusMe($isFocused)
-                    .onChange(of: isFocused) { isFocused in
-                        self.onFocusChange?(isFocused)
-                    }
-                    .keyboardType(viewModel.keyboardType.uiKeyboardType)
-                    .submitLabel(viewModel.keyboardReturnKeyType.submitLabel)
-                    .textContentType(viewModel.contentType?.uiTextContentType)
-                    .autocapitalization(viewModel.autoCapitalization.uiTextAutocapitalizationType)
-                    .disableAutocorrection(!viewModel.autoCorrect)
+                }
             }
         } else {
             TextField(viewModel.placeholder, text: text, onEditingChanged: { isEditing in


### PR DESCRIPTION
## Description

**Viewmodels Declarative iOS Components**

With Xcode 13.2.x when running on iOS 14 VMDTextField was crashing.

This is a workaround to avoir the crash until Xcode is fixed. Ref: https://github.com/gongzhang/swiftui-availability-check-crash

## How Has This Been Tested?

Tested in my project

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
