### PR TITLE
[VMD] Fix crash in VMDButtonViewModel

### DIFF
--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/button/ButtonShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/button/ButtonShowcaseViewModelController.kt
@@ -1,6 +1,8 @@
 package com.mirego.sample.viewmodels.showcase.button
 
 import com.mirego.trikot.kword.I18N
+import com.mirego.trikot.streams.reactive.just
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class ButtonShowcaseViewModelController(i18N: I18N) : VMDViewModelController<ButtonShowcaseViewModel, ButtonShowcaseNavigationDelegate>() {
@@ -9,6 +11,7 @@ class ButtonShowcaseViewModelController(i18N: I18N) : VMDViewModelController<But
     override fun onCreate() {
         super.onCreate()
         viewModel.closeButton.setAction { navigationDelegate?.close() }
+        viewModel.textButton.bindContent(VMDTextContent("Label").just())
         viewModel.textButton.setAction { navigationDelegate?.showMessage("Text button tapped !") }
         viewModel.imageButton.setAction { navigationDelegate?.showMessage("Image button tapped !") }
         viewModel.textImageButton.setAction { navigationDelegate?.showMessage("Text image button tapped !") }

--- a/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
+++ b/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.declarative.components.impl
 
+import com.mirego.trikot.foundation.concurrent.atomic
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.first
 import com.mirego.trikot.streams.reactive.observeOn
@@ -17,7 +18,7 @@ open class VMDButtonViewModelImpl<C : VMDContent>(
     defaultContent: C
 ) : VMDButtonViewModel<C>(cancellableManager) {
 
-    override var actionBlock: () -> Unit = {}
+    override var actionBlock: () -> Unit by atomic {}
 
     private val contentDelegate = published(defaultContent, this)
     override var content: C by contentDelegate


### PR DESCRIPTION
## Description

Having the VMDButtonViewModel actionBlock as a `var` was causing freezing exception if the ViewModel was freeze before setting the action. The ViewModel was frozen more often than we imagined, only binding a property on the ViewModel is freezing the ViewModel and all of the objects around 😬

## Motivation and Context

A regression was introduce in a previous modification and that regression was generating crashes everywhere 😬

## How Has This Been Tested?

Tested in VMD sample project

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
