### PR TITLE
[VM] LifecycleAdapter lifecycle fixes and test coverage

### DIFF
--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapter.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapter.kt
@@ -74,8 +74,10 @@ abstract class LifecycleAdapter<T, VH : LifecycleAdapter.LifecycleViewHolder>(
         open fun onDetach() {}
 
         fun attach() {
-            if (lifecycleRegistry.currentState != Lifecycle.State.RESUMED) {
+            if (lifecycleRegistry.currentState == Lifecycle.State.INITIALIZED) {
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+            }
+            if (lifecycleRegistry.currentState == Lifecycle.State.CREATED) {
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
                 onAttach()
@@ -92,7 +94,7 @@ abstract class LifecycleAdapter<T, VH : LifecycleAdapter.LifecycleViewHolder>(
 
         fun destroy() {
             detach()
-            if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            if (lifecycleRegistry.currentState == Lifecycle.State.CREATED) {
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
                 lifecycleRegistry = LifecycleRegistry(this)
             }

--- a/trikot-viewmodels/viewmodels/src/androidTest/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapterTest.kt
+++ b/trikot-viewmodels/viewmodels/src/androidTest/kotlin/com/mirego/trikot/viewmodels/adapter/LifecycleAdapterTest.kt
@@ -1,0 +1,136 @@
+package com.mirego.trikot.viewmodels.adapter
+
+import android.os.Build
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.mirego.trikot.viewmodels.TestActivity
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class LifecycleAdapterTest {
+
+    @Test
+    fun testLifecycle_simpleScenario() {
+        ActivityScenario.launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                val adapter = Adapter(activity)
+                val holder = adapter.onCreateViewHolder(FrameLayout(activity), 0)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                adapter.onBindViewHolder(holder, 0)
+                assertEquals(Lifecycle.State.RESUMED, holder.lifecycle.currentState)
+                moveToState(Lifecycle.State.DESTROYED)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                assertEquals(1, holder.onAttachCalls)
+                assertEquals(1, holder.onDetachCalls)
+            }
+        }
+    }
+
+    @Test
+    fun testLifecycle_detachAttachScenario() {
+        ActivityScenario.launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                val adapter = Adapter(activity)
+                val holder = adapter.onCreateViewHolder(FrameLayout(activity), 0)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                adapter.onBindViewHolder(holder, 0)
+                assertEquals(Lifecycle.State.RESUMED, holder.lifecycle.currentState)
+                adapter.onBindViewHolder(holder, 0)
+                assertEquals(Lifecycle.State.RESUMED, holder.lifecycle.currentState)
+                adapter.onViewDetachedFromWindow(holder)
+                assertEquals(Lifecycle.State.CREATED, holder.lifecycle.currentState)
+                adapter.onViewAttachedToWindow(holder)
+                assertEquals(Lifecycle.State.RESUMED, holder.lifecycle.currentState)
+                moveToState(Lifecycle.State.DESTROYED)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                assertEquals(2, holder.onAttachCalls)
+                assertEquals(2, holder.onDetachCalls)
+            }
+        }
+    }
+
+    @Test
+    fun testLifecycle_recyclingScenario() {
+        ActivityScenario.launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                val adapter = Adapter(activity)
+                val holder = adapter.onCreateViewHolder(FrameLayout(activity), 0)
+                adapter.onBindViewHolder(holder, 0)
+                adapter.onViewDetachedFromWindow(holder)
+                adapter.onViewRecycled(holder)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                assertEquals(1, holder.onAttachCalls)
+                assertEquals(1, holder.onDetachCalls)
+            }
+        }
+    }
+
+    @Test
+    fun testLifecycle_notBoundScenario() {
+        ActivityScenario.launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                val adapter = Adapter(activity)
+                val holder = adapter.onCreateViewHolder(FrameLayout(activity), 0)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                moveToState(Lifecycle.State.DESTROYED)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                assertEquals(0, holder.onAttachCalls)
+                assertEquals(0, holder.onDetachCalls)
+            }
+        }
+    }
+
+    @Test
+    fun testLifecycle_multipleBindScenario() {
+        ActivityScenario.launch(TestActivity::class.java).apply {
+            moveToState(Lifecycle.State.CREATED)
+            onActivity { activity ->
+                val adapter = Adapter(activity)
+                val holder = adapter.onCreateViewHolder(FrameLayout(activity), 0)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                adapter.onBindViewHolder(holder, 0)
+                adapter.onBindViewHolder(holder, 0)
+                adapter.onBindViewHolder(holder, 0)
+                adapter.onViewRecycled(holder)
+                adapter.onBindViewHolder(holder, 0)
+                moveToState(Lifecycle.State.DESTROYED)
+                assertEquals(Lifecycle.State.INITIALIZED, holder.lifecycle.currentState)
+                assertEquals(2, holder.onAttachCalls)
+                assertEquals(2, holder.onDetachCalls)
+            }
+        }
+    }
+
+    private class Adapter(lifecycleOwner: LifecycleOwner) :
+        LifecycleAdapter<String, LifecycleAdapter.LifecycleViewHolder>(lifecycleOwner, NoDiffCallback()) {
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+            ViewHolder(View(parent.context))
+    }
+
+    private class ViewHolder(itemView: View) : LifecycleAdapter.LifecycleViewHolder(itemView) {
+        var onAttachCalls = 0
+        var onDetachCalls = 0
+        override fun onAttach() {
+            super.onAttach()
+            onAttachCalls ++
+        }
+
+        override fun onDetach() {
+            super.onDetach()
+            onDetachCalls++
+        }
+    }
+}


### PR DESCRIPTION
## Description
This fixes a crash that would occur in certain conditions where lifecycle would be destroyed before onBind being called.
Also add some LifecycleAdapter unit test covering most of the scenarios.

## Motivation and Context
Crash fixed and test coverage lacking

## How Has This Been Tested?
Via unit tests

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
