### PR TITLE
[VMD] Fix missing wrappers for VMDTextField

### DIFF
--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDTextField.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDTextField.swift
@@ -43,7 +43,7 @@ public struct VMDTextField<Label>: View where Label: View {
             Group {
                 if #available(iOS 15.0, *) {
                     if let labelBuilder = labelBuilder {
-                        TextField(text: text, prompt: prompt, label: labelBuilder)
+                        TextField(text: $text, prompt: prompt, label: labelBuilder)
                             .onSubmit {
                                 viewModel.onReturnKeyTap()
                             }
@@ -58,7 +58,7 @@ public struct VMDTextField<Label>: View where Label: View {
                             .disableAutocorrection(!viewModel.autoCorrect)
                             .hidden(viewModel.isHidden)
                     } else {
-                        TextField(viewModel.placeholder, text: text, prompt: prompt)
+                        TextField(viewModel.placeholder, text: $text, prompt: prompt)
                             .onSubmit {
                                 viewModel.onReturnKeyTap()
                             }
@@ -82,7 +82,7 @@ public struct VMDTextField<Label>: View where Label: View {
                 handleTextTransformations(newValue)
             }
         } else {
-            TextField(viewModel.placeholder, text: text, onEditingChanged: { isEditing in
+            TextField(viewModel.placeholder, text: $text, onEditingChanged: { isEditing in
                 self.onFocusChange?(isEditing)
             }, onCommit: {
                 viewModel.onReturnKeyTap()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `$` symbol was missing from the earlier version.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
