### PR TITLE
Expose downloadImageAdapter to DefaultImageViewModelHandler

### DIFF
--- a/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
@@ -81,6 +81,10 @@ public class DefaultImageViewModelHandler: ImageViewModelHandler {
     public var isImageDependantOnViewSize = false
     public var minimumSizeChange: CGFloat = 50
     public var sizeMultiplier: CGFloat = UIScreen.main.scale
+    public var downloadImageAdapter: ((_ data: Data?) -> UIImage?) = { optinalData in
+        guard let data = optinalData else { return nil }
+        return UIImage(data: data)
+    }
 
     public var maxNumberOfImagesInCache: Int {
         get {
@@ -187,7 +191,7 @@ public class DefaultImageViewModelHandler: ImageViewModelHandler {
             MrFreeze().freeze(objectToFreeze: imageFlow)
 
             let dataTask = URLSession.shared.dataTask(with: url) { [weak imageView, weak self] data, response, error in
-                    let image = data != nil ? UIImage(data: data!) : nil
+                let image = self?.downloadImageAdapter(data)
                 DispatchQueue.main.async {
                     guard let imageView = imageView else { return }
                     if let httpURLResponse = response as? HTTPURLResponse, httpURLResponse.statusCode == 200,

--- a/trikot-viewmodels/swift-extensions/kingfisher/KFImageViewModelHandler.swift
+++ b/trikot-viewmodels/swift-extensions/kingfisher/KFImageViewModelHandler.swift
@@ -12,6 +12,7 @@ public class KFImageViewModelHandler: ImageViewModelHandler {
 
     public var isImageDependantOnViewSize = false
     public var sizeMultiplier: CGFloat = UIScreen.main.scale
+    public var imageProcessor: ImageProcessor? = nil
 
     public init() {}
 
@@ -105,7 +106,7 @@ public class KFImageViewModelHandler: ImageViewModelHandler {
     ) {
         guard let urlString = imageFlow.url, let url = URL(string: urlString) else { return }
 
-        var options: KingfisherOptionsInfo = []
+        var options: KingfisherOptionsInfo = imageProcessor != nil ? [.processor(imageProcessor!)] : []
         if let modifier = delegate?.requestModifier(for: url) {
             options.append(.requestModifier(modifier))
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
We expose the downloadImageAdapter to the DefaultImageViewModelHandler so we can override the default behaviour.

## Motivation and Context

<!--- Why is those changes required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to handle SVG image type, unfortunately UIKit does not handle SVG on is own. 
`UIImage(data: data)` with svg as data returns nil.
The solution is to expose a method `downloadImageAdapter` to let the applications handle the data itself.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The default behaviour remains the same and was tested here https://github.com/mirego/bellmedia-sports-mobile/pull/3654

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
