### PR TITLE
[VMD] Move view controller lifecycle methods from public to open

### DIFF
--- a/trikot-viewmodels-declarative/swift/swiftui/ViewModelViewController.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/ViewModelViewController.swift
@@ -22,14 +22,14 @@ open class ViewModelViewController<VMC: VMDViewModelController<VM, N>, VM, V: Ro
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
+    open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModelController.onAppear()
         NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
     }
 
-    public override func viewDidDisappear(_ animated: Bool) {
+    open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModelController.onDisappear()
 


### PR DESCRIPTION
## Description

This PR update the access control of `viewDidAppear(_:)` and `viewDidDisappear(_:)` to `open` so that it can be overridden in a subclass of `ViewModelViewController`.

## How Has This Been Tested?

This was tested in Sobeys project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
