### PR TITLE
Bump dependencies

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.20")
     implementation("com.android.tools.build:gradle:7.1.2")
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,13 +1,13 @@
 object Versions {
     const val KOTLIN = "1.6.10"
-    const val ATOMIC_FU = "0.17.0"
+    const val ATOMIC_FU = "0.17.1"
     const val ANDROID_GRADLE_PLUGIN = "7.1.2"
-    const val JETPACK_COMPOSE = "1.2.0-alpha03"
+    const val JETPACK_COMPOSE = "1.2.0-alpha07"
     const val COIL = "1.4.0"
     const val KTLINT = "10.2.0"
     const val KOTLINX_SERIALIZATION = "1.3.2"
-    const val KOTLINX_COROUTINES = "1.6.0"
-    const val KTOR = "2.0.0-beta-1"
+    const val KOTLINX_COROUTINES = "1.6.1"
+    const val KTOR = "2.0.0"
     const val KOTLIN_WRAPPERS_EXTENSIONS = "1.0.1-pre.290"
     const val ANDROIDX_LIFECYCLE = "2.4.0"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,14 +1,14 @@
 object Versions {
-    const val KOTLIN = "1.6.10"
+    const val KOTLIN = "1.6.20"
     const val ATOMIC_FU = "0.17.1"
     const val ANDROID_GRADLE_PLUGIN = "7.1.2"
-    const val JETPACK_COMPOSE = "1.2.0-alpha07"
+    const val JETPACK_COMPOSE = "1.2.0-alpha08"
     const val COIL = "1.4.0"
     const val KTLINT = "10.2.0"
     const val KOTLINX_SERIALIZATION = "1.3.2"
     const val KOTLINX_COROUTINES = "1.6.1"
     const val KTOR = "2.0.0"
-    const val KOTLIN_WRAPPERS_EXTENSIONS = "1.0.1-pre.290"
+    const val KOTLIN_WRAPPERS_EXTENSIONS = "1.0.1-pre.331"
     const val ANDROIDX_LIFECYCLE = "2.4.0"
 
     object Android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=3.2.3
+version=3.3.0
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official


### PR DESCRIPTION
## Description
Bump:
- AtomicFu from 0.17.0 to 0.17.1
- Jetpack Compose from 1.2.0-alpha03 to 1.2.0-alpha07
- Kotlinx.Coroutines from 1.6.0 to 1.6.1
- Ktor from 2.0.0-beta-1 to 2.0.0
- Kotlin to 1.6.20