### PR TITLE
Support branch-specific release on jenkins

### DIFF
--- a/jenkins-jobs/release.groovy
+++ b/jenkins-jobs/release.groovy
@@ -9,9 +9,17 @@ context.standardFolders()
 job(context.jobFullName) {
     description("Make a release of all trikot libraries")
     logRotator(5)
+    parameters {
+        stringParam {
+            name('branch')
+            defaultValue("${GIT_BRANCH}")
+            description('The git branch to be built')
+            trim(true)
+        }
+    }
     scm {
         git {
-            branch("${GIT_BRANCH}")
+            branch('${branch}')
             remote {
                 name('origin')
                 url("${GIT_URL}")


### PR DESCRIPTION
In order to support a parallel release of trikot with kotlin native's new memory model (since #19), we need to be able to specify the target branch when releasing this library on jenkins.
