### PR TITLE
[Streams] Rename Collect processor which is actually ScanWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Upcoming release
 
+## 3.2.1
+
+> 2022-03-22
+
+- [streams] Rename `collect()` operator to `scanWith()`
+
 ## 3.2.0
 
 > 2022-03-21

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanProcessorTests.kt
@@ -67,7 +67,31 @@ class ScanProcessorTests {
         publisher.value = 4
         publisher.complete()
 
-        assertEquals(listOf(10, 11, 13, 16, 20), receivedResults)
+        assertEquals(listOf(10, 10, 11, 13, 16, 20), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
+    fun testScanWithEmptyUpstream() {
+        val publisher = Publishers.empty<Int>()
+        val receivedResults = mutableListOf<Int>()
+        var completed = false
+
+        publisher
+            .scan(10) { acc, current -> acc + current }
+            .subscribe(
+                CancellableManager(),
+                onNext = {
+                    receivedResults.add(it)
+                },
+                onError = {
+                },
+                onCompleted = {
+                    completed = true
+                }
+            )
+
+        assertEquals(listOf(10), receivedResults)
         assertTrue(completed)
     }
 

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanWithProcessorTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanWithProcessorTests.kt
@@ -173,7 +173,6 @@ class ScanWithProcessorTests {
     fun testThrowingSupplier() {
         val publisher = Publishers.behaviorSubject("a")
 
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
         var receivedException: StreamsProcessorException? = null
 
         val scanPublisher = publisher.scanWith({ throw IllegalStateException() }) { acc, _ -> acc }
@@ -186,13 +185,14 @@ class ScanWithProcessorTests {
             )
             publisher.value = "b"
         }
+
+        assertEquals(null, receivedException)
     }
 
     @Test
     fun testMappingAnyException() {
         val publisher = Publishers.behaviorSubject("a")
 
-        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
         var receivedException: StreamsProcessorException? = null
 
         assertFailsWith(IllegalStateException::class) {
@@ -203,8 +203,9 @@ class ScanWithProcessorTests {
                     onNext = { },
                     onError = { receivedException = it as StreamsProcessorException }
                 )
-            publisher.value = "b"
         }
+
+        assertEquals(null, receivedException)
     }
 
     @Test

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanWithProcessorTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/reactive/processors/ScanWithProcessorTests.kt
@@ -3,14 +3,14 @@ package com.mirego.trikot.streams.reactive.processors
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.Publishers
 import com.mirego.trikot.streams.reactive.StreamsProcessorException
-import com.mirego.trikot.streams.reactive.collect
+import com.mirego.trikot.streams.reactive.scanWith
 import com.mirego.trikot.streams.reactive.subscribe
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-class CollectProcessorTests {
+class ScanWithProcessorTests {
     @Test
     fun testCollectToList() {
         val publisher = Publishers.behaviorSubject(0)
@@ -18,7 +18,7 @@ class CollectProcessorTests {
         var completed = false
 
         publisher
-            .collect(emptyList<Int>()) { acc, current -> acc + current }
+            .scanWith({ emptyList<Int>() }) { acc, current -> acc + current }
             .subscribe(
                 CancellableManager(),
                 onNext = { receivedResults += it },
@@ -33,6 +33,7 @@ class CollectProcessorTests {
         publisher.complete()
 
         val expectedResults = listOf(
+            listOf(),
             listOf(0),
             listOf(0, 1),
             listOf(0, 1, 2),
@@ -50,7 +51,7 @@ class CollectProcessorTests {
         var completed = false
 
         publisher
-            .collect("") { acc, current -> acc + current }
+            .scanWith({ "" }) { acc, current -> acc + current }
             .subscribe(
                 CancellableManager(),
                 onNext = { receivedResults += it },
@@ -65,6 +66,7 @@ class CollectProcessorTests {
         publisher.complete()
 
         val expectedResults = listOf(
+            "",
             "0",
             "01",
             "012",
@@ -76,11 +78,30 @@ class CollectProcessorTests {
     }
 
     @Test
+    fun testCollectWithEmptyUpstream() {
+        val publisher = Publishers.empty<Int>()
+        val receivedResults = mutableListOf<Int>()
+        var completed = false
+
+        publisher
+            .scanWith({ 0 }) { acc, current -> acc + current }
+            .subscribe(
+                CancellableManager(),
+                onNext = { receivedResults += it },
+                onError = { },
+                onCompleted = { completed = true }
+            )
+
+        assertEquals(listOf(0), receivedResults)
+        assertTrue(completed)
+    }
+
+    @Test
     fun testReconnection() {
         val publisher = Publishers.publishSubject<String>()
         val receivedResults = mutableListOf<String>()
 
-        val collectPublisher = publisher.collect("") { acc, current -> acc + current }
+        val collectPublisher = publisher.scanWith({ "" }) { acc, current -> acc + current }
 
         val cancellableManager1 = CancellableManager()
         val cancellableManager2 = CancellableManager()
@@ -100,7 +121,33 @@ class CollectProcessorTests {
 
         cancellableManager2.cancel()
 
-        assertEquals(listOf("a", "ab", "abc", "a", "ab", "abc"), receivedResults)
+        assertEquals(listOf("", "a", "ab", "abc", "", "a", "ab", "abc"), receivedResults)
+    }
+
+    @Test
+    fun testMultipleSubscribers() {
+        val publisher = Publishers.publishSubject<String>()
+
+        val collectPublisher = publisher.scanWith({ "" }) { acc, current -> acc + current }
+
+        val receivedResults1 = mutableListOf<String>()
+        val cancellableManager1 = CancellableManager()
+        collectPublisher.subscribe(cancellableManager1) { receivedResults1 += it }
+
+        publisher.value = "a"
+        publisher.value = "b"
+        publisher.value = "c"
+
+        val receivedResults2 = mutableListOf<String>()
+        val cancellableManager2 = CancellableManager()
+        collectPublisher.subscribe(cancellableManager2) { receivedResults2 += it }
+
+        publisher.value = "d"
+        publisher.value = "e"
+        publisher.value = "f"
+
+        assertEquals(listOf("", "a", "ab", "abc", "abcd", "abcde", "abcdef"), receivedResults1)
+        assertEquals(listOf("", "d", "de", "def"), receivedResults2)
     }
 
     @Test
@@ -110,7 +157,7 @@ class CollectProcessorTests {
         var receivedException: StreamsProcessorException? = null
 
         publisher
-            .collect(emptySet<Int>()) { _, _ -> throw expectedException }
+            .scanWith({ 0 }) { _, _ -> throw expectedException }
             .subscribe(
                 CancellableManager(),
                 onNext = { },
@@ -123,6 +170,25 @@ class CollectProcessorTests {
     }
 
     @Test
+    fun testThrowingSupplier() {
+        val publisher = Publishers.behaviorSubject("a")
+
+        @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
+        var receivedException: StreamsProcessorException? = null
+
+        val scanPublisher = publisher.scanWith({ throw IllegalStateException() }) { acc, _ -> acc }
+
+        assertFailsWith(IllegalStateException::class) {
+            scanPublisher.subscribe(
+                CancellableManager(),
+                onNext = { },
+                onError = { receivedException = it as StreamsProcessorException }
+            )
+            publisher.value = "b"
+        }
+    }
+
+    @Test
     fun testMappingAnyException() {
         val publisher = Publishers.behaviorSubject("a")
 
@@ -131,7 +197,7 @@ class CollectProcessorTests {
 
         assertFailsWith(IllegalStateException::class) {
             publisher
-                .collect(0) { _, _ -> throw IllegalStateException() }
+                .scanWith({ 0 }) { _, _ -> throw IllegalStateException() }
                 .subscribe(
                     CancellableManager(),
                     onNext = { },
@@ -149,7 +215,7 @@ class CollectProcessorTests {
         var receivedException: Throwable? = null
 
         publisher
-            .collect(0) { acc, value -> acc + value.toInt() }
+            .scanWith({ 0 }) { acc, value -> acc + value.toInt() }
             .subscribe(
                 CancellableManager(),
                 onNext = { },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Rename our newly added `Collect` processor to `ScanWith` as the current implementation actually responds to the [Scan](https://reactivex.io/documentation/operators/scan.html) reactive spec, not [Reduce/Collect](https://reactivex.io/documentation/operators/reduce.html).

<img alt="Screen Shot 2022-03-21 at 16 22 32" src="https://user-images.githubusercontent.com/5982196/159504191-835ae73f-b882-40a0-ada5-a2260f6c9a90.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


This is a **breaking change** as the `Publisher.collect` extension is removed and because the `Publisher.scan` operator now properly dispatches the provided initial value on subscription.

This partially reverts changes of previous commit from https://github.com/mirego/trikot/pull/54
