### PR TITLE
[VMD] Added interactionSource and indication as optional parameters for VMDButton

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
 
+import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -21,6 +22,8 @@ fun <C : VMDContent> VMDButton(
     modifier: Modifier = Modifier,
     viewModel: VMDButtonViewModel<C>,
     contentAlignment: Alignment = Alignment.Center,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    indication: Indication? = rememberRipple(),
     content: @Composable (BoxScope.(field: C) -> Unit)
 ) {
     val buttonViewModel: VMDButtonViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
@@ -31,8 +34,8 @@ fun <C : VMDContent> VMDButton(
             .clickable(
                 enabled = buttonViewModel.isEnabled,
                 onClick = viewModel.actionBlock,
-                interactionSource = remember { MutableInteractionSource() },
-                indication = rememberRipple()
+                interactionSource = interactionSource,
+                indication = indication
             ),
         contentAlignment = contentAlignment,
         content = { content(buttonViewModel.content) }


### PR DESCRIPTION
## Description

If we want to customize the look of the tapped state (ripple) of a button, we have to be able to specify these two values. Their default values remain the same, so this change is transparent.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
