### PR TITLE
[VMD] Add the possibility to animate object change in ObservableViewModelAdapter

### DIFF
--- a/trikot-viewmodels-declarative/swift/swiftui/Utilities/ObservableViewModelAdapter.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Utilities/ObservableViewModelAdapter.swift
@@ -1,4 +1,4 @@
-import UIKit
+import SwiftUI
 import Combine
 import TRIKOT_FRAMEWORK_NAME
 
@@ -7,13 +7,19 @@ public class ObservableViewModelAdapter<VM: VMDViewModel>: ObservableObject {
     private let propertyWillChangePublisher: AnyPublisher<KotlinUnit, Never>
     private var cancellable: AnyCancellable?
 
-    public init(viewModel: VM) {
+    public init(viewModel: VM, animation: Animation? = nil) {
         self.viewModel = viewModel
         self.propertyWillChangePublisher = viewModel.propertyWillChange.eraseToAnyPublisher()
         self.cancellable = propertyWillChangePublisher
             .receive(on: Foundation.DispatchQueue.main)
-            .sink { [weak self] (_) in
-                self?.objectWillChange.send()
+            .sink { [weak self] _ in
+                if let animation = animation {
+                    withAnimation(animation) {
+                        self?.objectWillChange.send()
+                    }
+                } else {
+                    self?.objectWillChange.send()
+                }
             }
     }
 
@@ -23,7 +29,7 @@ public class ObservableViewModelAdapter<VM: VMDViewModel>: ObservableObject {
 }
 
 public extension VMDViewModel {
-    func asObservable<Self>() -> ObservableViewModelAdapter<Self> {
-        return ObservableViewModelAdapter(viewModel: self as! Self)
+    func asObservable<Self>(animation: Animation? = nil) -> ObservableViewModelAdapter<Self> {
+        ObservableViewModelAdapter(viewModel: self as! Self, animation: animation)
     }
 }


### PR DESCRIPTION
## Description

This is a small first step to be able to animate modification triggered by the common code. By passing an animation to the ObservableViewModelAdapter, all changes of the object will be animated.

## How Has This Been Tested?

In my project

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
