### PR TITLE
[KWORD] Added an implementation of I18N that works with the Jetpack Compose Previewer.

### DIFF
--- a/trikot-kword/README.md
+++ b/trikot-kword/README.md
@@ -109,7 +109,10 @@ KWord.t(KWordTranslation.PLURAL, 17)
 See [swift extensions](./swift-extensions/README.md)
 
 # Tooling
+
 ## Android
-When using the Jetpack Compose previewer in Android Studio, there is a specific implementation of `I18N` that can be used to properly load the translations files. 
+
+When using the Jetpack Compose previewer in Android Studio, there is a specific implementation
+of `I18N` that can be used to properly load the translations files.
 
 [PreviewI18N](./kword/src/androidMain/kotlin/com/mirego/trikot/kword/android/PreviewI18N.kt)

--- a/trikot-kword/README.md
+++ b/trikot-kword/README.md
@@ -107,3 +107,9 @@ KWord.t(KWordTranslation.PLURAL, 17)
 ### iOS
 
 See [swift extensions](./swift-extensions/README.md)
+
+# Tooling
+## Android
+When using the Jetpack Compose previewer in Android Studio, there is a specific implementation of `I18N` that can be used to properly load the translations files. 
+
+[PreviewI18N](./kword/src/androidMain/kotlin/com/mirego/trikot/kword/android/PreviewI18N.kt)

--- a/trikot-kword/kword/src/androidMain/kotlin/com/mirego/trikot/kword/android/PreviewI18N.kt
+++ b/trikot-kword/kword/src/androidMain/kotlin/com/mirego/trikot/kword/android/PreviewI18N.kt
@@ -1,0 +1,49 @@
+package com.mirego.trikot.kword.android
+
+import com.mirego.trikot.kword.DefaultI18N
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * When using the Jetpack Compose previewer in Android Studio, it may be useful to have the actual translations. Since it's
+ * running in a different context than the app, the default Android implementation of I18N is not working.
+ *
+ * This implementation loads a translation file using an absolute path to the translations file in the developer environment.
+ *
+ * Here is a suggestion on how to setup your project to get this path automatically (without it being mandatory).
+
+ * First, add an entry to the non version-controlled local.properties:
+ * ```
+ * translation_file_path=/absolute/path/to/translation/file.json
+ * ```
+ *
+ * Then, add this snippet to your build.gradle file (example in Kotlin)
+ * ```
+ * val properties = gradleLocalProperties(rootDir)
+ * val translationFilePath: String = properties.getProperty("translation_file_path", "")
+ * buildConfigField("String", "TRANSLATION_FILE_PATH", "\"translationFilePath\"")
+ * ```
+ *
+ * This will add a property in the BuildConfig file. You can use it to instantiate the PreviewI18N class and use it for previews.
+ * ```
+ * val previewI18N = PreviewI18N(BuildConfig.TRANSLATION_FILE_PATH)
+ * ```
+ */
+class PreviewI18N(filePathAbsolute: String?) : DefaultI18N() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        allowSpecialFloatingPointValues = true
+    }
+
+    init {
+        val map = mutableMapOf<String, String>()
+        if (filePathAbsolute != null && filePathAbsolute.isNotEmpty()) {
+            val fileContent = File(filePathAbsolute).readText()
+            map.putAll(json.decodeFromString<Map<String, String>>(fileContent))
+            changeLocaleStrings(map)
+        }
+    }
+}

--- a/trikot-kword/kword/src/androidMain/kotlin/com/mirego/trikot/kword/android/PreviewI18N.kt
+++ b/trikot-kword/kword/src/androidMain/kotlin/com/mirego/trikot/kword/android/PreviewI18N.kt
@@ -12,22 +12,19 @@ import java.io.File
  * This implementation loads a translation file using an absolute path to the translations file in the developer environment.
  *
  * Here is a suggestion on how to setup your project to get this path automatically (without it being mandatory).
-
- * First, add an entry to the non version-controlled local.properties:
+ * Add this snippet to your build.gradle file (example in Kotlin)
  * ```
- * translation_file_path=/absolute/path/to/translation/file.json
- * ```
- *
- * Then, add this snippet to your build.gradle file (example in Kotlin)
- * ```
- * val properties = gradleLocalProperties(rootDir)
- * val translationFilePath: String = properties.getProperty("translation_file_path", "")
- * buildConfigField("String", "TRANSLATION_FILE_PATH", "\"translationFilePath\"")
+ * defaultConfig {
+ *   ...
+ *   val translationFilePath = "${project.rootDir}/common/resources/translations/translation.en.json"
+ *   buildConfigField("String", "KWORD_TRANSLATION_FILE_PATH", "\"$translationFilePath\"")
+ *   ...
+ * }
  * ```
  *
  * This will add a property in the BuildConfig file. You can use it to instantiate the PreviewI18N class and use it for previews.
  * ```
- * val previewI18N = PreviewI18N(BuildConfig.TRANSLATION_FILE_PATH)
+ * val previewI18N = PreviewI18N(BuildConfig.KWORD_TRANSLATION_FILE_PATH)
  * ```
  */
 class PreviewI18N(filePathAbsolute: String?) : DefaultI18N() {


### PR DESCRIPTION
## Description

The default implementation of Android kword does not work properly in the context of the Jetpack Compose previewer (it cannot load the file since it's not running the in the same context than the actual app).

## Motivation and Context

Having previews with the actual translations is useful.

## How Has This Been Tested?

In a project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
