### PR TITLE
[Streams] Introduce collect() operator for Publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Upcoming release
 
+## 3.1.19
+
+> 2022-03-21
+
+- [streams] Introduce `collect()` operator for Publishers
+
 ## 3.1.17
+
+> 2022-03-15
 
 - [kword] Introduce a new `DynamicI18N` concept which expose strings via Publishers. It is implemented via a `MultiLanguageI18N` to react on language changes. When the language switches all publishers will emit the localized string in the new language.
 - [kword] Allow loading json strings from multiple sources (paths) via the basePaths parameter.

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.streams.reactive
 
+import CollectProcessor
 import com.mirego.trikot.foundation.FoundationConfiguration
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotDispatchQueue
 import com.mirego.trikot.foundation.timers.TimerFactory
@@ -283,4 +284,20 @@ fun <T> Publisher<T>.takeWhile(predicate: TakeWhileProcessorPredicate<T>): Publi
  */
 fun <T> Publisher<T>.takeUntil(predicate: TakeUntilProcessorPredicate<T>): Publisher<T> {
     return TakeUntilProcessor(this, predicate)
+}
+
+/**
+ * Collects items emitted by the source Publisher into a single mutable data structure
+ * and returns an Publisher that emits this structure.
+ *
+ * Marbles diagram :
+ * -------(1)--------(2)----------(3)-------|->
+ * reduce([]) { acc, x => acc + x }
+ * ------([1])----([1, 2])----([1, 2, 3])---|->
+ *
+ * @see <a href="http://reactivex.io/RxJava/javadoc/rx/Observable.html#collect-rx.functions.Func0-rx.functions.Action2-">http://reactivex.io/RxJava/javadoc/rx/Observable.html#collect-rx.functions.Func0-rx.functions.Action2-</a>
+ */
+
+fun <T, R> Publisher<T>.collect(seed: R, collector: (R, T) -> R): Publisher<R> {
+    return CollectProcessor(this, seed, collector)
 }

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CollectProcessor.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CollectProcessor.kt
@@ -1,0 +1,39 @@
+import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import com.mirego.trikot.streams.reactive.processors.AbstractProcessor
+import com.mirego.trikot.streams.reactive.processors.ProcessorSubscription
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+
+typealias CollectorBlock<T, R> = (R, T) -> R
+
+class CollectProcessor<T, R>(
+    parentPublisher: Publisher<T>,
+    private val seed: R,
+    private val collector: CollectorBlock<T, R>
+) : AbstractProcessor<T, R>(parentPublisher) {
+
+    override fun createSubscription(subscriber: Subscriber<in R>): ProcessorSubscription<T, R> {
+        return CollectProcessorSubscription(subscriber, seed, collector)
+    }
+
+    private class CollectProcessorSubscription<T, R>(
+        subscriber: Subscriber<in R>,
+        seed: R,
+        private val collector: CollectorBlock<T, R>
+    ) : ProcessorSubscription<T, R>(subscriber) {
+
+        private var value: R by atomic(seed)
+
+        override fun onNext(t: T, subscriber: Subscriber<in R>) {
+            val nextValue = try {
+                collector.invoke(value, t)
+            } catch (e: StreamsProcessorException) {
+                subscriber.onError(e)
+                return
+            }
+            value = nextValue
+            subscriber.onNext(nextValue)
+        }
+    }
+}

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CollectProcessorTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/CollectProcessorTests.kt
@@ -1,0 +1,161 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.StreamsProcessorException
+import com.mirego.trikot.streams.reactive.collect
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CollectProcessorTests {
+    @Test
+    fun testCollectToList() {
+        val publisher = Publishers.behaviorSubject(0)
+        val receivedResults = mutableListOf<List<Int>>()
+        var completed = false
+
+        publisher
+            .collect(emptyList<Int>()) { acc, current -> acc + current }
+            .subscribe(
+                CancellableManager(),
+                onNext = { receivedResults += it },
+                onError = { },
+                onCompleted = { completed = true }
+            )
+
+        publisher.value = 1
+        publisher.value = 2
+        publisher.value = 3
+        publisher.value = 4
+        publisher.complete()
+
+        val expectedResults = listOf(
+            listOf(0),
+            listOf(0, 1),
+            listOf(0, 1, 2),
+            listOf(0, 1, 2, 3),
+            listOf(0, 1, 2, 3, 4),
+        )
+        assertEquals(expectedResults, receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testCollectToOtherType() {
+        val publisher = Publishers.behaviorSubject(0)
+        val receivedResults = mutableListOf<String>()
+        var completed = false
+
+        publisher
+            .collect("") { acc, current -> acc + current }
+            .subscribe(
+                CancellableManager(),
+                onNext = { receivedResults += it },
+                onError = { },
+                onCompleted = { completed = true }
+            )
+
+        publisher.value = 1
+        publisher.value = 2
+        publisher.value = 3
+        publisher.value = 4
+        publisher.complete()
+
+        val expectedResults = listOf(
+            "0",
+            "01",
+            "012",
+            "0123",
+            "01234"
+        )
+        assertEquals(expectedResults, receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testReconnection() {
+        val publisher = Publishers.publishSubject<String>()
+        val receivedResults = mutableListOf<String>()
+
+        val collectPublisher = publisher.collect("") { acc, current -> acc + current }
+
+        val cancellableManager1 = CancellableManager()
+        val cancellableManager2 = CancellableManager()
+        collectPublisher.subscribe(cancellableManager1) { receivedResults += it }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        cancellableManager1.cancel()
+
+        collectPublisher.subscribe(cancellableManager2) { receivedResults += it }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        cancellableManager2.cancel()
+
+        assertEquals(listOf("a", "ab", "abc", "a", "ab", "abc"), receivedResults)
+    }
+
+    @Test
+    fun testMappingStreamsProcessorException() {
+        val publisher = Publishers.behaviorSubject("a")
+        val expectedException = StreamsProcessorException()
+        var receivedException: StreamsProcessorException? = null
+
+        publisher
+            .collect(emptySet<Int>()) { _, _ -> throw expectedException }
+            .subscribe(
+                CancellableManager(),
+                onNext = { },
+                onError = { receivedException = it as StreamsProcessorException }
+            )
+
+        publisher.value = "b"
+
+        assertEquals(expectedException, receivedException)
+    }
+
+    @Test
+    fun testMappingAnyException() {
+        val publisher = Publishers.behaviorSubject("a")
+
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        var receivedException: StreamsProcessorException? = null
+
+        assertFailsWith(IllegalStateException::class) {
+            publisher
+                .collect(0) { _, _ -> throw IllegalStateException() }
+                .subscribe(
+                    CancellableManager(),
+                    onNext = { },
+                    onError = { receivedException = it as StreamsProcessorException }
+                )
+            publisher.value = "b"
+        }
+    }
+
+    @Test
+    fun testUpstreamError() {
+        val error = Throwable()
+        val publisher = Publishers.error<String>(error)
+
+        var receivedException: Throwable? = null
+
+        publisher
+            .collect(0) { acc, value -> acc + value.toInt() }
+            .subscribe(
+                CancellableManager(),
+                onNext = { },
+                onError = { receivedException = it }
+            )
+
+        assertEquals(error, receivedException)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Collects items emitted by the source Publisher into a single data structure and returns a Publisher that emits this updated structure.

<img width="646" alt="Marbles diagram" src="https://user-images.githubusercontent.com/5982196/159083693-91c68008-447f-4ad4-8e60-93088c6cdf86.png">

## Motivation and Context

I had a use case in my app where I needed such an operator! 😄 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been fully unit tested and used in a production app here at Mirego

## Types of changes



<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
