### PR TITLE
[VM] Make UIButton extension positionSubviews overridable

### DIFF
--- a/trikot-viewmodels/swift-extensions/UIButtonExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIButtonExtensions.swift
@@ -156,7 +156,8 @@ extension UIButton {
         return completedAttributedString
     }
 
-    public func positionSubviews(_ alignment: Alignment?) {
+    @objc
+    open func positionSubviews(_ alignment: Alignment?) {
         guard let buttonViewModel = buttonViewModel else { return }
         guard let alignment = alignment, [Alignment.right, Alignment.left].contains(alignment) else { resetAlignment() ; return }
 


### PR DESCRIPTION
## Description
UIButton subclasses can now override `positionSubviews` to make further adjustments once layout was adjusted to respect the image's alignment.
 
## How Has This Been Tested?

I tested that a subclass of `UIButton` could override `positionSubviews`:
```
private class Test: UIButton {

    override func positionSubviews(_ alignment: Alignment?) {
        super.positionSubviews(alignment)
    }
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
