### PR TITLE
[Streams] Add ability to bind a variable using an intermediate representation

### DIFF
--- a/trikot-streams/swift-extensions/TrikotPublisherExtensions.swift
+++ b/trikot-streams/swift-extensions/TrikotPublisherExtensions.swift
@@ -59,13 +59,6 @@ extension NSObject {
         }
     }
 
-    public func bind<T, V>(_ publisher: Publisher, _ keyPath: ReferenceWritableKeyPath<T, V>) {
-        observe(publisher) {[weak self] (newValue: V) in
-            guard let strongSelf = self as? T else { return }
-            strongSelf[keyPath: keyPath] = newValue
-        }
-    }
-
     public func observe<V>(_ concretePublisher: ConcretePublisher<V>, toClosure closure: @escaping ((V) -> Void)) {
         observe(cancellableManager: trikotInternalPublisherCancellableManager, concretePublisher: concretePublisher, toClosure: closure)
     }
@@ -83,11 +76,33 @@ extension NSObject {
         }
     }
 
+    public func bind<T, V>(_ publisher: Publisher, _ keyPath: ReferenceWritableKeyPath<T, V>) {
+        observe(publisher) {[weak self] (newValue: V) in
+            guard let strongSelf = self as? T else { return }
+            strongSelf[keyPath: keyPath] = newValue
+        }
+    }
+
     public func bind<T, V>(_ concretePublisher: ConcretePublisher<V>, _ keyPath: ReferenceWritableKeyPath<T, V>) {
         observe(concretePublisher) {[weak self] (newValue: V) in
             guard let strongSelf = self as? T else { return }
             strongSelf[keyPath: keyPath] = newValue
         }
+    }
+
+    public func bind<T, V, I>(_ publisher: Publisher, _ keyPath: ReferenceWritableKeyPath<T, V>, transform: @escaping ((I) -> V)) {
+        observe(publisher, toClosure: { [weak self] (newValue: Any?) in
+            guard let strongSelf = self as? T else { return }
+
+            if let newValue = newValue as? I {
+                strongSelf[keyPath: keyPath] = transform(newValue)
+            } else if let E = I.self as? ExpressibleByNilLiteral.Type, newValue is NSNull || newValue == nil {
+                // swiftlint:disable:next explicit_init
+                strongSelf[keyPath: keyPath] = transform(E.init(nilLiteral: ()) as! I)
+            } else {
+                assertionFailure("Incorrect binding value type" + (newValue is NSNull || newValue == nil ? " received null, property should be marked as optional" : ""))
+            }
+        })
     }
 }
 

--- a/trikot-streams/swift-extensions/TrikotPublisherExtensions.swift
+++ b/trikot-streams/swift-extensions/TrikotPublisherExtensions.swift
@@ -104,6 +104,13 @@ extension NSObject {
             }
         })
     }
+
+    public func bind<T, V, I>(_ concretePublisher: ConcretePublisher<I>, _ keyPath: ReferenceWritableKeyPath<T, V>, transform: @escaping ((I) -> V)) {
+        observe(concretePublisher, toClosure: { [weak self] (newValue: I) in
+            guard let strongSelf = self as? T else { return }
+            strongSelf[keyPath: keyPath] = transform(newValue)
+        })
+    }
 }
 
 extension Publisher {


### PR DESCRIPTION
## Description

Adds the ability to bind a publisher of value type `I` directly to a variable of type `V` by providing a transform block.

## Motivation and Context

This enables a more streamlined way to deal with differences between shared code data types and native data types.

Usage exemple:
```swift
class SomeClass {
    var location: CLLocationCoordinate2D

    func setupBindings() {
        bind(viewModel.location, \SomeClass.location) { (geoLoc: GeographicLocation) in
            CLLocationCoordinate2D(latitude: geoLoc.latitude, longitude: geoLoc.longitude)
        }
    }
}
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
