### PR TITLE
[VMD] Add showcase screen for toggle on iOS

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
@@ -15,20 +15,20 @@ import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.content.VMDContent
-import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
 
 @Composable
 fun VMDCheckbox(
     modifier: Modifier = Modifier,
     componentModifier: Modifier = Modifier,
-    viewModel: VMDToggleViewModel<VMDTextContent>,
+    viewModel: VMDToggleViewModel<VMDNoContent>,
     colors: CheckboxColors = CheckboxDefaults.colors()
 ) {
     VMDCheckbox(
         modifier = modifier,
         componentModifier = componentModifier,
         viewModel = viewModel,
-        label = { Text(text = it.text) },
+        label = {},
         colors = colors
     )
 }
@@ -64,7 +64,7 @@ fun <C : VMDContent> VMDCheckbox(
 fun EnabledToggleCheckboxPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(true, CancellableManager())
-    VMDCheckbox(viewModel = toggleViewModel, label = {})
+    VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
@@ -72,7 +72,7 @@ fun EnabledToggleCheckboxPreview() {
 fun DisabledToggleCheckboxPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(false, CancellableManager())
-    VMDCheckbox(viewModel = toggleViewModel, label = {})
+    VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
@@ -80,5 +80,5 @@ fun DisabledToggleCheckboxPreview() {
 fun SimpleTextToggleCheckboxPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withText("Label", true, CancellableManager())
-    VMDCheckbox(viewModel = toggleViewModel)
+    VMDCheckbox(viewModel = toggleViewModel, label = { Text(it.text) })
 }

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
@@ -1,7 +1,9 @@
 package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,9 +15,9 @@ fun VMDLabeledComponent(
     content: @Composable RowScope.() -> Unit
 ) {
     Row(
-        modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically
-
+        modifier = Modifier.fillMaxWidth().then(modifier),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
         label()
         content()

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
@@ -15,20 +15,21 @@ import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.content.VMDContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
 import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
 
 @Composable
 fun VMDSwitch(
     modifier: Modifier = Modifier,
     componentModifier: Modifier = Modifier,
-    viewModel: VMDToggleViewModel<VMDTextContent>,
+    viewModel: VMDToggleViewModel<VMDNoContent>,
     colors: SwitchColors = SwitchDefaults.colors()
 ) {
     VMDSwitch(
         modifier = modifier,
         componentModifier = componentModifier,
         viewModel = viewModel,
-        label = { Text(text = it.text) },
+        label = {},
         colors = colors
     )
 }
@@ -64,7 +65,7 @@ fun <C : VMDContent> VMDSwitch(
 fun EnabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(true, CancellableManager())
-    VMDSwitch(viewModel = toggleViewModel, label = {})
+    VMDSwitch(viewModel = toggleViewModel)
 }
 
 @Preview
@@ -72,7 +73,7 @@ fun EnabledSwitchPreview() {
 fun DisabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(false, CancellableManager())
-    VMDSwitch(viewModel = toggleViewModel, label = {})
+    VMDSwitch(viewModel = toggleViewModel)
 }
 
 @Preview
@@ -80,5 +81,5 @@ fun DisabledSwitchPreview() {
 fun SimpleTextSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withText("Label", true, CancellableManager())
-    VMDSwitch(viewModel = toggleViewModel)
+    VMDSwitch(viewModel = toggleViewModel, label = { Text(it.text) })
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/toggle/ToggleShowcaseView.kt
@@ -13,16 +13,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mirego.sample.resource.SampleImageProvider
 import com.mirego.sample.ui.showcase.ComponentShowcaseTitle
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
 import com.mirego.sample.ui.theming.SampleTextStyle
-import com.mirego.sample.ui.theming.medium
 import com.mirego.sample.viewmodels.showcase.toggle.ToggleShowcaseViewModel
+import com.mirego.sample.viewmodels.showcase.toggle.ToggleShowcaseViewModelPreview
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.LocalImage
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDCheckbox
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDSwitch
+import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDeclarative
 
 @Composable
 fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
@@ -39,27 +42,26 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.checkboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.emptyToggle,
-            label = {}
+            modifier = Modifier
+                .padding(start = 2.dp, top = 16.dp, end = 16.dp),
+            viewModel = viewModel.emptyToggle
         )
 
         ComponentShowcaseTitle(viewModel.textCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textToggle
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            viewModel = viewModel.textToggle,
+            label = { Text(it.text, style = SampleTextStyle.body) }
         )
 
         ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
             viewModel = viewModel.imageToggle,
             label = { content ->
                 LocalImage(
-                    modifier = Modifier
-                        .padding(4.dp),
                     imageResource = content.image,
                     colorFilter = ColorFilter.tint(Color.Black)
                 )
@@ -69,24 +71,19 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
             viewModel = viewModel.textImageToggle,
             label = { content ->
                 Row(
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     LocalImage(
-                        modifier = Modifier
-                            .padding(4.dp),
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
                     Text(
-                        modifier = Modifier.padding(start = 8.dp),
                         text = content.text,
-                        style = SampleTextStyle.body.medium()
+                        style = SampleTextStyle.body
                     )
                 }
             }
@@ -95,21 +92,19 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
             viewModel = viewModel.textPairToggle,
             label = { content ->
                 Column(
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(
                         text = content.first,
-                        style = SampleTextStyle.title2
+                        style = SampleTextStyle.body
                     )
                     Text(
                         text = content.second,
-                        style = SampleTextStyle.body
+                        style = SampleTextStyle.caption1
                     )
                 }
             }
@@ -118,27 +113,25 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.switchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.emptyToggle,
-            label = {}
+            modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
+            viewModel = viewModel.emptyToggle
         )
 
         ComponentShowcaseTitle(viewModel.textSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textToggle
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            viewModel = viewModel.textToggle,
+            label = { Text(it.text, style = SampleTextStyle.body) }
         )
 
         ComponentShowcaseTitle(viewModel.imageSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
             viewModel = viewModel.imageToggle,
             label = { content ->
                 LocalImage(
-                    modifier = Modifier
-                        .padding(4.dp),
                     imageResource = content.image,
                     colorFilter = ColorFilter.tint(Color.Black)
                 )
@@ -148,24 +141,20 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
             viewModel = viewModel.textImageToggle,
             label = { content ->
                 Row(
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     LocalImage(
-                        modifier = Modifier
-                            .padding(4.dp),
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
                     Text(
                         modifier = Modifier.padding(start = 8.dp),
                         text = content.text,
-                        style = SampleTextStyle.body.medium()
+                        style = SampleTextStyle.body
                     )
                 }
             }
@@ -174,24 +163,29 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 16.dp),
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
             viewModel = viewModel.textPairToggle,
             label = { content ->
                 Column(
-                    modifier = Modifier
-                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(
                         text = content.first,
-                        style = SampleTextStyle.title2
+                        style = SampleTextStyle.body
                     )
                     Text(
                         text = content.second,
-                        style = SampleTextStyle.body
+                        style = SampleTextStyle.caption1
                     )
                 }
             }
         )
     }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun ToggleShowcaseViewPreview() {
+    TrikotViewModelDeclarative.initialize(SampleImageProvider())
+    ToggleShowcaseView(toggleShowcaseViewModel = ToggleShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/text/TextShowcaseViewModelPreview.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/text/TextShowcaseViewModelPreview.kt
@@ -8,12 +8,9 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDImageContent
 import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModelImpl
 
 class TextShowcaseViewModelPreview : VMDViewModelImpl(CancellableManager()), TextShowcaseViewModel {
-    override val closeButton: VMDButtonViewModelImpl<VMDImageContent> =
-        VMDComponents.Button.withImage(
-            SampleImageResource.ICON_CLOSE, cancellableManager
-        )
-    override val title =
-        VMDComponents.Text.withContent("Text Showcase", cancellableManager)
+    override val title = VMDComponents.Text.withContent("Text Showcase", cancellableManager)
+
+    override val closeButton = VMDComponents.Button.withImage(SampleImageResource.ICON_CLOSE, cancellableManager)
 
     override val largeTitle = VMDComponents.Text.withContent(
         "Large Title",

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/toggle/ToggleShowcaseViewModelPreview.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/toggle/ToggleShowcaseViewModelPreview.kt
@@ -1,0 +1,30 @@
+package com.mirego.sample.viewmodels.showcase.toggle
+
+import com.mirego.sample.resources.SampleImageResource
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextImagePairContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextPairContent
+import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModelImpl
+
+class ToggleShowcaseViewModelPreview : VMDViewModelImpl(CancellableManager()), ToggleShowcaseViewModel {
+    override val title = VMDComponents.Text.withContent("Text Showcase", cancellableManager)
+    override val closeButton = VMDComponents.Button.withImage(SampleImageResource.ICON_CLOSE, cancellableManager)
+
+    override val checkboxTitle = VMDComponents.Text.withContent("Checkbox", cancellableManager)
+    override val textCheckboxTitle = VMDComponents.Text.withContent("Text checkbox", cancellableManager)
+    override val imageCheckboxTitle = VMDComponents.Text.withContent("Image checkbox", cancellableManager)
+    override val textImageCheckboxTitle = VMDComponents.Text.withContent("Text image checkbox", cancellableManager)
+    override val textPairCheckboxTitle = VMDComponents.Text.withContent("Text pair checkbox", cancellableManager)
+    override val switchTitle = VMDComponents.Text.withContent("Switch", cancellableManager)
+    override val textSwitchTitle = VMDComponents.Text.withContent("Text switch", cancellableManager)
+    override val imageSwitchTitle = VMDComponents.Text.withContent("Image switch", cancellableManager)
+    override val textImageSwitchTitle = VMDComponents.Text.withContent("Text image switch", cancellableManager)
+    override val textPairSwitchTitle = VMDComponents.Text.withContent("Text pair switch", cancellableManager)
+
+    override val emptyToggle = VMDComponents.Toggle.empty(cancellableManager)
+    override val textToggle = VMDComponents.Toggle.withText("Label", false, cancellableManager)
+    override val imageToggle = VMDComponents.Toggle.withImage(SampleImageResource.ICON_CLOSE, false, cancellableManager)
+    override val textImageToggle = VMDComponents.Toggle.withTextImage(VMDTextImagePairContent("Label", SampleImageResource.ICON_CLOSE), false, cancellableManager)
+    override val textPairToggle = VMDComponents.Toggle.withTextPair(VMDTextPairContent("Label", "Subtitle"), false, cancellableManager)
+}

--- a/trikot-viewmodels-declarative/sample/ios/Sample.xcodeproj/project.pbxproj
+++ b/trikot-viewmodels-declarative/sample/ios/Sample.xcodeproj/project.pbxproj
@@ -24,10 +24,13 @@
 		C8D868E2268AA9670054CF44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8D868E1268AA9670054CF44 /* Assets.xcassets */; };
 		C8D868E5268AA9670054CF44 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8D868E4268AA9670054CF44 /* Preview Assets.xcassets */; };
 		C8D868E8268AA9670054CF44 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C8D868E6268AA9670054CF44 /* LaunchScreen.storyboard */; };
+		E639E66427D0603900FEEA03 /* CheckboxStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E639E66327D0603900FEEA03 /* CheckboxStyle.swift */; };
 		E6B3102027CFAD52008D2F36 /* ButtonShowcaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B3101F27CFAD52008D2F36 /* ButtonShowcaseViewController.swift */; };
 		E6B3102227CFAD75008D2F36 /* ButtonShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B3102127CFAD75008D2F36 /* ButtonShowcaseView.swift */; };
 		E6B3102627CFBCD7008D2F36 /* ComponentShowcaseSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B3102527CFBCD7008D2F36 /* ComponentShowcaseSectionView.swift */; };
 		E6B3102827CFBD10008D2F36 /* RoundedShadowButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B3102727CFBD10008D2F36 /* RoundedShadowButtonStyle.swift */; };
+		E6B3103027D01F0F008D2F36 /* ToggleShowcaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B3102F27D01F0F008D2F36 /* ToggleShowcaseView.swift */; };
+		E6B3103227D01F1A008D2F36 /* ToggleShowcaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B3103127D01F1A008D2F36 /* ToggleShowcaseViewController.swift */; };
 		F25286619BB74750972639E1 /* Pods_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3240D0E8403B18772B9C9D06 /* Pods_Sample.framework */; };
 /* End PBXBuildFile section */
 
@@ -54,10 +57,13 @@
 		C8D868E7268AA9670054CF44 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C8D868E9268AA9670054CF44 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DCF87A6E6976B4011B629160 /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		E639E66327D0603900FEEA03 /* CheckboxStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckboxStyle.swift; sourceTree = "<group>"; };
 		E6B3101F27CFAD52008D2F36 /* ButtonShowcaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonShowcaseViewController.swift; sourceTree = "<group>"; };
 		E6B3102127CFAD75008D2F36 /* ButtonShowcaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonShowcaseView.swift; sourceTree = "<group>"; };
 		E6B3102527CFBCD7008D2F36 /* ComponentShowcaseSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentShowcaseSectionView.swift; sourceTree = "<group>"; };
 		E6B3102727CFBD10008D2F36 /* RoundedShadowButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedShadowButtonStyle.swift; sourceTree = "<group>"; };
+		E6B3102F27D01F0F008D2F36 /* ToggleShowcaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleShowcaseView.swift; sourceTree = "<group>"; };
+		E6B3103127D01F1A008D2F36 /* ToggleShowcaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleShowcaseViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +83,7 @@
 			children = (
 				C88356BB27580EC300DA0786 /* Text */,
 				E6B3101E27CFAD15008D2F36 /* Button */,
+				E6B3102E27D01EE8008D2F36 /* Toggle */,
 				E6B3102427CFBCC7008D2F36 /* Utilities */,
 			);
 			path = Showcase;
@@ -204,8 +211,18 @@
 			children = (
 				E6B3102527CFBCD7008D2F36 /* ComponentShowcaseSectionView.swift */,
 				E6B3102727CFBD10008D2F36 /* RoundedShadowButtonStyle.swift */,
+				E639E66327D0603900FEEA03 /* CheckboxStyle.swift */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		E6B3102E27D01EE8008D2F36 /* Toggle */ = {
+			isa = PBXGroup;
+			children = (
+				E6B3103127D01F1A008D2F36 /* ToggleShowcaseViewController.swift */,
+				E6B3102F27D01F0F008D2F36 /* ToggleShowcaseView.swift */,
+			);
+			path = Toggle;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -322,6 +339,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E639E66427D0603900FEEA03 /* CheckboxStyle.swift in Sources */,
 				C883569E2750339300DA0786 /* SampleImageProvider.swift in Sources */,
 				E6B3102827CFBD10008D2F36 /* RoundedShadowButtonStyle.swift in Sources */,
 				C8959A70268AB1690080732A /* HomeViewController.swift in Sources */,
@@ -329,6 +347,7 @@
 				C8959A76268B5CEB0080732A /* PreviewView.swift in Sources */,
 				C88356C1275814AC00DA0786 /* BaseViewModelViewController.swift in Sources */,
 				C8959A73268AB9D50080732A /* ViewControllerFactory.swift in Sources */,
+				E6B3103027D01F0F008D2F36 /* ToggleShowcaseView.swift in Sources */,
 				C8959A6B268AAADF0080732A /* AppBootstrap.swift in Sources */,
 				E6B3102227CFAD75008D2F36 /* ButtonShowcaseView.swift in Sources */,
 				C8959A78268B5D1F0080732A /* PreviewPadding.swift in Sources */,
@@ -338,6 +357,7 @@
 				E6B3102027CFAD52008D2F36 /* ButtonShowcaseViewController.swift in Sources */,
 				C8959A71268AB1690080732A /* HomeView.swift in Sources */,
 				C8D868DE268AA9660054CF44 /* SceneDelegate.swift in Sources */,
+				E6B3103227D01F1A008D2F36 /* ToggleShowcaseViewController.swift in Sources */,
 				E6B3102627CFBCD7008D2F36 /* ComponentShowcaseSectionView.swift in Sources */,
 				C8D868E0268AA9660054CF44 /* ContentView.swift in Sources */,
 			);

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/Home/HomeViewController.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/Home/HomeViewController.swift
@@ -21,15 +21,15 @@ extension HomeViewController: HomeNavigationDelegate {
         //TODO:
     }
 
-    func navigateToProgressShowcase() {
-        //TODO:
+    func navigateToToggleShowcase() {
+        present(viewControllerFactory.toggleShowcase(), animated: true, completion: nil)
     }
 
     func navigateToTextFieldShowcase() {
         //TODO:
     }
 
-    func navigateToToggleShowcase() {
+    func navigateToProgressShowcase() {
         //TODO:
     }
 }

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Toggle/ToggleShowcaseView.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Toggle/ToggleShowcaseView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+import Trikot
+import TRIKOT_FRAMEWORK_NAME
+
+struct ToggleShowcaseView: RootViewModelView {
+    typealias VM = ToggleShowcaseViewModel
+
+    @ObservedObject var observableViewModel: ObservableViewModelAdapter<ToggleShowcaseViewModel>
+
+    var viewModel: ToggleShowcaseViewModel {
+        return observableViewModel.viewModel
+    }
+
+    init(viewModel: ToggleShowcaseViewModel) {
+        self.observableViewModel = viewModel.asObservable()
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 40) {
+                    Group {
+                        ComponentShowcaseSectionView(viewModel.checkboxTitle) {
+                            VMDToggle(viewModel.emptyToggle)
+                                .toggleStyle(.squareCheckbox)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.textCheckboxTitle) {
+                            VMDToggle(viewModel.textToggle)
+                                .toggleStyle(.squareCheckboxWithLabel)
+                                .textStyle(.body)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.imageCheckboxTitle) {
+                            VMDToggle(viewModel.imageToggle) { imageContent in
+                                Image(imageContent.image)
+                            }
+                            .toggleStyle(.squareCheckboxWithLabel)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.textImageCheckboxTitle) {
+                            VMDToggle(viewModel.textImageToggle) { textImageContent in
+                                HStack {
+                                    Image(textImageContent.image)
+                                    Text(textImageContent.text)
+                                        .textStyle(.body)
+                                }
+                            }
+                            .toggleStyle(.squareCheckboxWithLabel)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.textPairCheckboxTitle) {
+                            VMDToggle(viewModel.textPairToggle) { textPairContent in
+                                VStack(alignment: .leading) {
+                                    Text(textPairContent.first)
+                                        .textStyle(.body)
+                                    Text(textPairContent.second)
+                                        .textStyle(.caption1)
+                                }
+                            }
+                            .toggleStyle(.squareCheckboxWithLabel)
+                        }
+                    }
+
+                    Group {
+                        ComponentShowcaseSectionView(viewModel.switchTitle) {
+                            VMDToggle(viewModel.emptyToggle)
+                                .toggleStyle(.switch)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.textSwitchTitle) {
+                            VMDToggle(viewModel.textToggle)
+                                .toggleStyle(.switch)
+                                .textStyle(.body)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.imageSwitchTitle) {
+                            VMDToggle(viewModel.imageToggle) { imageContent in
+                                Image(imageContent.image)
+                            }
+                            .toggleStyle(.switch)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.textImageSwitchTitle) {
+                            VMDToggle(viewModel.textImageToggle) { textImageContent in
+                                HStack {
+                                    Image(textImageContent.image)
+                                    Text(textImageContent.text)
+                                        .textStyle(.body)
+                                }
+                            }
+                            .toggleStyle(.switch)
+                        }
+
+                        ComponentShowcaseSectionView(viewModel.textPairSwitchTitle) {
+                            VMDToggle(viewModel.textPairToggle) { textPairContent in
+                                VStack(alignment: .leading) {
+                                    Text(textPairContent.first)
+                                        .textStyle(.body)
+                                    Text(textPairContent.second)
+                                        .textStyle(.caption1)
+                                }
+                            }
+                            .toggleStyle(.switch)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            }
+            .navigationTitle(viewModel.title.text)
+            .toolbar {
+                VMDButton(viewModel.closeButton) { (content: VMDImageContent) in
+                    content.image.image
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func testPlaceholder(placeholderImage: Image?) -> some View {
+        if let placeholderImage = placeholderImage {
+            placeholderImage
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 50)
+        }
+    }
+}
+
+struct ToggleShowcaseViewPreviews: PreviewProvider {
+    static var previews: some View {
+        return PreviewView {
+            ToggleShowcaseView(viewModel: ToggleShowcaseViewModelPreview())
+        }
+    }
+}

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Toggle/ToggleShowcaseView.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Toggle/ToggleShowcaseView.swift
@@ -116,16 +116,6 @@ struct ToggleShowcaseView: RootViewModelView {
             }
         }
     }
-
-    @ViewBuilder
-    private func testPlaceholder(placeholderImage: Image?) -> some View {
-        if let placeholderImage = placeholderImage {
-            placeholderImage
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 50)
-        }
-    }
 }
 
 struct ToggleShowcaseViewPreviews: PreviewProvider {

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Toggle/ToggleShowcaseViewController.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Toggle/ToggleShowcaseViewController.swift
@@ -1,0 +1,15 @@
+import UIKit
+import Trikot
+import TRIKOT_FRAMEWORK_NAME
+
+class ToggleShowcaseViewController: BaseViewModelViewController<ToggleShowcaseViewModelController, ToggleShowcaseViewModel, ToggleShowcaseView, ToggleShowcaseNavigationDelegate> {
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        .darkContent
+    }
+}
+
+extension ToggleShowcaseViewController: ToggleShowcaseNavigationDelegate {
+    func close() {
+        dismiss(animated: true, completion: nil)
+    }
+}

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Utilities/CheckboxStyle.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Utilities/CheckboxStyle.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct CheckboxStyle: ToggleStyle {
+    private let includeLabel: Bool
+
+    init(includeLabel: Bool) {
+        self.includeLabel = includeLabel
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        if includeLabel {
+            HStack {
+                configuration.label
+
+                Spacer()
+
+                checkbox(configuration: configuration)
+            }
+        } else {
+            checkbox(configuration: configuration)
+        }
+    }
+
+    private func checkbox(configuration: Configuration) -> some View {
+        Image(systemName: configuration.isOn ? "checkmark.square.fill" : "square")
+            .resizable()
+            .frame(width: 24, height: 24)
+            .foregroundColor(configuration.isOn ? .purple : .gray)
+            .font(.system(size: 20, weight: .bold, design: .default))
+            .onTapGesture {
+                configuration.isOn.toggle()
+            }
+    }
+}
+
+extension ToggleStyle where Self == CheckboxStyle {
+    static var squareCheckbox: CheckboxStyle {
+        get {
+            CheckboxStyle(includeLabel: false)
+        }
+    }
+
+    static var squareCheckboxWithLabel: CheckboxStyle {
+        get {
+            CheckboxStyle(includeLabel: true)
+        }
+    }
+}

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/ViewControllerFactory.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/ViewControllerFactory.swift
@@ -20,6 +20,10 @@ public class ViewControllerFactory {
     func buttonShowcase() -> ButtonShowcaseViewController {
         ButtonShowcaseViewController(viewModelController: viewModelControllerFactory.buttonShowcase()).assignFactory(self)
     }
+
+    func toggleShowcase() -> ToggleShowcaseViewController {
+        ToggleShowcaseViewController(viewModelController: viewModelControllerFactory.toggleShowcase()).assignFactory(self)
+    }
 }
 
 private extension BaseViewModelViewController {

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDToggle.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDToggle.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 
-public struct VMDSwitch<Label, Content: VMDContent>: View where Label: View {
+public struct VMDToggle<Label, Content>: View where Label: View, Content: VMDContent {
     private let labelBuilder: ((Content) -> Label)?
     private let title: String?
 
@@ -19,18 +19,6 @@ public struct VMDSwitch<Label, Content: VMDContent>: View where Label: View {
         }
     }
 
-    public init(_ viewModel: VMDToggleViewModel<VMDNoContent>) {
-        self.observableViewModel = viewModel.asObservable()
-        self.labelBuilder = nil
-        self.title = ""
-    }
-
-    public init(_ viewModel: VMDToggleViewModel<VMDTextContent>) {
-        self.observableViewModel = viewModel.asObservable()
-        self.labelBuilder = nil
-        self.title = viewModel.label.text
-    }
-
     public init(_ viewModel: VMDToggleViewModel<Content>, @ViewBuilder label: @escaping (Content) -> Label) {
         self.observableViewModel = viewModel.asObservable()
         self.labelBuilder = label
@@ -39,9 +27,16 @@ public struct VMDSwitch<Label, Content: VMDContent>: View where Label: View {
 
     public var body: some View {
         if let title = title {
-            Toggle(title, isOn: isOn)
-                .disabled(!viewModel.isEnabled)
-                .hidden(viewModel.isHidden)
+            if title.isEmpty {
+                Toggle(title, isOn: isOn)
+                    .labelsHidden()
+                    .disabled(!viewModel.isEnabled)
+                    .hidden(viewModel.isHidden)
+            } else {
+                Toggle(title, isOn: isOn)
+                    .disabled(!viewModel.isEnabled)
+                    .hidden(viewModel.isHidden)
+            }
         } else {
             Toggle(isOn: isOn) {
                 labelBuilder?(viewModel.label)
@@ -49,5 +44,21 @@ public struct VMDSwitch<Label, Content: VMDContent>: View where Label: View {
             .disabled(!viewModel.isEnabled)
             .hidden(viewModel.isHidden)
         }
+    }
+}
+
+extension VMDToggle where Content == VMDNoContent, Label == EmptyView {
+    public init(_ viewModel: VMDToggleViewModel<VMDNoContent>) {
+        self.observableViewModel = viewModel.asObservable()
+        self.labelBuilder = nil
+        self.title = ""
+    }
+}
+
+extension VMDToggle where Content == VMDTextContent, Label == Text {
+    public init(_ viewModel: VMDToggleViewModel<VMDTextContent>) {
+        self.observableViewModel = viewModel.asObservable()
+        self.labelBuilder = nil
+        self.title = viewModel.label.text
     }
 }


### PR DESCRIPTION
## Description
Add showcase screen for toggle in sample project of `trikot.viewmodels.declarative` on iOS.

This PR also:
- Remove specific `VMDCheckbox` constructor taking `VMDTextContent` as content type on Android. This was mostly unusable because it was not possible to style the text.
- Make `VMDLabeledComponent` on Android more uniform with iOS.
- Rewrite `VMDToggle` constructors on iOS to avoid having to specify explicitely label type

## Result
| **iOS** | **Android** |
|-----|---------|
| ![Simulator Screen Shot - iPhone 13 - 2022-03-02 at 22 59 49](https://user-images.githubusercontent.com/291573/156496377-9b8496e6-f093-4470-ad91-77d48cbb9f5e.png) | ![Screenshot_1646280001](https://user-images.githubusercontent.com/291573/156496394-7a1597f6-ce14-4d08-b416-5b0c9e697a34.png) |


## How Has This Been Tested?
Tested in sample project

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)