### PR TITLE
[ViewModel] Use bindViewModel in LabelViewModelBinder

### DIFF
--- a/trikot-viewmodels/sample/common/src/commonMain/kotlin/com/trikot/viewmodels/sample/viewmodels/home/LabelsViewModel.kt
+++ b/trikot-viewmodels/sample/common/src/commonMain/kotlin/com/trikot/viewmodels/sample/viewmodels/home/LabelsViewModel.kt
@@ -108,6 +108,11 @@ class LabelsViewModel :
                     )
                 )
             ).just()
-        }
+        },
+        MutableHeaderListItemViewModel(".accessibilityLabel (\"This is an accessible label\")"),
+        MutableLabelListItemViewModel().also {
+            it.label.accessibilityLabel = "This is an accessible label".just()
+            it.label.text = "I am accessible".just()
+        },
     ).just()
 }

--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/LabelViewModelBinder.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/LabelViewModelBinder.kt
@@ -1,10 +1,7 @@
 package com.mirego.trikot.viewmodels
 
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.view.View
 import android.widget.TextView
-import androidx.core.view.ViewCompat
 import androidx.databinding.BindingAdapter
 import com.mirego.trikot.streams.reactive.just
 import com.mirego.trikot.streams.reactive.observe
@@ -84,28 +81,7 @@ object LabelViewModelBinder {
         hiddenVisibility: HiddenVisibility,
         lifecycleOwnerWrapper: LifecycleOwnerWrapper
     ) {
-        labelViewModel.hidden.observe(lifecycleOwnerWrapper.lifecycleOwner) { hidden ->
-            with(textView) { visibility = if (hidden) hiddenVisibility.value else View.VISIBLE }
-        }
-
-        labelViewModel.alpha.observe(lifecycleOwnerWrapper.lifecycleOwner) { alpha ->
-            textView.alpha = alpha
-        }
-
-        labelViewModel.backgroundColor
-            .observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
-                if (selector.isEmpty) {
-                    return@observe
-                }
-
-                textView.background ?: run {
-                    ViewCompat.setBackground(textView, ColorDrawable(Color.WHITE))
-                }
-
-                ViewCompat.setBackgroundTintList(textView, selector.toColorStateList())
-            }
-
-        textView.bindAction(labelViewModel, lifecycleOwnerWrapper)
+        textView.bindViewModel(labelViewModel, hiddenVisibility, lifecycleOwnerWrapper)
     }
 }
 

--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/ViewModelBinder.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/ViewModelBinder.kt
@@ -27,9 +27,18 @@ fun View.bindViewModel(
     viewModel: ViewModel?,
     lifecycleOwnerWrapper: LifecycleOwnerWrapper
 ) {
+    bindViewModel(viewModel, HiddenVisibility.GONE, lifecycleOwnerWrapper)
+}
+
+@BindingAdapter("view_model", "hiddenVisibility", "lifecycleOwnerWrapper")
+fun View.bindViewModel(
+    viewModel: ViewModel?,
+    hiddenVisibility: HiddenVisibility,
+    lifecycleOwnerWrapper: LifecycleOwnerWrapper
+) {
     (viewModel ?: NoViewModel).let {
         it.hidden.observe(lifecycleOwnerWrapper.lifecycleOwner) { isHidden ->
-            visibility = if (isHidden) View.GONE else View.VISIBLE
+            visibility = if (isHidden) hiddenVisibility.value else View.VISIBLE
         }
 
         it.alpha.observe(lifecycleOwnerWrapper.lifecycleOwner) { alpha ->
@@ -52,20 +61,17 @@ fun View.bindViewModel(
             }
         }
 
-        bindAction(it, lifecycleOwnerWrapper)
+        it.backgroundColor.observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
+            if (selector.isEmpty) return@observe
 
-        it.backgroundColor
-            .observe(lifecycleOwnerWrapper.lifecycleOwner) { selector ->
-                if (selector.isEmpty) {
-                    return@observe
-                }
-
-                background ?: run {
-                    ViewCompat.setBackground(this, ColorDrawable(Color.WHITE))
-                }
-
-                ViewCompat.setBackgroundTintList(this, selector.toColorStateList())
+            background ?: run {
+                ViewCompat.setBackground(this, ColorDrawable(Color.WHITE))
             }
+
+            ViewCompat.setBackgroundTintList(this, selector.toColorStateList())
+        }
+
+        bindAction(it, lifecycleOwnerWrapper)
     }
 }
 


### PR DESCRIPTION
## Description

Not sure why the code was duplicated, but this is the only binder that does not call `View.bindViewModel(...)` internally. 
I realized this in my project when the new accessibility feature was not working only with labels on Android. It was already OK on iOS.

## How Has This Been Tested?

In the sample app.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
