### PR TITLE
[VMD] Add complex placeholders capability on Android

### DIFF
--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/image/ImageShowcaseView.kt
@@ -1,23 +1,32 @@
 package com.mirego.sample.ui.showcase.image
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.ImagePainter
 import com.mirego.sample.resource.SampleImageProvider
 import com.mirego.sample.ui.showcase.ComponentShowcaseTitle
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
+import com.mirego.sample.ui.theming.SampleTextStyle
 import com.mirego.sample.viewmodels.showcase.image.ImageShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.image.ImageShowcaseViewModelPreview
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.LocalImage
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDImage
 import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDeclarative
 
@@ -88,6 +97,40 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
             viewModel = viewModel.placeholderImage,
             contentScale = ContentScale.Crop,
             placeholderContentScale = ContentScale.Crop
+        )
+
+        ComponentShowcaseTitle(viewModel.complexPlaceholderImageTitle)
+
+        val imageModifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(imageAspectRatio)
+            .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+
+        VMDImage(
+            modifier = imageModifier,
+            viewModel = viewModel.complexPlaceholderImage,
+            contentScale = ContentScale.Crop,
+            placeholderContentScale = ContentScale.Crop,
+            placeholder = { placeholderImageResource, state ->
+                Column(
+                    modifier = imageModifier.background(Color.LightGray.copy(alpha = 0.5f)),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    LocalImage(
+                        imageResource = placeholderImageResource,
+                        modifier = Modifier.size(width = (50 * imageAspectRatio).dp, height = 50.dp).padding(bottom = 10.dp),
+                        contentScale = ContentScale.Crop
+                    )
+
+                    when (state) {
+                        is ImagePainter.State.Empty -> Text("There is no image to display", style = SampleTextStyle.subheadline)
+                        is ImagePainter.State.Loading -> Text("Loading", style = SampleTextStyle.subheadline)
+                        is ImagePainter.State.Error -> Text("Unable to load the remote image", style = SampleTextStyle.subheadline)
+                        else -> {}
+                    }
+                }
+            }
         )
     }
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/image/ImageShowcaseViewModel.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/image/ImageShowcaseViewModel.kt
@@ -20,4 +20,7 @@ interface ImageShowcaseViewModel : ShowcaseViewModel {
 
     val placeholderImageTitle: VMDTextViewModel
     val placeholderImage: VMDImageViewModel
+
+    val complexPlaceholderImageTitle: VMDTextViewModel
+    val complexPlaceholderImage: VMDImageViewModel
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/image/ImageShowcaseViewModelImpl.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/image/ImageShowcaseViewModelImpl.kt
@@ -5,6 +5,8 @@ import com.mirego.sample.resources.SampleImageResource
 import com.mirego.sample.viewmodels.showcase.ShowcaseViewModelImpl
 import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.viewmodels.declarative.components.VMDImageViewModel
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextViewModel
 import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor
 
@@ -29,4 +31,7 @@ class ImageShowcaseViewModelImpl(i18N: I18N, cancellableManager: CancellableMana
 
     override val placeholderImageTitle = VMDComponents.Text.withContent(i18N[KWordTranslation.IMAGE_SHOWCASE_PLACEHOLDER_IMAGE_TITLE], cancellableManager)
     override val placeholderImage = VMDComponents.Image.remote(null, SampleImageResource.IMAGE_PLACEHOLDER, cancellableManager)
+
+    override val complexPlaceholderImageTitle = VMDComponents.Text.withContent(i18N[KWordTranslation.IMAGE_SHOWCASE_COMPLEX_PLACEHOLDER_IMAGE_TITLE], cancellableManager)
+    override val complexPlaceholderImage = VMDComponents.Image.remote(null, SampleImageResource.IMAGE_PLACEHOLDER, cancellableManager)
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/image/ImageShowcaseViewModelPreview.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/image/ImageShowcaseViewModelPreview.kt
@@ -27,9 +27,8 @@ class ImageShowcaseViewModelPreview : VMDViewModelImpl(CancellableManager()), Im
     override val remoteImageDescriptor = VMDImageDescriptor.Remote("https://picsum.photos/2000/1600", placeholderImageResource = SampleImageResource.IMAGE_PLACEHOLDER)
 
     override val placeholderImageTitle = VMDComponents.Text.withContent("Placeholder image", cancellableManager)
-    override val placeholderImage = VMDComponents.Image.remote(
-        null,
-        SampleImageResource.IMAGE_PLACEHOLDER,
-        cancellableManager
-    )
+    override val placeholderImage = VMDComponents.Image.remote(null, SampleImageResource.IMAGE_PLACEHOLDER, cancellableManager)
+
+    override val complexPlaceholderImageTitle = VMDComponents.Text.withContent("Complex placeholder image", cancellableManager)
+    override val complexPlaceholderImage = VMDComponents.Image.remote(null, SampleImageResource.IMAGE_PLACEHOLDER, cancellableManager)
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/resources/translations/translation.en.json
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/resources/translations/translation.en.json
@@ -13,6 +13,7 @@
   "home_component_textfield": "TextField",
   "home_component_toggle": "Toggle",
   "home_component_progress": "Progress",
+  "image_showcase_complex_placeholder_image_title": "Complex placeholder",
   "image_showcase_title": "Image showcase",
   "image_showcase_local_title": "Local image",
   "image_showcase_remote_title": "Remote image",

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Image/ImageShowcaseView.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/Showcase/Image/ImageShowcaseView.swift
@@ -25,24 +25,28 @@ struct ImageShowcaseView: RootViewModelView {
                         VMDImage(viewModel.localImage)
                             .resizable()
                             .aspectRatio(imageAspectRatio, contentMode: .fill)
+                            .clipped()
                     }
 
                     ComponentShowcaseSectionView(viewModel.remoteImageTitle) {
                         VMDImage(viewModel.remoteImage)
                             .resizable()
                             .aspectRatio(imageAspectRatio, contentMode: .fill)
+                            .clipped()
                     }
 
                     ComponentShowcaseSectionView(viewModel.localImageDescriptorTitle) {
                         VMDImage(viewModel.localImageDescriptor)
                             .resizable()
                             .aspectRatio(imageAspectRatio, contentMode: .fill)
+                            .clipped()
                     }
 
                     ComponentShowcaseSectionView(viewModel.remoteImageDescriptorTitle) {
                         VMDImage(viewModel.remoteImageDescriptor)
                             .resizable()
                             .aspectRatio(imageAspectRatio, contentMode: .fill)
+                            .clipped()
                     }
 
                     ComponentShowcaseSectionView(viewModel.placeholderImageTitle) {
@@ -53,9 +57,43 @@ struct ImageShowcaseView: RootViewModelView {
                                     placeholderImage
                                         .resizable()
                                         .aspectRatio(imageAspectRatio, contentMode: .fill)
+                                        .clipped()
                                 }
                             })
-                            .aspectRatio(contentMode: .fit)
+                    }
+
+                    ComponentShowcaseSectionView(viewModel.complexPlaceholderImageTitle) {
+                        VMDImage(viewModel.complexPlaceholderImage)
+                            .resizable()
+                            .placeholder({ status, progress, placeholderImage in
+                                Color.gray.opacity(0.25)
+                                    .frame(maxWidth: .infinity)
+                                    .aspectRatio(imageAspectRatio, contentMode: .fill)
+                                    .overlay(
+                                            VStack(spacing: 10) {
+                                            if let placeholderImage = placeholderImage {
+                                                placeholderImage
+                                                    .resizable()
+                                                    .aspectRatio(imageAspectRatio, contentMode: .fill)
+                                                    .frame(width: 50 * imageAspectRatio, height: 50)
+                                            }
+
+                                            switch status {
+                                            case .empty:
+                                                Text("There is no image to display")
+                                                    .style(.subheadline)
+                                            case .loading:
+                                                Text("Loading \(progress.fractionCompleted)")
+                                                    .style(.subheadline)
+                                            case .error:
+                                                Text("Unable to load the remote image")
+                                                    .style(.subheadline)
+                                            default:
+                                                EmptyView()
+                                            }
+                                        }
+                                    )
+                            })
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDImage+Configuration.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDImage+Configuration.swift
@@ -28,12 +28,29 @@ public extension VMDImage {
         }
     }
 
+    @available(*, deprecated, message: "Use placeholder(status:progress:placeholderImage) instead")
     func placeholder<Content: View>(@ViewBuilder _ content: @escaping (_ progress: Progress, _ placeholderImage: Image?) -> Content) -> VMDImage {
         configure {
             $0
         } remote: { kfImage, placehoder in
             kfImage.placeholder { progress in
                 content(progress, placehoder.image)
+            }
+        }
+    }
+
+    func placeholder<Content: View>(@ViewBuilder _ content: @escaping (_ status: VMDImageLoadingStatus, _ progress: Progress, _ placeholderImage: Image?) -> Content) -> VMDImage {
+        configure {
+            $0
+        } remote: { kfImage, placehoder in
+            kfImage.placeholder { progress in
+                content(loadingStatus, progress, placehoder.image)
+            }
+            .onSuccess { result in
+                loadingStatus = .success
+            }
+            .onFailure { error in
+                loadingStatus = .error
             }
         }
     }

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDImage.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDImage.swift
@@ -2,6 +2,13 @@ import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 import Kingfisher
 
+public enum VMDImageLoadingStatus {
+    case empty
+    case loading
+    case success
+    case error
+}
+
 public struct VMDImage: View {
     public typealias LocalImageConfiguration = (Image) -> Image
     public typealias RemoteImageConfiguration = (KFImage, VMDImageResource) -> KFImage
@@ -14,6 +21,7 @@ public struct VMDImage: View {
     }
 
     @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDImageViewModel>
+    @State var loadingStatus: VMDImageLoadingStatus = .empty
 
     public init(_ viewModel: VMDImageViewModel) {
         self.observableViewModel = viewModel.asObservable()


### PR DESCRIPTION
## Description
Add the ability to provide a composable function as image placeholder that takes the image loading state as parameter to adapt the placeholder depending on that state.

## Motivation and Context
It was not possible to display a complex placeholder that was more than an image taking all of its parent bounds.

## How Has This Been Tested?
An exemple have been added in the sample app.

## Result
| **iOS** | **Android** |
|--------|-------------|
| ![Simulator Screen Shot - iPhone 13 - 2022-03-09 at 11 10 04](https://user-images.githubusercontent.com/291573/157484477-fe3f7e84-dbf1-4f7e-8a5f-3e3e894f1463.png) | ![Screenshot_1646842208](https://user-images.githubusercontent.com/291573/157484502-3cf5508a-c2c3-4413-810d-6d086ab441dd.png) |


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
