### PR TITLE
Prefix UIView extensions properties with "trikot" for viewmodels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Upcoming release
 
+## 4.0.0
+
+> 2022-07-05
+
+- [viewmodels] BREAKING: UIView extensions properties are now prefixed with "trikot" on iOS and tvOS
+
 ## 3.3.8
 
 > 2022-06-21

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=4.0.0
+version=3.3.9
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=3.3.9
+version=4.0.0
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/trikot-viewmodels/swift-extensions/UIButtonExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIButtonExtensions.swift
@@ -15,11 +15,11 @@ extension UIButton {
         }
     }
 
-    public var buttonViewModel: ButtonViewModel? {
-        get { return trikotViewModel() }
+    public var trikotButtonViewModel: ButtonViewModel? {
+        get { return getTrikotViewModel() }
         set(value) {
             removeTarget(self, action: #selector(onPrimaryActionTriggered), for: .primaryActionTriggered)
-            viewModel = value
+            trikotViewModel = value
             if let buttonViewModel = value {
                 trikotInternalPublisherCancellableManager.add(cancellable: KeyValueObservationHolder(self.observe(\UIButton.isHighlighted) { (button, _) in
                     button.updateBackgroundColor()
@@ -158,7 +158,7 @@ extension UIButton {
 
     @objc
     open func positionSubviews(_ alignment: Alignment?) {
-        guard let buttonViewModel = buttonViewModel else { return }
+        guard let buttonViewModel = trikotButtonViewModel else { return }
         guard let alignment = alignment, [Alignment.right, Alignment.left].contains(alignment) else { resetAlignment() ; return }
 
         observe(buttonViewModel.imageResource.first()) {[weak self] (imageSelector: StateSelector<ImageResource>) in
@@ -206,7 +206,7 @@ extension UIButton {
     }
 
     func updateBackgroundColor() {
-        guard let buttonViewModel = buttonViewModel else { return }
+        guard let buttonViewModel = trikotButtonViewModel else { return }
         observe(buttonViewModel.backgroundColor.first()) {[weak self] (selector: StateSelector) in
             self?.updateBackgroundColor(selector)
         }

--- a/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
@@ -52,10 +52,10 @@ extension UIImageView {
         }
     }
 
-    public var imageViewModel: ImageViewModel? {
-        get { return trikotViewModel() }
+    public var trikotImageViewModel: ImageViewModel? {
+        get { return getTrikotViewModel() }
         set(value) {
-            viewModel = value
+            trikotViewModel = value
             UIImageView.imageViewModelHandler.handleImage(imageViewModel: value, on: self)
         }
     }

--- a/trikot-viewmodels/swift-extensions/UILabelExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UILabelExtensions.swift
@@ -2,10 +2,10 @@ import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
 extension UILabel {
-    public var labelViewModel: LabelViewModel? {
-        get { return trikotViewModel() }
+    public var trikotLabelViewModel: LabelViewModel? {
+        get { return getTrikotViewModel() }
         set(value) {
-            viewModel = value
+            trikotViewModel = value
             if let labelViewModel = value {
                 if let richText = labelViewModel.richText {
                     observe(richText) {[weak self] (richText: RichText) in

--- a/trikot-viewmodels/swift-extensions/UIPickerExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIPickerExtensions.swift
@@ -15,10 +15,10 @@ extension UIPickerView {
         }
     }
     
-    public var pickerViewModel: PickerViewModel? {
-        get { return trikotViewModel() }
+    public var trikotPickerViewModel: PickerViewModel? {
+        get { return getTrikotViewModel() }
         set(value) {
-            viewModel = value
+            trikotViewModel = value
             
             guard let pickerViewModel = value else { return }
 
@@ -45,7 +45,7 @@ extension UIPickerView {
 
 extension UIPickerView : UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        self.pickerViewModel?.setSelectedElementIndex(index: Int32(row))
+        self.trikotPickerViewModel?.setSelectedElementIndex(index: Int32(row))
     }
 }
 

--- a/trikot-viewmodels/swift-extensions/UISliderExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UISliderExtensions.swift
@@ -7,13 +7,13 @@ extension UISlider {
         static var impactFeedbackStyle = UnsafeMutablePointer<Int8>.allocate(capacity: 1)
     }
 
-    public var sliderViewModel: SliderViewModel? {
-        get { return trikotViewModel() }
+    public var trikotSliderViewModel: SliderViewModel? {
+        get { return getTrikotViewModel() }
         set(value) {
             if oldValue() == nil { oldValue(value: 0) }
             if impactFeedbackStyle() == nil { impactFeedbackStyle(value: .light) }
 
-            viewModel = value
+            trikotViewModel = value
             guard let sliderViewModel = value else { return }
             self.minimumValue = Float(sliderViewModel.minValue)
             self.maximumValue = Float(sliderViewModel.maxValue)
@@ -34,7 +34,7 @@ extension UISlider {
                 UIImpactFeedbackGenerator(style: getFeedbackStyle(style: style)).impactOccurred()
             }
             oldValue(value: integerValue)
-            sliderViewModel?.setSelectedValue(value: integerValue)
+            trikotSliderViewModel?.setSelectedValue(value: integerValue)
         }
     }
 

--- a/trikot-viewmodels/swift-extensions/UISwitchExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UISwitchExtensions.swift
@@ -7,12 +7,12 @@ extension UISwitch {
         static var impactFeedbackStyle = UnsafeMutablePointer<Int8>.allocate(capacity: 1)
     }
     
-    public var toggleSwitchViewModel: ToggleSwitchViewModel? {
-        get { return trikotViewModel() }
+    public var trikotToggleSwitchViewModel: ToggleSwitchViewModel? {
+        get { return getTrikotViewModel() }
         set(value) {
             if impactFeedbackStyle() == nil { impactFeedbackStyle(value: .light) }
             
-            viewModel = value
+            trikotViewModel = value
             guard let toggleSwitchViewModel = value else { return }
 
             observe(PublisherExtensionsKt.distinctUntilChanged(toggleSwitchViewModel.checked)) { [weak self] (value: Bool) in
@@ -40,7 +40,7 @@ extension UISwitch {
         if #available(iOS 10.0, *), let style = impactFeedbackStyle() {
             UIImpactFeedbackGenerator(style: getFeedbackStyle(style: style)).impactOccurred()
         }
-        guard let toggleSwitchViewModel = toggleSwitchViewModel else { return }
+        guard let toggleSwitchViewModel = trikotToggleSwitchViewModel else { return }
         observe(toggleSwitchViewModel.toggleSwitchAction.first()) {[weak self] (value: ViewModelAction) in value.execute(actionContext: self) }
         PromiseCompanion().from(single: toggleSwitchViewModel.checked, cancellableManager: nil).onSuccess(accept: { value in
             let isOn = (value as! Bool)

--- a/trikot-viewmodels/swift-extensions/UITextFieldExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UITextFieldExtensions.swift
@@ -2,11 +2,11 @@ import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
 extension UITextField {
-    public var inputTextViewModel: InputTextViewModel? {
-        get { return trikotViewModel() }
+    public var trikotInputTextViewModel: InputTextViewModel? {
+        get { return getTrikotViewModel() }
         set(value) {
             removeTarget(self, action: #selector(onEditingChanged), for: .editingChanged)
-            viewModel = value
+            trikotViewModel = value
             if let inputTextViewModel = value {
                 addTarget(self, action: #selector(onEditingChanged), for: .editingChanged)
 
@@ -65,6 +65,6 @@ extension UITextField {
 
     @objc
     private func onEditingChanged() {
-        inputTextViewModel?.setUserInput(value: text ?? "")
+        trikotInputTextViewModel?.setUserInput(value: text ?? "")
     }
 }

--- a/trikot-viewmodels/swift-extensions/UITextViewExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UITextViewExtensions.swift
@@ -2,10 +2,10 @@ import UIKit
 import TRIKOT_FRAMEWORK_NAME
 
 extension UITextView {
-    public var labelViewModel: LabelViewModel? {
-        get { trikotViewModel() }
+    public var trikotLabelViewModel: LabelViewModel? {
+        get { getTrikotViewModel() }
         set(value) {
-            viewModel = value
+            trikotViewModel = value
             if let labelViewModel = value {
                 if let richText = labelViewModel.richText, let font = self.font {
                     observe(richText) {[weak self] (richText: RichText) in

--- a/trikot-viewmodels/swift-extensions/UIViewExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIViewExtensions.swift
@@ -3,8 +3,8 @@ import TRIKOT_FRAMEWORK_NAME
 import Trikot
 
 extension UIView {
-    public var viewModel: ViewModel? {
-        get { return trikotViewModel() }
+    public var trikotViewModel: ViewModel? {
+        get { return getTrikotViewModel() }
         set(viewModel) {
             unsubscribeFromAllPublisher()
             setTrikotViewModel(viewModel: viewModel)
@@ -63,7 +63,7 @@ extension UIView {
         static var viewModelKey = UnsafeMutablePointer<Int8>.allocate(capacity: 1)
     }
 
-    public func trikotViewModel<T>() -> T? {
+    public func getTrikotViewModel<T>() -> T? {
         return objc_getAssociatedObject(self, AssociatedKeys.viewModelKey) as? T
     }
 
@@ -73,7 +73,7 @@ extension UIView {
 
     @objc
     private func trikotOnViewTouchUp() {
-        let localViewModel: ViewModel? = trikotViewModel()
+        let localViewModel: ViewModel? = getTrikotViewModel()
         guard let viewModelModel = localViewModel else { return }
         observe(viewModelModel.action.first()) {[weak self] (value: ViewModelAction) in value.execute(actionContext: self) }
     }


### PR DESCRIPTION
## Description

All (or at least, the most used and problematic) public properties used for binding the ViewModels on `UIView` extensions are now prefixed with "trikot".

## Motivation and Context

This prevents naming conflicts with host applications.

## How Has This Been Tested?

Tested in my application. A simple rename in all UIViews did the trick :).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
