### PR TITLE
[59] For all numbers keep them as raw numbers instead of converting them to String.

### DIFF
--- a/trikot-graphql/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQuery.kt
+++ b/trikot-graphql/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/GraphqlQuery.kt
@@ -42,7 +42,7 @@ abstract class AbstractGraphqlQuery<T>(override val deserializer: Deserializatio
     private fun anyToJson(any: Any): String {
         return when (any) {
             is List<*> -> listJson(any)
-            is Int,
+            is Number,
             is Boolean -> "$any"
             is GraphqlJsonObject -> any.body
             else -> "\"${any.toString().escapeForGraphql()}\""

--- a/trikot-graphql/graphql/src/commonTest/kotlin/com/mirego/trikot/graphql/GraphqlQueryTests.kt
+++ b/trikot-graphql/graphql/src/commonTest/kotlin/com/mirego/trikot/graphql/GraphqlQueryTests.kt
@@ -16,6 +16,26 @@ class GraphqlQueryTests {
         )
     }
 
+    @Test
+    fun givenQueryWithNumbersTheyArentEscaped() {
+        val query = NumberQuery()
+
+        assertEquals(
+            "{\"query\": \"PutSomeNumbers\",\"variables\": {\"float\":5.5,\"int\":-5,\"double\":-123.45}}",
+            query.requestBody
+        )
+    }
+
+    class NumberQuery : AbstractGraphqlQuery<String>(String.serializer()) {
+        override val variables = mapOf(
+            "float" to 5.5f,
+            "int" to -5,
+            "double" to -123.45
+        )
+
+        override val query = "PutSomeNumbers"
+    }
+
     class QueryTest : AbstractGraphqlQuery<String>(String.serializer()) {
         override val variables = mapOf("var" to stringToEscape())
 


### PR DESCRIPTION

## Description

Use raw value for **all numbers** instead of just `Int`

## Motivation and Context

Fixes issue #59 

## How Has This Been Tested?

Added a test specifically for number types.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
