### PR TITLE
[New MM] - Revert freezes removal

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=3.2.1-M3-SNAPSHOT
+version=3.2.0
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=3.2.1-M2
+version=3.2.1-M3-SNAPSHOT
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/trikot-bluetooth/swift-extensions/TrikotAttributeProfileCharacteristic.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotAttributeProfileCharacteristic.swift
@@ -4,7 +4,7 @@ import CoreBluetooth
 class TrikotAttributeProfileCharacteristic: NSObject, AttributeProfileCharacteristic {
     private let characteristic: CBCharacteristic
     private let peripheral: CBPeripheral
-    let event: Publisher = Publishers().publishSubject()
+    let event = frozenSubject()
 
     var newValue: Data? {
         didSet {

--- a/trikot-bluetooth/swift-extensions/TrikotAttributeProfileService.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotAttributeProfileService.swift
@@ -7,7 +7,7 @@ class TrikotAttributeProfileService: NSObject, AttributeProfileService {
 
     var trikotCharacteristics = [CBCharacteristic: TrikotAttributeProfileCharacteristic]()
 
-    let characteristics: Publisher = Publishers().behaviorSubject(value: nil)
+    let characteristics: Publisher = frozenBehaviorSubject()
 
     init(service: CBService, peripheral: CBPeripheral) {
         self.service = service

--- a/trikot-bluetooth/swift-extensions/TrikotBluetoothDevice.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotBluetoothDevice.swift
@@ -10,8 +10,8 @@ class TrikotBluetoothDevice: NSObject, BluetoothDevice, CBPeripheralDelegate {
 
     var physicalAddress: String
 
-    var attributeProfileServices: Publisher = Publishers().behaviorSubject(value: nil)
-    var isConnected: Publisher = Publishers().behaviorSubject(value: nil)
+    var attributeProfileServices: Publisher = frozenBehaviorSubject()
+    var isConnected: Publisher = frozenBehaviorSubject()
 
     var managerIsConnected = false {
         didSet {

--- a/trikot-bluetooth/swift-extensions/TrikotBluetoothExtensions.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotBluetoothExtensions.swift
@@ -1,6 +1,18 @@
 import Foundation
 import TRIKOT_FRAMEWORK_NAME
 
+func frozenBehaviorSubject(value: Any? = nil) -> Publisher {
+    let publisher = Publishers().behaviorSubject(value: value)
+    MrFreeze().freeze(objectToFreeze: publisher)
+    return publisher
+}
+
+func frozenSubject(value: Any? = nil) -> Publisher {
+    let publisher = Publishers().publishSubject()
+    MrFreeze().freeze(objectToFreeze: publisher)
+    return publisher
+}
+
 extension Publisher {
     func asBehaviorSubject() -> BehaviorSubject {
         return self as! BehaviorSubject

--- a/trikot-bluetooth/swift-extensions/TrikotBluetoothManager.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotBluetoothManager.swift
@@ -7,14 +7,14 @@ public class TrikotBluetoothManager: NSObject, BluetoothManager, CBCentralManage
     private let dispatchQueue = DispatchQueue(label: TrikotBluetoothManager.QueueLabel, qos: .background)
     private lazy var centralManager = CBCentralManager(delegate: self, queue: dispatchQueue)
 
-    private let scanResultpublisher = Publishers().behaviorSubject(value: nil)
+    private let scanResultpublisher = frozenBehaviorSubject()
     private let numberOfScanRequest = Atomic<Int>(0)
 
     private var scanResults = [CBPeripheral: TrikotBluetoothScanResult]()
     private var connectedDevices = [CBPeripheral: TrikotBluetoothDevice]()
     private var delegates = [CBCentralManagerDelegate]()
 
-    private let bluetoothStatePublisher: Publisher = Publishers().behaviorSubject(value: nil)
+    private let bluetoothStatePublisher: Publisher = frozenBehaviorSubject()
 
     public lazy var statePublisher = PublisherExtensionsKt.map(bluetoothStatePublisher) { (value: Any) in
         guard let centralManagerState = value as? CBManagerState else { return nil }

--- a/trikot-bluetooth/swift-extensions/TrikotBluetoothScanResult.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotBluetoothScanResult.swift
@@ -6,7 +6,7 @@ class TrikotBluetoothScanResult: NSObject, BluetoothScanResult {
     private let centralManager: CBCentralManager
     private let peripheral: CBPeripheral
     private var lostHeartbeatTimer: Foundation.Timer?
-    private var manufacturerData = Publishers().behaviorSubject(value: nil)
+    private var manufacturerData = frozenBehaviorSubject()
 
     var bluetoothDevice: TrikotBluetoothDevice?
 
@@ -14,7 +14,7 @@ class TrikotBluetoothScanResult: NSObject, BluetoothScanResult {
 
     var physicalAddress: String
 
-    var rssi: Publisher = Publishers().behaviorSubject(value: nil)
+    var rssi: Publisher = frozenBehaviorSubject()
 
     var onHeartBeatLost: (() -> Void)? {
         didSet {

--- a/trikot-datasources/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseDataSourceTests.kt
+++ b/trikot-datasources/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseDataSourceTests.kt
@@ -6,6 +6,7 @@ import com.mirego.trikot.datasources.testutils.assertPending
 import com.mirego.trikot.datasources.testutils.assertValue
 import com.mirego.trikot.datasources.testutils.get
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.MrFreeze
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue
 import com.mirego.trikot.streams.StreamsConfiguration
 import com.mirego.trikot.streams.cancellable.CancellableManager
@@ -226,6 +227,7 @@ class BaseDataSourceTests {
     @Test
     fun givenNetworkDataWhenRefreshingThenPendingWithCurrentData() {
         val networkDataSourceReadPublisher = ReadFromCachePublisher().also {
+            MrFreeze.freeze(it)
             it.dispatchResult(networkResult)
         }
         val dataSource = BasicDataSource(mutableMapOf(simpleCacheableId to networkDataSourceReadPublisher))

--- a/trikot-foundation/README.md
+++ b/trikot-foundation/README.md
@@ -47,6 +47,20 @@ val otherDate = Date.fromISO8601(isoDate)
 otherDate == date               // true
 ```
 
+## Multiplatform freezing
+
+Allow freezing in common code. Does nothing in js and JVM.
+
+```kotlin
+freeze(objectToFreeze)
+```
+
+In swift, use access freeze via MrFreezeKt class helper to freeze object.
+
+```swift
+MrFreezeKt.freeze(objectToFreeze: objectToFreeze)
+```
+
 ## Dispatch Queues
 
 While waiting for [Sharing of coroutines across threads in Kotlin/Native](https://github.com/Kotlin/kotlinx.coroutines/pull/1648) to work correctly. Trikot.foundation provide a standard Thread model based on queues. When this issue will be resolved, DispatchQueues will be converted to Coroutines.

--- a/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
+++ b/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
@@ -1,0 +1,8 @@
+package com.mirego.trikot.foundation.concurrent
+
+expect object MrFreeze {
+    fun <T> freeze(objectToFreeze: T): T
+    actual fun ensureNeverFrozen(objectToProtect: Any)
+}
+
+expect fun <T> freeze(objectToFreeze: T): T

--- a/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/SequentialDispatchQueue.kt
+++ b/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/SequentialDispatchQueue.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
 import com.mirego.trikot.foundation.concurrent.AtomicListReference
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.freeze
 
 /**
  * Ensure dispatch blocks are executed sequentially on a dispatch queue.
@@ -46,7 +47,7 @@ open class SequentialDispatchQueue(override val dispatchQueue: TrikotDispatchQue
     }
 
     companion object {
-        private val NoDispatchBlock = {}
-        private val SyncDispatchBlock = {}
+        private val NoDispatchBlock = freeze {}
+        private val SyncDispatchBlock = freeze {}
     }
 }

--- a/trikot-foundation/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReferenceTest.kt
+++ b/trikot-foundation/trikotFoundation/src/commonTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReferenceTest.kt
@@ -12,6 +12,7 @@ class AtomicReferenceTest {
     fun canSetNewNullValueAndReadAfterFreezing() {
         atomicReference.compareAndSet(null, expectedValue)
         assertEquals(expectedValue, atomicReference.value)
+        MrFreeze.freeze(atomicReference)
         atomicReference.compareAndSet(expectedValue, null)
         assertNull(atomicReference.value)
     }
@@ -20,6 +21,7 @@ class AtomicReferenceTest {
     fun canSwapValue() {
         assertEquals(expectedValue, atomicReference.compareAndSwap(null, expectedValue))
         assertEquals(null, atomicReference.compareAndSwap(expectedValue, null))
+        freeze(atomicReference)
         assertEquals(expectedValue, atomicReference.compareAndSwap(null, expectedValue))
         assertEquals(expectedValue, atomicReference.compareAndSwap(null, "other"))
         assertEquals("other", atomicReference.compareAndSwap(expectedValue, "other"))

--- a/trikot-foundation/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSGlobalDispatchQueue.kt
+++ b/trikot-foundation/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSGlobalDispatchQueue.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import platform.darwin.DISPATCH_QUEUE_PRIORITY_HIGH
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_global_queue
@@ -8,11 +9,14 @@ open class IOSGlobalDispatchQueue : TrikotDispatchQueue {
     override fun isSerial() = false
 
     override fun dispatch(block: DispatchBlock) {
+        freeze(block)
+
         dispatch_async(
-            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)
-        ) {
-            runQueueTask(block)
-        }
+            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0),
+            freeze {
+                runQueueTask(block)
+            }
+        )
     }
 
     private fun runQueueTask(block: DispatchBlock) {

--- a/trikot-foundation/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
+++ b/trikot-foundation/trikotFoundation/src/iosArm32Main/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import platform.darwin.DISPATCH_QUEUE_SERIAL
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_queue_create
@@ -14,9 +15,14 @@ open class IOSSerialDispatchQueue(identifier: String) : TrikotDispatchQueue {
     override fun isSerial() = true
 
     override fun dispatch(block: DispatchBlock) {
-        dispatch_async(serialQueue) {
-            runQueueTask(block)
-        }
+        freeze(block)
+
+        dispatch_async(
+            serialQueue,
+            freeze {
+                runQueueTask(block)
+            }
+        )
     }
 
     private fun runQueueTask(block: DispatchBlock) {

--- a/trikot-foundation/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSGlobalDispatchQueue.kt
+++ b/trikot-foundation/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSGlobalDispatchQueue.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import platform.darwin.DISPATCH_QUEUE_PRIORITY_HIGH
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_global_queue
@@ -8,11 +9,14 @@ open class IOSGlobalDispatchQueue : TrikotDispatchQueue {
     override fun isSerial() = false
 
     override fun dispatch(block: DispatchBlock) {
+        freeze(block)
+
         dispatch_async(
-            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH.toLong(), 0UL)
-        ) {
-            runQueueTask(block)
-        }
+            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH.toLong(), 0UL),
+            freeze {
+                runQueueTask(block)
+            }
+        )
     }
 
     private fun runQueueTask(block: DispatchBlock) {

--- a/trikot-foundation/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
+++ b/trikot-foundation/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/IOSSerialDispatchQueue.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import platform.darwin.DISPATCH_QUEUE_SERIAL
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_queue_create
@@ -14,9 +15,14 @@ open class IOSSerialDispatchQueue(identifier: String) : TrikotDispatchQueue {
     override fun isSerial() = true
 
     override fun dispatch(block: DispatchBlock) {
-        dispatch_async(serialQueue) {
-            runQueueTask(block)
-        }
+        freeze(block)
+
+        dispatch_async(
+            serialQueue,
+            freeze {
+                runQueueTask(block)
+            }
+        )
     }
 
     private fun runQueueTask(block: DispatchBlock) {

--- a/trikot-foundation/trikotFoundation/src/jsMain/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
+++ b/trikot-foundation/trikotFoundation/src/jsMain/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
@@ -1,0 +1,13 @@
+package com.mirego.trikot.foundation.concurrent
+
+actual object MrFreeze {
+    actual fun <T> freeze(objectToFreeze: T): T {
+        return objectToFreeze
+    }
+
+    actual fun ensureNeverFrozen(objectToProtect: Any) {}
+}
+
+actual fun <T> freeze(objectToFreeze: T): T {
+    return MrFreeze.freeze(objectToFreeze)
+}

--- a/trikot-foundation/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
+++ b/trikot-foundation/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
@@ -1,0 +1,13 @@
+package com.mirego.trikot.foundation.concurrent
+
+actual object MrFreeze {
+    actual fun <T> freeze(objectToFreeze: T): T {
+        return objectToFreeze
+    }
+
+    actual fun ensureNeverFrozen(objectToProtect: Any) {}
+}
+
+actual fun <T> freeze(objectToFreeze: T): T {
+    return MrFreeze.freeze(objectToFreeze)
+}

--- a/trikot-foundation/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
+++ b/trikot-foundation/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/concurrent/MrFreeze.kt
@@ -1,0 +1,18 @@
+package com.mirego.trikot.foundation.concurrent
+
+import kotlin.native.concurrent.ensureNeverFrozen
+import kotlin.native.concurrent.freeze
+
+actual object MrFreeze {
+    actual fun <T> freeze(objectToFreeze: T): T {
+        return objectToFreeze.freeze()
+    }
+
+    actual fun ensureNeverFrozen(objectToProtect: Any) {
+        objectToProtect.ensureNeverFrozen()
+    }
+}
+
+actual fun <T> freeze(objectToFreeze: T): T {
+    return MrFreeze.freeze(objectToFreeze)
+}

--- a/trikot-foundation/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/UIThreadDispatchQueue.kt
+++ b/trikot-foundation/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/concurrent/dispatchQueue/UIThreadDispatchQueue.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.foundation.concurrent.dispatchQueue
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import platform.Foundation.NSThread
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
@@ -15,9 +16,13 @@ actual class UIThreadDispatchQueue actual constructor() : TrikotDispatchQueue {
         if (currentCount == 1 && NSThread.isMainThread) {
             runQueueTask(block)
         } else {
-            dispatch_async(dispatch_get_main_queue()) {
-                runQueueTask(block)
-            }
+            freeze(block)
+            dispatch_async(
+                dispatch_get_main_queue(),
+                freeze {
+                    runQueueTask(block)
+                }
+            )
         }
     }
 

--- a/trikot-foundation/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/timers/PlatformTimer.kt
+++ b/trikot-foundation/trikotFoundation/src/nativeMain/kotlin/com/mirego/trikot/foundation/timers/PlatformTimer.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.foundation.timers
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import platform.Foundation.NSDefaultRunLoopMode
 import platform.Foundation.NSRunLoop
 import platform.Foundation.NSTimer
@@ -7,11 +8,11 @@ import kotlin.time.Duration
 
 actual class PlatformTimer actual constructor(delay: Duration, repeat: Boolean, block: () -> Unit) : Timer {
     private val timerBlock: (NSTimer?) -> Unit = { _ -> block() }
-
+    private val frozenTimerBlock = timerBlock.also { freeze(it) }
     private val timer = NSTimer.timerWithTimeInterval(
         (delay.inWholeMilliseconds / 1000.0),
         repeat,
-        timerBlock
+        frozenTimerBlock
     )
 
     init {

--- a/trikot-foundation/trikotFoundation/src/nativeTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicPropertyNativeTest.kt
+++ b/trikot-foundation/trikotFoundation/src/nativeTest/kotlin/com/mirego/trikot/foundation/concurrent/AtomicPropertyNativeTest.kt
@@ -1,0 +1,36 @@
+package com.mirego.trikot.foundation.concurrent
+
+import kotlin.native.concurrent.freeze
+import kotlin.native.concurrent.isFrozen
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AtomicPropertyNativeTest {
+    private var atomicPropertyNullable: Any? by atomicNullable(Any())
+    private var atomicPropertyNullableWithValue: Any by atomic(Any())
+    private var atomicPropertyNullableFrozen: Any? by atomicNullable(Any()).freeze()
+    private var atomicPropertyNullableWithValueFrozen: Any by atomic(Any()).freeze()
+
+    @Test
+    fun testValueIsNeverFrozenByDefault() {
+        assertFalse(atomicPropertyNullable.isFrozen)
+        atomicPropertyNullable = Any()
+        assertFalse(atomicPropertyNullable.isFrozen)
+
+        assertFalse(atomicPropertyNullableWithValue.isFrozen)
+        atomicPropertyNullableWithValue = Any()
+        assertFalse(atomicPropertyNullableWithValue.isFrozen)
+    }
+
+    @Test
+    fun testValueIsFrozenIfDelegateIsFrozen() {
+        assertTrue(atomicPropertyNullableFrozen.isFrozen)
+        atomicPropertyNullableFrozen = Any()
+        assertTrue(atomicPropertyNullableFrozen.isFrozen)
+
+        assertTrue(atomicPropertyNullableWithValueFrozen.isFrozen)
+        atomicPropertyNullableWithValueFrozen = Any()
+        assertTrue(atomicPropertyNullableWithValueFrozen.isFrozen)
+    }
+}

--- a/trikot-graphql/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQueryPublisher.kt
+++ b/trikot-graphql/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQueryPublisher.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.graphql
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import com.mirego.trikot.http.ApplicationJSON
 import com.mirego.trikot.http.ContentType
 import com.mirego.trikot.http.HttpConfiguration
@@ -17,7 +18,7 @@ class GraphqlQueryPublisher<T>(
     httpHeaderProvider: HttpHeaderProvider = HttpConfiguration.defaultHttpHeaderProvider,
     requestTimeout: Duration? = null
 ) : DeserializableHttpRequestPublisher<T>(
-    query.deserializer,
+    freeze(query.deserializer),
     createRequestBuilder(query.requestBody, baseUrl, path, requestTimeout),
     httpHeaderProvider
 ) {

--- a/trikot-http/swift-extensions/TrikotHttpResponse.swift
+++ b/trikot-http/swift-extensions/TrikotHttpResponse.swift
@@ -25,9 +25,9 @@ public class TrikotHttpResponse: NSObject, HttpResponse {
             statusCode = Int32(response.statusCode)
         }
         if let data = data, data.count > 0 {
-            bodyByteArray = ByteArrayNativeUtils().convert(data: data) as? KotlinByteArray
+            bodyByteArray = MrFreeze().freeze(objectToFreeze: ByteArrayNativeUtils().convert(data: data)) as? KotlinByteArray
         } else {
-            bodyByteArray = KotlinByteArray(size: 0)
+            bodyByteArray = MrFreeze().freeze(objectToFreeze: KotlinByteArray(size: 0)) as? KotlinByteArray
         }
 
         self.headers = headers

--- a/trikot-streams/README.md
+++ b/trikot-streams/README.md
@@ -2,6 +2,7 @@
 
 Elegant implementation of ReactiveStreams for Kotlin Multiplatform.
 
+- Manage object immutability in native implementation (Object are frozen when switching threads)
 - Multithread support with ObserveOn and SubscribeOn processors
 - Simplify the management of publishers subscriptions and unsubscriptions
 - Help you focus on what you need to do by hiding Multiplatform complexity

--- a/trikot-streams/documentation/PUBLISHERS.md
+++ b/trikot-streams/documentation/PUBLISHERS.md
@@ -4,6 +4,7 @@
 
 - `Publisher` **never** emit a null value
 - [PublisherExtentions](../streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt) offers a kotlin way to subscribe easily and use `processors`
+- Publishers values and subscribers will be [frozen](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.native.concurrent/freeze.html) when switching from a thread to another.
 
 #### PublisherExtensions
 

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -3,6 +3,7 @@ package com.mirego.trikot.streams.reactive
 import com.mirego.trikot.foundation.FoundationConfiguration
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotDispatchQueue
 import com.mirego.trikot.foundation.timers.TimerFactory
+import com.mirego.trikot.streams.StreamsConfiguration
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.backoff.Backoff
 import com.mirego.trikot.streams.reactive.backoff.BackoffPolicy
@@ -38,6 +39,7 @@ import com.mirego.trikot.streams.reactive.processors.TakeUntilProcessor
 import com.mirego.trikot.streams.reactive.processors.TakeUntilProcessorPredicate
 import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessor
 import com.mirego.trikot.streams.reactive.processors.TakeWhileProcessorPredicate
+import com.mirego.trikot.streams.reactive.processors.ThreadLocalProcessor
 import com.mirego.trikot.streams.reactive.processors.TimeoutProcessor
 import com.mirego.trikot.streams.reactive.processors.WithCancellableManagerProcessor
 import com.mirego.trikot.streams.reactive.processors.WithCancellableManagerProcessorResultType
@@ -131,6 +133,13 @@ fun <T> Publisher<T>.startWith(value: T): Publisher<T> {
 
 fun <T, R> Publisher<T>.filterNotNull(block: ((T) -> R?)): Publisher<R> {
     return this.filter { block(it) != null }.map { block(it)!! }
+}
+
+fun <T> Publisher<T>.threadLocal(
+    observeOnQueue: TrikotDispatchQueue,
+    subscribeOnQueue: TrikotDispatchQueue = StreamsConfiguration.publisherExecutionDispatchQueue
+): Publisher<T> {
+    return ThreadLocalProcessor(this, observeOnQueue, subscribeOnQueue)
 }
 
 fun <T> Publisher<T>.timeout(

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/Publishers.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.streams.reactive
 
 import com.mirego.trikot.foundation.FoundationConfiguration
+import com.mirego.trikot.foundation.concurrent.MrFreeze
 import com.mirego.trikot.foundation.timers.TimerFactory
 import org.reactivestreams.Publisher
 import kotlin.time.Duration
@@ -10,8 +11,16 @@ object Publishers {
         return BehaviorSubjectImpl(value)
     }
 
+    fun <T> frozenBehaviorSubject(value: T? = null): BehaviorSubject<T> {
+        return MrFreeze.freeze(BehaviorSubjectImpl(value))
+    }
+
     fun <T> publishSubject(): PublishSubject<T> {
         return PublishSubjectImpl()
+    }
+
+    fun <T> frozenPublishSubject(): PublishSubject<T> {
+        return MrFreeze.freeze(PublishSubjectImpl())
     }
 
     /**

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ObserveOnProcessor.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ObserveOnProcessor.kt
@@ -4,6 +4,7 @@ import com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQ
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotDispatchQueue
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotQueueDispatcher
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.dispatch
+import com.mirego.trikot.foundation.concurrent.freeze
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 
@@ -27,10 +28,12 @@ open class ObserveOnProcessor<T>(
     ) : ProcessorSubscription<T, T>(s), TrikotQueueDispatcher {
 
         override fun onNext(t: T, subscriber: Subscriber<in T>) {
+            freeze(t)
             dispatch { subscriber.onNext(t) }
         }
 
         override fun onError(t: Throwable) {
+            freeze(t)
             dispatch { super.onError(t) }
         }
 

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SubscribeOnProcessor.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SubscribeOnProcessor.kt
@@ -3,6 +3,7 @@ package com.mirego.trikot.streams.reactive.processors
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotDispatchQueue
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotQueueDispatcher
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.dispatch
+import com.mirego.trikot.foundation.concurrent.freeze
 import org.reactivestreams.Publisher
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
@@ -12,6 +13,7 @@ class SubscribeOnProcessor<T>(parentPublisher: Publisher<T>, override val dispat
     TrikotQueueDispatcher {
 
     override fun subscribe(s: Subscriber<in T>) {
+        freeze(s)
         dispatch {
             super.subscribe(s)
         }
@@ -29,6 +31,7 @@ class SubscribeOnProcessor<T>(parentPublisher: Publisher<T>, override val dispat
         }
 
         override fun onCancel(s: Subscription) {
+            freeze(s)
             dispatch {
                 super.onCancel(s)
             }

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ThreadLocalProcessor.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/ThreadLocalProcessor.kt
@@ -1,0 +1,102 @@
+package com.mirego.trikot.streams.reactive.processors
+
+import com.mirego.trikot.foundation.concurrent.MrFreeze
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotDispatchQueue
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.observeOn
+import com.mirego.trikot.streams.reactive.subscribe
+import com.mirego.trikot.streams.reactive.subscribeOn
+import org.reactivestreams.Processor
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import kotlin.native.concurrent.ThreadLocal
+
+class ThreadLocalProcessor<T>(
+    private val parentPublisher: Publisher<T>,
+    private val observeOnQueue: TrikotDispatchQueue,
+    private val subscribeOnQueue: TrikotDispatchQueue
+) : Processor<T, T> {
+    override fun onSubscribe(s: Subscription) {
+        throw IllegalStateException("Should never be called")
+    }
+
+    override fun onNext(t: T) {
+        throw IllegalStateException("Should never be called")
+    }
+
+    override fun onError(t: Throwable) {
+        throw IllegalStateException("Should never be called")
+    }
+
+    override fun onComplete() {
+        throw IllegalStateException("Should never be called")
+    }
+
+    override fun subscribe(s: Subscriber<in T>) {
+        s.onSubscribe(ThreadLocalSubscription(s, parentPublisher, subscribeOnQueue, observeOnQueue))
+    }
+
+    class ThreadLocalSubscription<T>(
+        subscriber: Subscriber<in T>,
+        parentPublisher: Publisher<T>,
+        subscriptionQueue: TrikotDispatchQueue,
+        private val observeOnQueue: TrikotDispatchQueue
+    ) : Subscription {
+
+        private val cancellableManager = CancellableManager()
+
+        override fun request(n: Long) {
+            // NO-OP
+        }
+
+        override fun cancel() {
+            cancellableManager.cancel()
+            observeOnQueue.dispatch { ThreadLocalProcessorSubscribers.remove(this) }
+        }
+
+        init {
+            MrFreeze.ensureNeverFrozen(subscriber)
+            ThreadLocalProcessorSubscribers.set(this, subscriber)
+            val subscription = this
+            parentPublisher.subscribeOn(subscriptionQueue)
+                .observeOn(observeOnQueue)
+                .subscribe(
+                    cancellableManager,
+                    onNext = {
+                        ThreadLocalProcessorSubscribers.get(subscription)?.onNext(it)
+                    },
+                    onError = {
+                        ThreadLocalProcessorSubscribers.get(subscription)?.onError(it)
+                    },
+                    onCompleted = {
+                        ThreadLocalProcessorSubscribers.get(subscription)?.onComplete()
+                    }
+                )
+        }
+    }
+}
+
+@ThreadLocal
+object ThreadLocalProcessorSubscribers {
+    fun <T> get(subscription: ThreadLocalProcessor.ThreadLocalSubscription<T>): Subscriber<T>? {
+        @Suppress("UNCHECKED_CAST")
+        return subscriptions[subscription] as? Subscriber<T>
+    }
+
+    fun <T> set(
+        subscription: ThreadLocalProcessor.ThreadLocalSubscription<T>,
+        s: Subscriber<in T>
+    ) {
+        subscriptions[subscription] = s
+    }
+
+    fun <T> remove(subscription: ThreadLocalProcessor.ThreadLocalSubscription<T>) {
+        subscriptions.remove(subscription)
+    }
+
+    private val subscriptions =
+        HashMap<ThreadLocalProcessor.ThreadLocalSubscription<*>, Subscriber<*>>().also {
+            MrFreeze.ensureNeverFrozen(it)
+        }
+}

--- a/trikot-streams/streams/src/iosX64Test/kotlin/com/FrozenPublisherTests.kt
+++ b/trikot-streams/streams/src/iosX64Test/kotlin/com/FrozenPublisherTests.kt
@@ -1,0 +1,21 @@
+package com
+
+import com.mirego.trikot.streams.reactive.Publishers
+import kotlin.native.concurrent.isFrozen
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class FrozenPublisherTests {
+
+    @Test
+    fun frozenBehaviourSubjectsReallyReturnsAFrozenPublisher() {
+        val publisher = Publishers.frozenBehaviorSubject("test")
+        assertTrue(publisher.isFrozen)
+    }
+
+    @Test
+    fun frozenPublishSubjectsReallyReturnsAFrozenPublisher() {
+        val publisher = Publishers.frozenPublishSubject<String>()
+        assertTrue(publisher.isFrozen)
+    }
+}

--- a/trikot-streams/streams/src/iosX64Test/kotlin/com/ThreadLocalProcessorTests.kt
+++ b/trikot-streams/streams/src/iosX64Test/kotlin/com/ThreadLocalProcessorTests.kt
@@ -1,0 +1,53 @@
+package com
+
+import com.mirego.trikot.foundation.concurrent.MrFreeze
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.DispatchBlock
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.TrikotDispatchQueue
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.map
+import com.mirego.trikot.streams.reactive.processors.ThreadLocalProcessor
+import com.mirego.trikot.streams.reactive.shared
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import kotlin.native.concurrent.ensureNeverFrozen
+import kotlin.native.concurrent.freeze
+import kotlin.native.concurrent.isFrozen
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class ThreadLocalProcessorTests {
+
+    @Test
+    fun threadLocalSubscribersAreNotFrozenByFrozenParentPublisher() {
+        val initialPublisher = Publishers.frozenBehaviorSubject("a")
+        val threadLocal =
+            ThreadLocalProcessor(initialPublisher, FreezingDispatchQueue(), FreezingDispatchQueue())
+        val sharedPublisher = threadLocal.shared().also { MrFreeze.ensureNeverFrozen(it) }
+        val mapProcessor = sharedPublisher.map { it + "mapped" }
+        val subscriber = object : Subscriber<String> {
+            override fun onComplete() {
+            }
+
+            override fun onError(t: Throwable) {
+            }
+
+            override fun onNext(t: String) {
+            }
+
+            override fun onSubscribe(s: Subscription) {
+            }
+        }
+        sharedPublisher.ensureNeverFrozen()
+        subscriber.ensureNeverFrozen()
+
+        mapProcessor.subscribe(subscriber)
+        assertFalse { subscriber.isFrozen }
+    }
+
+    class FreezingDispatchQueue() : TrikotDispatchQueue {
+        override fun dispatch(block: DispatchBlock) {
+            block.freeze()
+            block()
+        }
+    }
+}

--- a/trikot-streams/swift-extensions/TrikotPublisherExtensions.swift
+++ b/trikot-streams/swift-extensions/TrikotPublisherExtensions.swift
@@ -49,6 +49,7 @@ extension NSObject {
                     assert(value is V, "Incorrect binding value type - Cannot cast \(value.self) to \(V.self)")
                     closure(value as! V)
                 } else {
+                    MrFreezeKt.freeze(objectToFreeze: value)
                     DispatchQueue.main.async {
                         assert(value is V, "Incorrect binding value type - Cannot cast \(value.self) to \(V.self)")
                         closure(value as! V)
@@ -67,6 +68,7 @@ extension NSObject {
             if Thread.current.isMainThread {
                 closure(value as! V)
             } else {
+                MrFreezeKt.freeze(objectToFreeze: value)
                 DispatchQueue.main.async {
                     closure(value as! V)
                 }

--- a/trikot-viewmodels-declarative/sample/ios/Podfile.lock
+++ b/trikot-viewmodels-declarative/sample/ios/Podfile.lock
@@ -3,25 +3,25 @@ PODS:
   - Kingfisher (7.1.2)
   - ReachabilitySwift (5.0.0)
   - SwiftLint (0.43.1)
-  - Trikot/http (3.2.1-M2):
+  - Trikot/http (3.2.1-M3-SNAPSHOT):
     - ReachabilitySwift (~> 5.0)
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/kword (3.2.1-M2):
+  - Trikot/kword (3.2.1-M3-SNAPSHOT):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/streams (3.2.1-M2):
+  - Trikot/streams (3.2.1-M3-SNAPSHOT):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative (3.2.1-M2):
+  - Trikot/viewmodels.declarative (3.2.1-M3-SNAPSHOT):
     - Trikot/streams
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.Combine (3.2.1-M2):
+  - Trikot/viewmodels.declarative.Combine (3.2.1-M3-SNAPSHOT):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.SwiftUI (3.2.1-M2):
+  - Trikot/viewmodels.declarative.SwiftUI (3.2.1-M3-SNAPSHOT):
     - Introspect (~> 0.1)
     - Kingfisher (~> 7.1)
     - Trikot/viewmodels.declarative
     - Trikot/viewmodels.declarative.Combine
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.UIKit (3.2.1-M2):
+  - Trikot/viewmodels.declarative.UIKit (3.2.1-M3-SNAPSHOT):
     - Kingfisher (>= 5.0)
     - Trikot/streams
     - Trikot/viewmodels.declarative
@@ -56,7 +56,7 @@ SPEC CHECKSUMS:
   Kingfisher: 44ed6a8504763f27bab46163adfac83f5deb240c
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
-  Trikot: cf4f66f573299c543fdad6795f90048fb6c20d51
+  Trikot: 2a6ffd237081802fbd108c10d63b356bc2ffe611
   TRIKOT_FRAMEWORK_NAME: b6f7d050429a0edb5ae07cafea0da05aff67e2c4
 
 PODFILE CHECKSUM: 8057f57ba2a2db77f33517422839afd5282c408e

--- a/trikot-viewmodels-declarative/swift/uikit/VMDNSObjectExtensions.swift
+++ b/trikot-viewmodels-declarative/swift/uikit/VMDNSObjectExtensions.swift
@@ -55,6 +55,7 @@ extension ViewModelDeclarativeWrapper where Base : NSObject {
             if Thread.current.isMainThread {
                 closure(value as! V)
             } else {
+                MrFreezeKt.freeze(objectToFreeze: value)
                 DispatchQueue.main.async {
                     closure(value as! V)
                 }

--- a/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/properties/VMDColor.kt
+++ b/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/properties/VMDColor.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.declarative.properties
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import kotlin.math.roundToInt
 
 class VMDColor(val red: Int, val green: Int, val blue: Int, val alpha: Float = 1.0f) {
@@ -26,6 +27,6 @@ class VMDColor(val red: Int, val green: Int, val blue: Int, val alpha: Float = 1
     }
 
     companion object {
-        val None = VMDColor(-1, -1, -1, -1f)
+        val None = freeze(VMDColor(-1, -1, -1, -1f))
     }
 }

--- a/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/properties/VMDImageResource.kt
+++ b/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/properties/VMDImageResource.kt
@@ -1,5 +1,7 @@
 package com.mirego.trikot.viewmodels.declarative.properties
 
+import com.mirego.trikot.foundation.concurrent.freeze
+
 /**
  * An image resource within a known set of images contained in the application. [VMDImageResource.None]
  * is used to represent the absence of image. An enum containing all the known images usually
@@ -7,7 +9,7 @@ package com.mirego.trikot.viewmodels.declarative.properties
  */
 interface VMDImageResource {
     companion object {
-        val None = VMDNoImageResource() as VMDImageResource
+        val None = freeze(VMDNoImageResource() as VMDImageResource)
     }
 }
 

--- a/trikot-viewmodels/sample/ios/Podfile.lock
+++ b/trikot-viewmodels/sample/ios/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - Kingfisher (6.3.1)
   - SwiftLint (0.43.0)
-  - Trikot/streams (3.2.1-M2):
+  - Trikot/streams (3.2.1-M3-SNAPSHOT):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels (3.2.1-M2):
+  - Trikot/viewmodels (3.2.1-M3-SNAPSHOT):
     - Trikot/streams
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.Kingfisher (3.2.1-M2):
+  - Trikot/viewmodels.Kingfisher (3.2.1-M3-SNAPSHOT):
     - Kingfisher (>= 5.0)
     - Trikot/streams
     - Trikot/viewmodels
@@ -34,7 +34,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Kingfisher: 016c8b653a35add51dd34a3aba36b580041acc74
   SwiftLint: 0c645fdc6feed3e390c1701ab3cc669f88b42752
-  Trikot: cf4f66f573299c543fdad6795f90048fb6c20d51
+  Trikot: 2a6ffd237081802fbd108c10d63b356bc2ffe611
   TRIKOT_FRAMEWORK_NAME: 56bdfbf35c0a1e66e4e5dac00e9b212512355bb1
 
 PODFILE CHECKSUM: b514fb641e6b1741e7101243fd38210ee176ce80

--- a/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
@@ -183,6 +183,9 @@ public class DefaultImageViewModelHandler: ImageViewModelHandler {
                 observeImageFlow(onSuccess, cancellableManager: cancellableManager, imageViewModel: imageViewModel, imageView: imageView)
             }
         } else {
+            MrFreeze().freeze(objectToFreeze: cancellableManager)
+            MrFreeze().freeze(objectToFreeze: imageFlow)
+
             let dataTask = URLSession.shared.dataTask(with: url) { [weak imageView, weak self] data, response, error in
                     let image = data != nil ? UIImage(data: data!) : nil
                 DispatchQueue.main.async {

--- a/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/Color.kt
+++ b/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/Color.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.properties
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import kotlin.math.roundToInt
 
 data class Color(val red: Int, val green: Int, val blue: Int, val alpha: Float = 1.0f) {
@@ -26,8 +27,8 @@ data class Color(val red: Int, val green: Int, val blue: Int, val alpha: Float =
     }
 
     companion object {
-        val None = Color(-1, -1, -1, -1f)
-        val Black = Color(0, 0, 0)
-        val White = Color(255, 255, 255)
+        val None = freeze(Color(-1, -1, -1, -1f))
+        val Black = freeze(Color(0, 0, 0))
+        val White = freeze(Color(255, 255, 255))
     }
 }

--- a/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/InputTextEditorAction.kt
+++ b/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/InputTextEditorAction.kt
@@ -1,5 +1,7 @@
 package com.mirego.trikot.viewmodels.properties
 
+import com.mirego.trikot.foundation.concurrent.freeze
+
 typealias InputTextEditorActionBlock = (actionContext: Any?) -> Boolean
 
 open class InputTextEditorAction(private var action: InputTextEditorActionBlock) {
@@ -8,6 +10,6 @@ open class InputTextEditorAction(private var action: InputTextEditorActionBlock)
     open fun execute(actionContext: Any? = null): Boolean = action(actionContext)
 
     companion object {
-        val None = InputTextEditorAction { false }
+        val None = freeze(InputTextEditorAction { false })
     }
 }

--- a/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/ViewModelAction.kt
+++ b/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/ViewModelAction.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.properties
 
+import com.mirego.trikot.foundation.concurrent.freeze
 import kotlin.js.JsName
 
 typealias ViewModelActionBlock = (actionContext: Any?) -> Unit
@@ -15,6 +16,6 @@ open class ViewModelAction(private var action: ViewModelActionBlock) {
     }
 
     companion object {
-        val None = ViewModelAction {}
+        val None = freeze(ViewModelAction {})
     }
 }

--- a/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/resource/ImageResource.kt
+++ b/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/resource/ImageResource.kt
@@ -1,8 +1,10 @@
 package com.mirego.trikot.viewmodels.resource
 
+import com.mirego.trikot.foundation.concurrent.freeze
+
 interface ImageResource {
     companion object {
-        val None = NoImageResource() as ImageResource
+        val None = freeze(NoImageResource() as ImageResource)
     }
 }
 

--- a/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/resource/TextAppearanceResource.kt
+++ b/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/resource/TextAppearanceResource.kt
@@ -1,8 +1,10 @@
 package com.mirego.trikot.viewmodels.resource
 
+import com.mirego.trikot.foundation.concurrent.freeze
+
 interface TextAppearanceResource {
     companion object {
-        val None = NoTextAppearanceResource() as TextAppearanceResource
+        val None = freeze(NoTextAppearanceResource() as TextAppearanceResource)
     }
 }
 

--- a/trikot-viewmodels/viewmodels/src/iosMainShared/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/trikot-viewmodels/viewmodels/src/iosMainShared/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -14,6 +14,7 @@ import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import platform.darwin.sel_registerName
+import kotlin.native.concurrent.freeze
 
 @Suppress("unused")
 actual class ApplicationStatePublisher :
@@ -26,9 +27,12 @@ actual class ApplicationStatePublisher :
         if (NSThread.isMainThread) {
             setInitialValue()
         } else {
-            dispatch_async(dispatch_get_main_queue()) {
-                setInitialValue()
-            }
+            dispatch_async(
+                dispatch_get_main_queue(),
+                {
+                    setInitialValue()
+                }.freeze()
+            )
         }
     }
 
@@ -55,7 +59,7 @@ actual class ApplicationStatePublisher :
         private var callback: ((ApplicationState) -> Unit)? by atomicNullable(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure
+            callback = closure.freeze()
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),

--- a/trikot-viewmodels/viewmodels/src/macosX64Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/trikot-viewmodels/viewmodels/src/macosX64Main/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -13,6 +13,7 @@ import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import platform.darwin.sel_registerName
+import kotlin.native.concurrent.freeze
 
 @Suppress("unused")
 actual class ApplicationStatePublisher :
@@ -25,9 +26,12 @@ actual class ApplicationStatePublisher :
         if (NSThread.isMainThread) {
             setInitialValue()
         } else {
-            dispatch_async(dispatch_get_main_queue()) {
-                setInitialValue()
-            }
+            dispatch_async(
+                dispatch_get_main_queue(),
+                {
+                    setInitialValue()
+                }.freeze()
+            )
         }
     }
 
@@ -54,7 +58,7 @@ actual class ApplicationStatePublisher :
         private var callback: ((ApplicationState) -> Unit)? by atomicNullable(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure
+            callback = closure.freeze()
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("didBecomeActive"),

--- a/trikot-viewmodels/viewmodels/src/watchosMainShared/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/trikot-viewmodels/viewmodels/src/watchosMainShared/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -14,6 +14,7 @@ import platform.darwin.NSObject
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import platform.darwin.sel_registerName
+import kotlin.native.concurrent.freeze
 
 @Suppress("unused")
 actual class ApplicationStatePublisher :
@@ -26,9 +27,12 @@ actual class ApplicationStatePublisher :
         if (NSThread.isMainThread) {
             setInitialValue()
         } else {
-            dispatch_async(dispatch_get_main_queue()) {
-                setInitialValue()
-            }
+            dispatch_async(
+                dispatch_get_main_queue(),
+                {
+                    setInitialValue()
+                }.freeze()
+            )
         }
     }
 
@@ -55,7 +59,7 @@ actual class ApplicationStatePublisher :
         private var callback: ((ApplicationState) -> Unit)? by atomicNullable(null)
 
         fun start(closure: (ApplicationState) -> Unit) {
-            callback = closure
+            callback = closure.freeze()
             NSNotificationCenter.defaultCenter.addObserver(
                 this,
                 sel_registerName("willEnterForeground"),


### PR DESCRIPTION
## Description
We revert the freeze removal from https://github.com/mirego/trikot/pull/19

## Motivation and Context
We want future releases of trikot to be compatible with both memory models. This will stay true for given transition period which hasn't been determined yet.

## How Has This Been Tested?
I've tested this with an app in both modes.
