### PR TITLE
Fixed the method to observe a ViewModel as State (Jetpack Compose)

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ViewModelExtensions.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ViewModelExtensions.kt
@@ -41,7 +41,7 @@ fun <R, T : R> Publisher<T>.subscribeAsState(initial: R, key: Any? = initial): S
 @Composable
 inline fun <T, S> S.asState(
     initial: T,
-    key: Any? = initial,
+    key: Any? = null,
     crossinline subscribe: S.((T) -> Unit) -> Cancellable
 ): State<T> {
     val state = remember(key) { mutableStateOf(initial, neverEqualPolicy()) }


### PR DESCRIPTION
When observing a ViewModel asState, we now use the instance of the ViewModel as the key to decide if remember() must re-calculate the value.

## Motivation and Context

The current implementation of observeAsState() uses the remember mechanism to remember the value.  The mechanism behind Remember() is that the value is "calculated" once, and if the UI is re-composed afterward, the same value will be used.

The problem with that approach here is that if we observeAsState a ViewModel, and the _instance_ of the viewmodel changes between two recomposition, the remembered state will not be recalculated with the new instance.

By using the ViewModel instance as the "rememberance" key, we make sure that we update the State.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
