### PR TITLE
[VMD] Update VMDImageProvider's signature on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Upcoming release
+
+- [VMD] Update VMDImageProvider's signature on iOS
+
 ## 3.1.2
 
 > 2022-01-18

--- a/trikot-viewmodels-declarative/sample/ios/Sample/SampleImageProvider.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/SampleImageProvider.swift
@@ -2,7 +2,7 @@ import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
 class SampleImageProvider: VMDImageProvider {
-    func imageNameForResource(imageResource: VMDImageResource) -> UIImage? {
+    func imageForResource(imageResource: VMDImageResource) -> UIImage? {
         guard let resource = imageResource as? SampleImageResource else { return nil }
         switch resource {
         case .iconClose:

--- a/trikot-viewmodels-declarative/sample/ios/Sample/SampleImageProvider.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/SampleImageProvider.swift
@@ -2,11 +2,11 @@ import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
 class SampleImageProvider: VMDImageProvider {
-    func imageNameForResource(imageResource: VMDImageResource) -> String? {
+    func imageNameForResource(imageResource: VMDImageResource) -> UIImage? {
         guard let resource = imageResource as? SampleImageResource else { return nil }
         switch resource {
         case .iconClose:
-            return "icn_close"
+            return UIImage(named: "icn_close")
         default:
             return nil
         }

--- a/trikot-viewmodels-declarative/swift/swiftui/Extensions/VMDImageResource+Extensions.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Extensions/VMDImageResource+Extensions.swift
@@ -3,7 +3,7 @@ import TRIKOT_FRAMEWORK_NAME
 
 extension VMDImageResource {
     public var image: Image? {
-        if let uiImage = TrikotViewModelDeclarative.shared.imageProvider.imageNameForResource(imageResource: self) {
+        if let uiImage = TrikotViewModelDeclarative.shared.imageProvider.imageForResource(imageResource: self) {
             return Image(uiImage: uiImage)
         }
         return nil

--- a/trikot-viewmodels-declarative/swift/swiftui/Extensions/VMDImageResource+Extensions.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Extensions/VMDImageResource+Extensions.swift
@@ -3,8 +3,8 @@ import TRIKOT_FRAMEWORK_NAME
 
 extension VMDImageResource {
     public var image: Image? {
-        if let imageName = TrikotViewModelDeclarative.shared.imageProvider.imageNameForResource(imageResource: self) {
-            return Image(imageName)
+        if let uiImage = TrikotViewModelDeclarative.shared.imageProvider.imageNameForResource(imageResource: self) {
+            return Image(uiImage: uiImage)
         }
         return nil
     }

--- a/trikot-viewmodels-declarative/swift/uikit/VMDImageResourceExtensions.swift
+++ b/trikot-viewmodels-declarative/swift/uikit/VMDImageResourceExtensions.swift
@@ -3,6 +3,6 @@ import UIKit
 
 extension VMDImageResource {
     public var uiImage: UIImage? {
-        return TrikotViewModelDeclarative.shared.imageProvider.imageNameForResource(imageResource: self)
+        return TrikotViewModelDeclarative.shared.imageProvider.imageForResource(imageResource: self)
     }
 }

--- a/trikot-viewmodels-declarative/swift/uikit/VMDImageResourceExtensions.swift
+++ b/trikot-viewmodels-declarative/swift/uikit/VMDImageResourceExtensions.swift
@@ -3,10 +3,6 @@ import UIKit
 
 extension VMDImageResource {
     public var uiImage: UIImage? {
-        if let imageName = TrikotViewModelDeclarative.shared.imageProvider.imageNameForResource(imageResource: self) {
-            return UIImage(named: imageName)
-        } else {
-            return nil
-        }
+        return TrikotViewModelDeclarative.shared.imageProvider.imageNameForResource(imageResource: self)
     }
 }

--- a/trikot-viewmodels-declarative/viewmodels-declarative/src/iosMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProvider.kt
+++ b/trikot-viewmodels-declarative/viewmodels-declarative/src/iosMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProvider.kt
@@ -1,7 +1,8 @@
 package com.mirego.trikot.viewmodels.declarative.configuration
 
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
+import platform.UIKit.UIImage
 
 actual interface VMDImageProvider {
-    fun imageNameForResource(imageResource: VMDImageResource): String?
+    fun imageNameForResource(imageResource: VMDImageResource): UIImage?
 }

--- a/trikot-viewmodels-declarative/viewmodels-declarative/src/iosMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProvider.kt
+++ b/trikot-viewmodels-declarative/viewmodels-declarative/src/iosMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProvider.kt
@@ -4,5 +4,5 @@ import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
 import platform.UIKit.UIImage
 
 actual interface VMDImageProvider {
-    fun imageNameForResource(imageResource: VMDImageResource): UIImage?
+    fun imageForResource(imageResource: VMDImageResource): UIImage?
 }


### PR DESCRIPTION
## Description
Change `VMDImageProvider` return type to `UIImage` instead of `String`.

## Motivation and Context
- Adds compile time safety when used in conjunction with a code generator like `SwiftGen` of `R.swift`
- Adds the ability to reference system images (ex: `UIImage(systemName: "heart.fill")`)

## How Has This Been Tested?
Tested integrated with the Sample App

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
