### PR TITLE
[VMD] Add VMDLazyColumn and VMDLazyRow compose components + update android sample

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
@@ -6,9 +6,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,13 +16,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mirego.trikot.viewmodels.declarative.components.VMDListViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
-import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 
-@Deprecated("Use either VMDLazyColumn or VMDLazyRow instead")
 @Composable
-fun <C : VMDIdentifiableContent> VMDList(
+fun <C : VMDIdentifiableContent> VMDLazyColumn(
     modifier: Modifier = Modifier,
     viewModel: VMDListViewModel<C>,
     state: LazyListState = rememberLazyListState(),
@@ -35,7 +32,7 @@ fun <C : VMDIdentifiableContent> VMDList(
     flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
     itemContent: @Composable LazyItemScope.(item: C) -> Unit
 ) {
-    VMDSectionedList(
+    VMDLazyColumnIndexed(
         modifier = modifier,
         viewModel = viewModel,
         state = state,
@@ -43,13 +40,14 @@ fun <C : VMDIdentifiableContent> VMDList(
         reverseLayout = reverseLayout,
         verticalArrangement = verticalArrangement,
         horizontalAlignment = horizontalAlignment,
-        flingBehavior = flingBehavior) {
-        items(viewModel.elements, key = { item -> item.identifier }, itemContent = itemContent)
+        flingBehavior = flingBehavior
+    ) { _, item ->
+        itemContent(item)
     }
 }
 
 @Composable
-fun <C : VMDIdentifiableContent> VMDSectionedList(
+fun <C : VMDIdentifiableContent> VMDLazyColumnIndexed(
     modifier: Modifier = Modifier,
     viewModel: VMDListViewModel<C>,
     state: LazyListState = rememberLazyListState(),
@@ -59,9 +57,9 @@ fun <C : VMDIdentifiableContent> VMDSectionedList(
         if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
-    content: LazyListScope.(elements: List<C>) -> Unit
+    itemContent: @Composable LazyItemScope.(index: Int, item: C) -> Unit
 ) {
-    val listViewModel: VMDListViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val listViewModel: VMDListViewModel<C> by viewModel.observeAsState()
 
     LazyColumn(
         modifier = modifier
@@ -73,6 +71,8 @@ fun <C : VMDIdentifiableContent> VMDSectionedList(
         horizontalAlignment = horizontalAlignment,
         flingBehavior = flingBehavior
     ) {
-        content(listViewModel.elements)
+        itemsIndexed(listViewModel.elements, key = { _, item -> item.identifier }, itemContent = itemContent)
     }
 }
+
+

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
@@ -74,5 +74,3 @@ fun <C : VMDIdentifiableContent> VMDLazyColumnIndexed(
         itemsIndexed(listViewModel.elements, key = { _, item -> item.identifier }, itemContent = itemContent)
     }
 }
-
-

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
@@ -6,9 +6,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,62 +17,61 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mirego.trikot.viewmodels.declarative.components.VMDListViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
-import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 
-@Deprecated("Use either VMDLazyColumn or VMDLazyRow instead")
 @Composable
-fun <C : VMDIdentifiableContent> VMDList(
+fun <C : VMDIdentifiableContent> VMDLazyRow(
     modifier: Modifier = Modifier,
     viewModel: VMDListViewModel<C>,
     state: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     reverseLayout: Boolean = false,
-    verticalArrangement: Arrangement.Vertical =
-        if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
-    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    horizontalArrangement: Arrangement.Horizontal =
+        if (!reverseLayout) Arrangement.Start else Arrangement.End,
+    verticalAlignment: Alignment.Vertical = Alignment.Top,
     flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
     itemContent: @Composable LazyItemScope.(item: C) -> Unit
 ) {
-    VMDSectionedList(
+    VMDLazyRowIndexed(
         modifier = modifier,
         viewModel = viewModel,
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,
-        verticalArrangement = verticalArrangement,
-        horizontalAlignment = horizontalAlignment,
-        flingBehavior = flingBehavior) {
-        items(viewModel.elements, key = { item -> item.identifier }, itemContent = itemContent)
+        horizontalArrangement = horizontalArrangement,
+        verticalAlignment = verticalAlignment,
+        flingBehavior = flingBehavior
+    ) { _, item ->
+        itemContent(item)
     }
 }
 
 @Composable
-fun <C : VMDIdentifiableContent> VMDSectionedList(
+fun <C : VMDIdentifiableContent> VMDLazyRowIndexed(
     modifier: Modifier = Modifier,
     viewModel: VMDListViewModel<C>,
     state: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     reverseLayout: Boolean = false,
-    verticalArrangement: Arrangement.Vertical =
-        if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
-    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    horizontalArrangement: Arrangement.Horizontal =
+        if (!reverseLayout) Arrangement.Start else Arrangement.End,
+    verticalAlignment: Alignment.Vertical = Alignment.Top,
     flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
-    content: LazyListScope.(elements: List<C>) -> Unit
+    itemContent: @Composable LazyItemScope.(index: Int, item: C) -> Unit
 ) {
-    val listViewModel: VMDListViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val listViewModel: VMDListViewModel<C> by viewModel.observeAsState()
 
-    LazyColumn(
+    LazyRow(
         modifier = modifier
             .hidden(listViewModel.isHidden),
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,
-        verticalArrangement = verticalArrangement,
-        horizontalAlignment = horizontalAlignment,
+        horizontalArrangement = horizontalArrangement,
+        verticalAlignment = verticalAlignment,
         flingBehavior = flingBehavior
     ) {
-        content(listViewModel.elements)
+        itemsIndexed(listViewModel.elements, key = { _, item -> item.identifier }, itemContent = itemContent)
     }
 }

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
@@ -21,7 +21,7 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingA
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 
-@Deprecated("Use either VMDLazyColumn or VMDLazyRow instead")
+@Deprecated("Use either VMDLazyColumn instead")
 @Composable
 fun <C : VMDIdentifiableContent> VMDList(
     modifier: Modifier = Modifier,

--- a/trikot-viewmodels-declarative/sample/android/src/main/AndroidManifest.xml
+++ b/trikot-viewmodels-declarative/sample/android/src/main/AndroidManifest.xml
@@ -54,5 +54,9 @@
             android:name="com.mirego.sample.ui.showcase.animation.types.AnimationTypesShowcaseActivity"
             android:theme="@style/Theme.MaterialComponents.Light.NoActionBar" />
 
+        <activity
+            android:name="com.mirego.sample.ui.showcase.components.list.ListShowcaseActivity"
+            android:theme="@style/Theme.MaterialComponents.Light.NoActionBar" />
+
     </application>
 </manifest>

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/home/HomeActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/home/HomeActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.setContent
 import com.mirego.sample.ui.showcase.animation.types.AnimationTypesShowcaseActivity
 import com.mirego.sample.ui.showcase.components.button.ButtonShowcaseActivity
 import com.mirego.sample.ui.showcase.components.image.ImageShowcaseActivity
+import com.mirego.sample.ui.showcase.components.list.ListShowcaseActivity
 import com.mirego.sample.ui.showcase.components.progress.ProgressShowcaseActivity
 import com.mirego.sample.ui.showcase.components.text.TextShowcaseActivity
 import com.mirego.sample.ui.showcase.components.textfield.TextFieldShowcaseActivity
@@ -53,5 +54,9 @@ class HomeActivity : ViewModelActivity<HomeViewModelController, HomeViewModel, H
 
     override fun navigateToAnimationTypesShowcase() {
         startActivity(AnimationTypesShowcaseActivity.intent(this))
+    }
+
+    override fun navigateToListShowcase() {
+        startActivity(ListShowcaseActivity.intent(this))
     }
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseActivity.kt
@@ -1,0 +1,32 @@
+package com.mirego.sample.ui.showcase.components.list
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseNavigationDelegate
+import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModel
+import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModelController
+import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
+
+class ListShowcaseActivity : ViewModelActivity<ListShowcaseViewModelController, ListShowcaseViewModel, ListShowcaseNavigationDelegate>(), ListShowcaseNavigationDelegate {
+
+    override val viewModelController: ListShowcaseViewModelController by lazy {
+        getViewModelController(ListShowcaseViewModelController::class)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ListShowcaseView(listShowcaseViewModel = viewModel)
+        }
+    }
+
+    override fun close() {
+        finish()
+    }
+
+    companion object {
+        fun intent(context: Context) = Intent(context, ListShowcaseActivity::class.java)
+    }
+}

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
@@ -1,0 +1,62 @@
+package com.mirego.sample.ui.showcase.components.list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
+import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLazyColumnIndexed
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLazyRow
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLazyRowIndexed
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDText
+
+@Composable
+fun ListShowcaseView(listShowcaseViewModel: ListShowcaseViewModel) {
+    val viewModel: ListShowcaseViewModel by listShowcaseViewModel.observeAsState()
+
+    Box(
+        Modifier.fillMaxSize()
+    ) {
+
+        ComponentShowcaseTopBar(viewModel)
+
+        VMDLazyRow(
+            modifier = Modifier.padding(top = 80.dp),
+            viewModel = viewModel.listViewModel,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(16.dp)
+        ) { element ->
+            VMDText(viewModel = element.content)
+        }
+
+        VMDLazyColumnIndexed(
+            modifier = Modifier
+                .padding(top = 150.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.listViewModel,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(16.dp)
+        ) { index, element ->
+            Column {
+                if (index != 0) {
+                    Divider(modifier = Modifier.padding(bottom = 16.dp))
+                }
+                VMDText(viewModel = element.content)
+            }
+        }
+    }
+}

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,7 +19,6 @@ import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewMod
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLazyColumnIndexed
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLazyRow
-import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLazyRowIndexed
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDText
 
 @Composable

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/factories/SampleViewModelControllerFactory.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/factories/SampleViewModelControllerFactory.kt
@@ -4,6 +4,7 @@ import com.mirego.sample.viewmodels.home.HomeViewModelController
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewModelController
+import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseViewModelController
@@ -26,4 +27,6 @@ interface SampleViewModelControllerFactory : VMDViewModelControllerFactory {
     fun textFieldShowcase(): TextFieldShowcaseViewModelController
 
     fun animationTypesShowcase(): AnimationTypesShowcaseViewModelController
+
+    fun listShowcase(): ListShowcaseViewModelController
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/factories/SampleViewModelControllerFactoryImpl.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/factories/SampleViewModelControllerFactoryImpl.kt
@@ -49,6 +49,6 @@ class SampleViewModelControllerFactoryImpl : SampleViewModelControllerFactory {
     }
 
     override fun listShowcase(): ListShowcaseViewModelController {
-       return ListShowcaseViewModelController(i18N)
+        return ListShowcaseViewModelController(i18N)
     }
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/factories/SampleViewModelControllerFactoryImpl.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/factories/SampleViewModelControllerFactoryImpl.kt
@@ -4,6 +4,7 @@ import com.mirego.sample.viewmodels.home.HomeViewModelController
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewModelController
+import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModelController
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseViewModelController
@@ -45,5 +46,9 @@ class SampleViewModelControllerFactoryImpl : SampleViewModelControllerFactory {
 
     override fun animationTypesShowcase(): AnimationTypesShowcaseViewModelController {
         return AnimationTypesShowcaseViewModelController(i18N)
+    }
+
+    override fun listShowcase(): ListShowcaseViewModelController {
+       return ListShowcaseViewModelController(i18N)
     }
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/home/HomeNavigationDelegate.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/home/HomeNavigationDelegate.kt
@@ -16,4 +16,6 @@ interface HomeNavigationDelegate : VMDNavigationDelegate {
     fun navigateToProgressShowcase()
 
     fun navigateToAnimationTypesShowcase()
+
+    fun navigateToListShowcase()
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/home/HomeViewModelController.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/home/HomeViewModelController.kt
@@ -54,6 +54,12 @@ class HomeViewModelController(i18N: I18N) :
                                 cancellableManager = cancellableManager
                             ) {
                                 setAction { navigationDelegate?.navigateToProgressShowcase() }
+                            },
+                            HomeSectionElementViewModelImpl(
+                                text = i18N[KWordTranslation.HOME_COMPONENT_LIST],
+                                cancellableManager = cancellableManager
+                            ) {
+                                setAction { navigationDelegate?.navigateToListShowcase() }
                             }
                         ),
                         cancellableManager = cancellableManager

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseNavigationDelegate.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseNavigationDelegate.kt
@@ -1,0 +1,5 @@
+package com.mirego.sample.viewmodels.showcase.components.list
+
+import com.mirego.sample.viewmodels.showcase.ShowcaseNavigationDelegate
+
+interface ListShowcaseNavigationDelegate: ShowcaseNavigationDelegate

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseNavigationDelegate.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseNavigationDelegate.kt
@@ -2,4 +2,4 @@ package com.mirego.sample.viewmodels.showcase.components.list
 
 import com.mirego.sample.viewmodels.showcase.ShowcaseNavigationDelegate
 
-interface ListShowcaseNavigationDelegate: ShowcaseNavigationDelegate
+interface ListShowcaseNavigationDelegate : ShowcaseNavigationDelegate

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModel.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModel.kt
@@ -1,0 +1,10 @@
+package com.mirego.sample.viewmodels.showcase.components.list
+
+import com.mirego.sample.viewmodels.showcase.ShowcaseViewModel
+import com.mirego.trikot.viewmodels.declarative.components.VMDListViewModel
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextViewModel
+import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContentWrapper
+
+interface ListShowcaseViewModel : ShowcaseViewModel {
+    val listViewModel: VMDListViewModel<VMDIdentifiableContentWrapper<VMDTextViewModel>>
+}

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModelController.kt
@@ -1,0 +1,13 @@
+package com.mirego.sample.viewmodels.showcase.components.list
+
+import com.mirego.trikot.kword.I18N
+import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
+
+class ListShowcaseViewModelController(i18N: I18N) : VMDViewModelController<ListShowcaseViewModel, ListShowcaseNavigationDelegate>() {
+    override val viewModel: ListShowcaseViewModelImpl = ListShowcaseViewModelImpl(i18N, cancellableManager)
+
+    override fun onCreate() {
+        super.onCreate()
+        viewModel.closeButton.setAction { navigationDelegate?.close() }
+    }
+}

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModelImpl.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModelImpl.kt
@@ -1,0 +1,20 @@
+package com.mirego.sample.viewmodels.showcase.components.list
+
+import com.mirego.sample.KWordTranslation
+import com.mirego.sample.viewmodels.showcase.ShowcaseViewModelImpl
+import com.mirego.trikot.kword.I18N
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.viewmodels.declarative.components.VMDListViewModel
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContentWrapper
+
+class ListShowcaseViewModelImpl(i18N: I18N, cancellableManager: CancellableManager) : ShowcaseViewModelImpl(cancellableManager), ListShowcaseViewModel {
+    override val title: VMDTextViewModel = VMDComponents.Text.withContent(i18N[KWordTranslation.LIST_SHOWCASE_TITLE], cancellableManager)
+    override val listViewModel: VMDListViewModel<VMDIdentifiableContentWrapper<VMDTextViewModel>> = VMDComponents.List.of(
+        VMDIdentifiableContentWrapper("item_1", VMDComponents.Text.withContent("Item 1", cancellableManager)),
+        VMDIdentifiableContentWrapper("item_2", VMDComponents.Text.withContent("Item 2", cancellableManager)),
+        VMDIdentifiableContentWrapper("item_3", VMDComponents.Text.withContent("Item 3", cancellableManager)),
+        cancellableManager = cancellableManager
+    )
+}

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/resources/translations/translation.en.json
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/resources/translations/translation.en.json
@@ -14,6 +14,7 @@
   "home_component_textfield": "TextField",
   "home_component_toggle": "Toggle",
   "home_component_progress": "Progress",
+  "home_component_list": "List",
   "image_showcase_complex_placeholder_image_title": "Complex placeholder",
   "home_animations_title": "Animations",
   "home_animation_easing": "Animation Easing",
@@ -68,5 +69,6 @@
   "animation_types_ease_out_tile": "Ease Out",
   "animation_types_ease_in_ease_out_tile": "Ease In/Out",
   "animation_types_cubic_bezier_tile": "Cubic Bezier (0, 1, 0, 1)",
-  "animation_types_spring_tile": "Spring"
+  "animation_types_spring_tile": "Spring",
+  "list_showcase_title": "List showcase"
 }

--- a/trikot-viewmodels-declarative/sample/ios/Sample/UI/Home/HomeViewController.swift
+++ b/trikot-viewmodels-declarative/sample/ios/Sample/UI/Home/HomeViewController.swift
@@ -36,4 +36,8 @@ extension HomeViewController: HomeNavigationDelegate {
     func navigateToAnimationTypesShowcase() {
         present(viewControllerFactory.animationTypesShowcase(), animated: true, completion: nil)
     }
+
+    func navigateToListShowcase() {
+        //TODO: present list showcase
+    }
 }

--- a/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/VMDListViewModel.kt
+++ b/trikot-viewmodels-declarative/viewmodels-declarative/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/VMDListViewModel.kt
@@ -4,7 +4,6 @@ import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModelImpl
 
-abstract class VMDListViewModel<E : VMDIdentifiableContent>(cancellableManager: CancellableManager) :
-    VMDViewModelImpl(cancellableManager) {
+abstract class VMDListViewModel<E : VMDIdentifiableContent>(cancellableManager: CancellableManager) : VMDViewModelImpl(cancellableManager) {
     abstract val elements: List<E>
 }


### PR DESCRIPTION
## Description
I added the following compose components for VMDListViewModel : VMDLazyColumn, VMDLazyColumnIndexed, VMDLazyRow and VMDLazyRowIndexed.


## Motivation and Context
We have a generic VMDList component in compose that can only layout the list vertically, I think the naming is too generic because it assume we want to layout in a vertical list. I added VMDLazyColumn, VMDLazyColumnIndexed, VMDLazyRow and VMDLazyRowIndexed to allow layout in row or column and to have the ability to receive the index for example if we want to do a zebra list or add divider except for the last item etc.


## How Has This Been Tested?
I added a list showcase screen in the sample which uses those new components


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

![Screenshot_20220427_104627](https://user-images.githubusercontent.com/9321287/165548418-6646dc81-a9df-4acb-b429-bcd606b7c0d9.png)

