### PR TITLE
[Viewmodels] Add Kingfisher image handler implementation

### DIFF
--- a/Trikot.podspec
+++ b/Trikot.podspec
@@ -40,6 +40,16 @@ Pod::Spec.new do |spec|
     subspec.dependency 'Trikot/streams'
   end
 
+  spec.subspec 'viewmodels.Kingfisher' do |subspec|
+    subspec.source_files = 'trikot-viewmodels/swift-extensions/kingfisher/*.swift'
+    subspec.tvos.source_files = 'trikot-viewmodels/swift-extensions/kingfisher/*.swift'
+    subspec.ios.deployment_target = '10.0'
+    subspec.tvos.deployment_target = '10.0'
+    subspec.dependency 'Trikot/streams'
+    subspec.dependency 'Trikot/viewmodels'
+    subspec.dependency 'Kingfisher', '>= 5.0'
+  end
+
   # View Model Declarative
   spec.subspec 'viewmodels.declarative' do |subspec|
     subspec.source_files = 'trikot-viewmodels-declarative/swift/core/**/*.swift'

--- a/trikot-viewmodels/sample/ios/Podfile
+++ b/trikot-viewmodels/sample/ios/Podfile
@@ -10,6 +10,7 @@ target 'iosApp' do
   pod 'SwiftLint'
   pod 'TRIKOT_FRAMEWORK_NAME', :path => '../common'
   pod 'Trikot/viewmodels', :path => '../../..'
+  pod 'Trikot/viewmodels.Kingfisher', :path => '../../..'
   pod 'Trikot/streams', :path => '../../..', :inhibit_warnings => true
     
   target 'iosAppTests' do

--- a/trikot-viewmodels/sample/ios/Podfile.lock
+++ b/trikot-viewmodels/sample/ios/Podfile.lock
@@ -1,9 +1,15 @@
 PODS:
+  - Kingfisher (6.3.1)
   - SwiftLint (0.43.0)
   - Trikot/streams (1.0.0):
     - TRIKOT_FRAMEWORK_NAME
   - Trikot/viewmodels (1.0.0):
     - Trikot/streams
+    - TRIKOT_FRAMEWORK_NAME
+  - Trikot/viewmodels.Kingfisher (1.0.0):
+    - Kingfisher (>= 5.0)
+    - Trikot/streams
+    - Trikot/viewmodels
     - TRIKOT_FRAMEWORK_NAME
   - TRIKOT_FRAMEWORK_NAME (0.0.1)
 
@@ -11,10 +17,12 @@ DEPENDENCIES:
   - SwiftLint
   - Trikot/streams (from `../../..`)
   - Trikot/viewmodels (from `../../..`)
+  - Trikot/viewmodels.Kingfisher (from `../../..`)
   - TRIKOT_FRAMEWORK_NAME (from `../common`)
 
 SPEC REPOS:
   trunk:
+    - Kingfisher
     - SwiftLint
 
 EXTERNAL SOURCES:
@@ -24,10 +32,11 @@ EXTERNAL SOURCES:
     :path: "../common"
 
 SPEC CHECKSUMS:
+  Kingfisher: 016c8b653a35add51dd34a3aba36b580041acc74
   SwiftLint: 0c645fdc6feed3e390c1701ab3cc669f88b42752
-  Trikot: d17a0b8275c187cd70eadbaeae75d5e8cb49f0a1
+  Trikot: 2abcf73080096a884470e89864a7fd28e58d0e41
   TRIKOT_FRAMEWORK_NAME: 56bdfbf35c0a1e66e4e5dac00e9b212512355bb1
 
-PODFILE CHECKSUM: d3b0c411d9d461abf985e853a677a047048d7133
+PODFILE CHECKSUM: feb948266ab857852d3fa3971383989be3336a6c
 
 COCOAPODS: 1.9.3

--- a/trikot-viewmodels/swift-extensions/kingfisher/KFImageViewModelHandler.swift
+++ b/trikot-viewmodels/swift-extensions/kingfisher/KFImageViewModelHandler.swift
@@ -1,0 +1,145 @@
+import UIKit
+import Kingfisher
+import TRIKOT_FRAMEWORK_NAME
+
+public protocol KFImageUrlRequestModifierDelegate: AnyObject {
+    func requestModifier(for url: URL) -> ImageDownloadRequestModifier
+}
+
+public class KFImageViewModelHandler: ImageViewModelHandler {
+
+    public weak var delegate: KFImageUrlRequestModifierDelegate?
+
+    public var isImageDependantOnViewSize = false
+    public var sizeMultiplier: CGFloat = UIScreen.main.scale
+
+    public init() {}
+
+    public func handleImage(imageViewModel: ImageViewModel?, on imageView: UIImageView) {
+        guard let imageViewModel = imageViewModel else {
+            imageView.unsubscribeFromAllPublisher()
+            return
+        }
+
+        imageView.image = nil
+        imageView.restoreContentMode()
+
+        let imageFlowPublisher = imageViewModel.imageFlow(
+            width: ImageWidth(value: Int32(imageView.frame.width * sizeMultiplier)),
+            height: ImageHeight(value: Int32(imageView.frame.height * sizeMultiplier))
+        )
+
+        let cancellableManagerProvider = CancellableManagerProvider()
+
+        observeImageFlow(
+            imageFlowPublisher,
+            cancellableManager: cancellableManagerProvider.cancelPreviousAndCreate(),
+            imageViewModel: imageViewModel,
+            imageView: imageView
+        )
+
+        imageView.trikotInternalPublisherCancellableManager.add(cancellable: cancellableManagerProvider)
+    }
+
+    private func observeImageFlow(
+        _ imageFlowPublisher: Publisher,
+        cancellableManager: CancellableManager,
+        imageViewModel: ImageViewModel,
+        imageView: UIImageView
+    ) {
+        let cancellableManagerProvider = CancellableManagerProvider()
+        cancellableManager.add(cancellable: cancellableManagerProvider)
+
+        imageView.observe(cancellableManager: cancellableManager, publisher: imageFlowPublisher) {[weak self] (imageFlow: ImageFlow) in
+            self?.doLoadImageFlow(
+                cancellableManager: cancellableManagerProvider.cancelPreviousAndCreate(),
+                imageViewModel: imageViewModel,
+                imageFlow: imageFlow,
+                imageView: imageView
+            )
+        }
+    }
+
+    private func doLoadImageFlow(
+        cancellableManager: CancellableManager,
+        imageViewModel: ImageViewModel,
+        imageFlow: ImageFlow,
+        imageView: UIImageView
+    ) {
+        var unProcessedImage: UIImage?
+
+        if let imageResource = imageFlow.imageResource {
+            unProcessedImage = ImageViewModelResourceManager.shared.image(fromResource: imageResource)
+            imageViewModel.setImageState(imageState: ImageState.success)
+        }
+
+        if let imageResource = imageFlow.placeholderImageResource {
+            if let placeholderContentMode = imageView.placeholderContentMode {
+                imageView.saveContentMode()
+                imageView.contentMode = placeholderContentMode
+            }
+            unProcessedImage = ImageViewModelResourceManager.shared.image(fromResource: imageResource)
+        }
+
+        if let unProcessedImage = unProcessedImage {
+            if let tintColor = imageFlow.tintColor {
+                imageView.image = unProcessedImage.imageWithTintColor(tintColor.color())
+            } else {
+                imageView.image = unProcessedImage
+            }
+        }
+
+        downloadImageFlowIfNeeded(
+            cancellableManager: cancellableManager,
+            imageViewModel: imageViewModel,
+            imageFlow: imageFlow,
+            imageView: imageView
+        )
+    }
+
+    private func downloadImageFlowIfNeeded(
+        cancellableManager: CancellableManager,
+        imageViewModel: ImageViewModel,
+        imageFlow: ImageFlow,
+        imageView: UIImageView
+    ) {
+        guard let urlString = imageFlow.url, let url = URL(string: urlString) else { return }
+
+        var options: KingfisherOptionsInfo = []
+        if let modifier = delegate?.requestModifier(for: url) {
+            options.append(.requestModifier(modifier))
+        }
+
+        let task = imageView.kf.setImage(with: url, options: options, completionHandler: { [weak self] result in
+            MrFreeze().freeze(objectToFreeze: cancellableManager)
+            MrFreeze().freeze(objectToFreeze: imageFlow)
+
+            switch result {
+            case .success:
+                if let onSuccess = imageFlow.onSuccess {
+                    self?.observeImageFlow(
+                        onSuccess,
+                        cancellableManager: cancellableManager,
+                        imageViewModel: imageViewModel,
+                        imageView: imageView
+                    )
+                } else {
+                    imageViewModel.setImageState(imageState: ImageState.success)
+                }
+            case .failure:
+                if let onError = imageFlow.onError {
+                    self?.observeImageFlow(
+                        onError,
+                        cancellableManager: cancellableManager,
+                        imageViewModel: imageViewModel,
+                        imageView: imageView
+                    )
+                } else {
+                    imageViewModel.setImageState(imageState: ImageState.error)
+                }
+            }
+        })
+
+        cancellableManager.add { task?.cancel() }
+    }
+}


### PR DESCRIPTION
## Description
Add custom ImageViewModelHandler implementation using [KingFisher](https://github.com/onevcat/Kingfisher).

Note: This pull request was brought back from our old trikot repo (https://github.com/mirego/trikot.viewmodels/pull/63)

## Motivation and Context
KingFisher is more flexible than our default implementation, and allows us to easily [modify image requests before sending](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#modify-a-request-before-sending), especially useful when authentication headers need to be passed to the request.

KingFisher also allows [built-in cache handling](https://github.com/onevcat/Kingfisher/wiki/Cheat-Sheet#cache), which make it much easier for our implementation.

## How Has This Been Tested?
- [x] All features has been added/updated in sample application ( /sample )

This has been tested in the sample application as well as in at least two production apps here @ mirego.

## Types of changes
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change