### PR TITLE
[VMD] Source was not properly packaged in the viewmodels-declarative-compose artefact

### DIFF
--- a/trikot-viewmodels-declarative/compose/build.gradle.kts
+++ b/trikot-viewmodels-declarative/compose/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
+
 plugins {
     id("com.android.library")
     id("kotlin-android")
@@ -12,7 +14,6 @@ android {
         minSdk = Versions.Android.MIN_SDK
         targetSdk = Versions.Android.TARGET_SDK
     }
-
     buildFeatures {
         compose = true
         buildConfig = false
@@ -26,6 +27,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = "11"
+    }
+    sourceSets {
+        println("SSS $this")
     }
 }
 
@@ -50,22 +54,23 @@ dependencies {
 }
 
 tasks {
-    val sourcesJar by creating(Jar::class) {
+    val sourcesJar by registering(Jar::class) {
+        val sourceSet = android.sourceSets.getByName("main").kotlin as DefaultAndroidSourceDirectorySet
+        from(sourceSet.srcDirs)
         archiveClassifier.set("sources")
-        from(android.sourceSets.getByName("main").java.srcDirs().toString())
+    }
+
+    artifacts {
+        archives(sourcesJar)
     }
 }
+
 
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("release") {
+            create<MavenPublication>("composeAar") {
                 from(components["release"])
-                artifactId = "viewmodels-declarative-compose"
-                artifact(tasks["sourcesJar"])
-            }
-            create<MavenPublication>("debug") {
-                from(components["debug"])
                 artifactId = "viewmodels-declarative-compose"
                 artifact(tasks["sourcesJar"])
             }

--- a/trikot-viewmodels-declarative/compose/build.gradle.kts
+++ b/trikot-viewmodels-declarative/compose/build.gradle.kts
@@ -62,7 +62,6 @@ tasks {
     }
 }
 
-
 afterEvaluate {
     publishing {
         publications {

--- a/trikot-viewmodels-declarative/compose/build.gradle.kts
+++ b/trikot-viewmodels-declarative/compose/build.gradle.kts
@@ -28,9 +28,6 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
-    sourceSets {
-        println("SSS $this")
-    }
 }
 
 kotlin {


### PR DESCRIPTION
## Description

Since source was not properly packaged, it was not possible to browser the code of all the VMD binding for jetpack compose, when used in a project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
