### PR TITLE
Request unbounded events with subscribe extension

### DIFF
--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/SubscriberFromBlock.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/SubscriberFromBlock.kt
@@ -29,6 +29,7 @@ class SubscriberFromBlock<T>(
                 }
             }
         )
+        s.request(Long.MAX_VALUE)
     }
 
     override fun onNext(t: T) {

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/SubscriberFromBlockTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/SubscriberFromBlockTests.kt
@@ -8,7 +8,6 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class SubscriberFromBlockTests {
     var behaviorSubject = Publishers.behaviorSubject<String>()
@@ -40,7 +39,7 @@ class SubscriberFromBlockTests {
 
         val publisher = object : Publisher<Int> {
             override fun subscribe(s: Subscriber<in Int>) {
-                s.onSubscribe(object: Subscription {
+                s.onSubscribe(object : Subscription {
                     override fun request(n: Long) {
                         requestCount = n
                     }
@@ -51,7 +50,6 @@ class SubscriberFromBlockTests {
             }
         }
         publisher.subscribe(cancellableManager) {
-
         }
 
         assertEquals(Long.MAX_VALUE, requestCount)

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/SubscriberFromBlockTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/SubscriberFromBlockTests.kt
@@ -5,8 +5,10 @@ import com.mirego.trikot.streams.reactive.processors.AbstractProcessor
 import com.mirego.trikot.streams.reactive.processors.ProcessorSubscription
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SubscriberFromBlockTests {
     var behaviorSubject = Publishers.behaviorSubject<String>()
@@ -29,6 +31,30 @@ class SubscriberFromBlockTests {
         }
 
         assertEquals(1, count)
+    }
+
+    @Test
+    fun whenSubscribingItRequestAllEvents() {
+        val cancellableManager = CancellableManager()
+        var requestCount = 0L
+
+        val publisher = object : Publisher<Int> {
+            override fun subscribe(s: Subscriber<in Int>) {
+                s.onSubscribe(object: Subscription {
+                    override fun request(n: Long) {
+                        requestCount = n
+                    }
+
+                    override fun cancel() {
+                    }
+                })
+            }
+        }
+        publisher.subscribe(cancellableManager) {
+
+        }
+
+        assertEquals(Long.MAX_VALUE, requestCount)
     }
 
     class TriggerHappyProcessor<T>(parentPublisher: Publisher<T>, private val value: T) :


### PR DESCRIPTION
## Description
This fixes an issue where `request` would never be called on subscribe.
`request` is usually used for backpressure management which we don't support but to be compliant with the spec, we must still request for Long.MAX_VALUE events. It marks the Publisher as "effectively unbounded".

## Motivation and Context
This fix was required to be able to use coroutines interop https://github.com/Kotlin/kotlinx.coroutines/tree/master/reactive/kotlinx-coroutines-reactive

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
