### PR TITLE
[VMD] Fix android RemoteImage to allow alignment + add a placeholder content scale property

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -27,6 +27,7 @@ fun VMDImage(
     viewModel: VMDImageViewModel,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String = ""
@@ -40,6 +41,7 @@ fun VMDImage(
         contentScale = contentScale,
         colorFilter = colorFilter,
         contentDescription = contentDescription,
+        placeholderContentScale = placeholderContentScale,
         imageDescriptor = imageViewModel.image
     )
 }
@@ -50,6 +52,7 @@ fun VMDImage(
     imageDescriptor: VMDImageDescriptor,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String = ""
@@ -73,6 +76,7 @@ fun VMDImage(
                 placeholderImage = imageDescriptor.placeholderImageResource,
                 alignment = alignment,
                 contentScale = contentScale,
+                placeholderContentScale = placeholderContentScale,
                 colorFilter = colorFilter,
                 contentDescription = contentDescription
             )
@@ -108,6 +112,7 @@ fun RemoteImage(
     placeholderImage: VMDImageResource = VMDImageResource.None,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = ContentScale.Fit,
     colorFilter: ColorFilter? = null,
     contentDescription: String = ""
 ) {
@@ -117,9 +122,22 @@ fun RemoteImage(
             size(OriginalSize)
         }
     )
-
-    Box {
-        Image(
+    when (coilPainter.state) {
+        is ImagePainter.State.Loading -> LocalImage(
+            imageResource = placeholderImage,
+            modifier = modifier,
+            colorFilter = colorFilter,
+            contentScale = placeholderContentScale,
+            contentDescription = contentDescription
+        )
+        is ImagePainter.State.Error -> LocalImage(
+            imageResource = placeholderImage,
+            modifier = modifier,
+            colorFilter = colorFilter,
+            contentScale = placeholderContentScale,
+            contentDescription = contentDescription
+        )
+        is ImagePainter.State.Success -> Image(
             painter = coilPainter,
             modifier = modifier,
             alignment = alignment,
@@ -127,23 +145,6 @@ fun RemoteImage(
             contentScale = contentScale,
             contentDescription = contentDescription
         )
-        when (coilPainter.state) {
-            is ImagePainter.State.Loading -> LocalImage(
-                imageResource = placeholderImage,
-                modifier = modifier,
-                colorFilter = colorFilter,
-                contentScale = contentScale,
-                contentDescription = contentDescription
-            )
-            is ImagePainter.State.Error -> LocalImage(
-                imageResource = placeholderImage,
-                modifier = modifier,
-                colorFilter = colorFilter,
-                contentScale = contentScale,
-                contentDescription = contentDescription
-            )
-            else -> {
-            }
-        }
+        ImagePainter.State.Empty -> {}
     }
 }

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -27,7 +27,7 @@ fun VMDImage(
     viewModel: VMDImageViewModel,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
-    placeholderContentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String = ""
@@ -52,7 +52,7 @@ fun VMDImage(
     imageDescriptor: VMDImageDescriptor,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
-    placeholderContentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String = ""
@@ -112,7 +112,7 @@ fun RemoteImage(
     placeholderImage: VMDImageResource = VMDImageResource.None,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
-    placeholderContentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = contentScale,
     colorFilter: ColorFilter? = null,
     contentDescription: String = ""
 ) {


### PR DESCRIPTION
## Description
There was an extra Box layer wrapping the RemoteImage which was not being passed the received modifier so when passing a modifier with align properties the image was align within that extra box layer instead of within the VMDImage parent's layout.

We also add an option to add a different content scale for the placeholder image.

## Motivation and Context
 With the current implementation it is not possible to correctly align a VMDImage that is of RemoteImage type.

## How Has This Been Tested?
Tested with the sample app.

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
