### PR TITLE
Add a new parameter to allow or disable hardware acceleration on VMDImage

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -30,7 +30,8 @@ fun VMDImage(
     placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = ""
+    contentDescription: String = "",
+    allowHardware: Boolean = true
 ) {
     val imageViewModel by viewModel.observeAsState()
 
@@ -42,7 +43,8 @@ fun VMDImage(
         colorFilter = colorFilter,
         contentDescription = contentDescription,
         placeholderContentScale = placeholderContentScale,
-        imageDescriptor = imageViewModel.image
+        imageDescriptor = imageViewModel.image,
+        allowHardware = allowHardware
     )
 }
 
@@ -55,7 +57,8 @@ fun VMDImage(
     placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = ""
+    contentDescription: String = "",
+    allowHardware: Boolean = true
 ) {
     when (imageDescriptor) {
         is Local -> {
@@ -78,7 +81,8 @@ fun VMDImage(
                 contentScale = contentScale,
                 placeholderContentScale = placeholderContentScale,
                 colorFilter = colorFilter,
-                contentDescription = contentDescription
+                contentDescription = contentDescription,
+                allowHardware = allowHardware
             )
         }
     }
@@ -114,11 +118,13 @@ fun RemoteImage(
     contentScale: ContentScale = ContentScale.Fit,
     placeholderContentScale: ContentScale = contentScale,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = ""
+    contentDescription: String = "",
+    allowHardware: Boolean = true
 ) {
     val coilPainter = rememberImagePainter(
         imageUrl,
         builder = {
+            allowHardware(allowHardware)
             size(OriginalSize)
         }
     )


### PR DESCRIPTION
## Description

Add a new parameter on VMDImage to enable or disable hardware acceleration for an image

## Motivation and Context

This is needed since we sometimes need to disable hardware acceleration for an image. In our case, we needed to disable it when we were taking an image of the screen


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
