### PR TITLE
[VM] Update lifecycle observers

### DIFF
--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapter.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapter.kt
@@ -4,10 +4,8 @@ import android.view.View
 import androidx.annotation.CallSuper
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.OnLifecycleEvent
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView

--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapter.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapter.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.viewmodels.adapter
 
 import android.view.View
 import androidx.annotation.CallSuper
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -21,11 +22,11 @@ abstract class LifecycleAdapter<T, VH : LifecycleAdapter.LifecycleViewHolder>(
 
     init {
         lifecycleOwner.lifecycle.addObserver(
-            object : LifecycleObserver {
-                @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-                fun detachAll() {
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    super.onDestroy(owner)
                     viewHolders.forEach {
-                        it.detach()
+                        it.destroy()
                     }
                     viewHolders.clear()
                     lifecycleOwner.lifecycle.removeObserver(this)
@@ -55,6 +56,7 @@ abstract class LifecycleAdapter<T, VH : LifecycleAdapter.LifecycleViewHolder>(
     @CallSuper
     override fun onViewRecycled(holder: VH) {
         super.onViewRecycled(holder)
+        holder.destroy()
         viewHolders.remove(holder)
     }
 
@@ -74,18 +76,26 @@ abstract class LifecycleAdapter<T, VH : LifecycleAdapter.LifecycleViewHolder>(
         open fun onDetach() {}
 
         fun attach() {
-            if (lifecycleRegistry.currentState != Lifecycle.State.STARTED) {
+            if (lifecycleRegistry.currentState != Lifecycle.State.RESUMED) {
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+                lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
                 onAttach()
             }
         }
 
         fun detach() {
-            if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            if (lifecycleRegistry.currentState == Lifecycle.State.RESUMED) {
+                lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-                lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
                 onDetach()
+            }
+        }
+
+        fun destroy() {
+            detach()
+            if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+                lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
                 lifecycleRegistry = LifecycleRegistry(this)
             }
         }

--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -1,8 +1,8 @@
 package com.mirego.trikot.viewmodels.lifecycle
 
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import org.reactivestreams.Publisher
@@ -10,7 +10,7 @@ import org.reactivestreams.Publisher
 actual class ApplicationStatePublisher :
     BehaviorSubjectImpl<ApplicationState>(),
     Publisher<ApplicationState>,
-    LifecycleObserver {
+    DefaultLifecycleObserver {
 
     private val lifecycle = ProcessLifecycleOwner.get().lifecycle
 
@@ -29,15 +29,13 @@ actual class ApplicationStatePublisher :
         super.onNoSubscription()
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
-    @Suppress("unused")
-    fun onMoveToForeground() {
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
         value = ApplicationState.FOREGROUND
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    @Suppress("unused")
-    fun onMoveToBackground() {
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
         value = ApplicationState.BACKGROUND
     }
 }


### PR DESCRIPTION
## Description
Switch away from lifecycle observers with `OnLifecycleEvent` as they use reflection and are deprecated in favor of `DefaultLifecycleObserver`

Fix lifecycle viewmodel so that it moves to STOPPED state when view is detached from window and DESTROYED when holder is recycled / parent lifecycle is destroyed.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
