### PR TITLE
Add support for Flowi18N when creating components using factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Upcoming release
 
+## 3.3.9
+
+> 2022-07-06
+
+- [VMD-flow] Add support for use of FlowI18N in VMDComponents factory
+
 ## 3.3.8
 
 > 2022-06-21

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
@@ -25,9 +25,7 @@ import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
 import com.mirego.trikot.viewmodels.declarative.properties.VMDProgressDetermination
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 
 object VMDComponents {
     class Text {

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
@@ -13,12 +13,21 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDImageContent
 import com.mirego.trikot.viewmodels.declarative.content.VMDImageDescriptorContent
 import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
 import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextFlowImagePairContent
 import com.mirego.trikot.viewmodels.declarative.content.VMDTextImagePairContent
 import com.mirego.trikot.viewmodels.declarative.content.VMDTextPairContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextPairFlowContent
+import com.mirego.trikot.viewmodels.declarative.extension.asVMDTextContent
+import com.mirego.trikot.viewmodels.declarative.extension.asVMDTextImagePairContent
+import com.mirego.trikot.viewmodels.declarative.extension.asVMDTextPairContent
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
 import com.mirego.trikot.viewmodels.declarative.properties.VMDProgressDetermination
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 
 object VMDComponents {
     class Text {
@@ -37,6 +46,15 @@ object VMDComponents {
             ) =
                 VMDTextViewModelImpl(coroutineScope)
                     .apply { text = content }
+                    .apply(closure)
+
+            fun withContent(
+                contentFlow: Flow<String>,
+                coroutineScope: CoroutineScope,
+                closure: VMDTextViewModelImpl.() -> Unit = {}
+            ) =
+                VMDTextViewModelImpl(coroutineScope)
+                    .apply { bindText(contentFlow) }
                     .apply(closure)
         }
     }
@@ -100,6 +118,15 @@ object VMDComponents {
                 VMDButtonViewModelImpl(coroutineScope, VMDTextContent(text))
                     .apply(closure)
 
+            fun withText(
+                textFlow: Flow<String>,
+                coroutineScope: CoroutineScope,
+                closure: VMDButtonViewModelImpl<VMDTextContent>.() -> Unit = {}
+            ) =
+                VMDButtonViewModelImpl(coroutineScope, VMDTextContent(""))
+                    .apply { bindContent(textFlow.asVMDTextContent()) }
+                    .apply(closure)
+
             fun withImage(
                 image: VMDImageResource,
                 coroutineScope: CoroutineScope,
@@ -136,12 +163,30 @@ object VMDComponents {
                 VMDButtonViewModelImpl(coroutineScope, textPair)
                     .apply(closure)
 
+            fun withTextPair(
+                textPairFlow: VMDTextPairFlowContent,
+                coroutineScope: CoroutineScope,
+                closure: VMDButtonViewModelImpl<VMDTextPairContent>.() -> Unit = {}
+            ) =
+                VMDButtonViewModelImpl(coroutineScope, VMDTextPairContent("", ""))
+                    .apply { bindContent(flowOf(textPairFlow).asVMDTextPairContent()) }
+                    .apply(closure)
+
             fun withTextImage(
                 textImage: VMDTextImagePairContent,
                 coroutineScope: CoroutineScope,
                 closure: VMDButtonViewModelImpl<VMDTextImagePairContent>.() -> Unit = {}
             ) =
                 VMDButtonViewModelImpl(coroutineScope, textImage)
+                    .apply(closure)
+
+            fun withTextImage(
+                textFlowImage: VMDTextFlowImagePairContent,
+                coroutineScope: CoroutineScope,
+                closure: VMDButtonViewModelImpl<VMDTextImagePairContent>.() -> Unit = {}
+            ) =
+                VMDButtonViewModelImpl(coroutineScope, VMDTextImagePairContent("", textFlowImage.image))
+                    .apply { bindContent(flowOf(textFlowImage).asVMDTextImagePairContent()) }
                     .apply(closure)
         }
     }
@@ -162,6 +207,15 @@ object VMDComponents {
             ) =
                 VMDTextFieldViewModelImpl(coroutineScope)
                     .apply { placeholder = placeholderText }
+                    .apply(closure)
+
+            fun withPlaceholder(
+                placeholderTextFlow: Flow<String>,
+                coroutineScope: CoroutineScope,
+                closure: VMDTextFieldViewModelImpl.() -> Unit = {}
+            ) =
+                VMDTextFieldViewModelImpl(coroutineScope)
+                    .apply { bindPlaceholder(placeholderTextFlow) }
                     .apply(closure)
         }
     }
@@ -194,6 +248,17 @@ object VMDComponents {
                     .apply { isOn = state }
                     .apply(closure)
 
+            fun withText(
+                textFlow: Flow<String>,
+                state: Boolean,
+                coroutineScope: CoroutineScope,
+                closure: VMDToggleViewModelImpl<VMDTextContent>.() -> Unit = {}
+            ) =
+                VMDToggleViewModelImpl(coroutineScope, VMDTextContent(""))
+                    .apply { bindContent(textFlow.asVMDTextContent()) }
+                    .apply { isOn = state }
+                    .apply(closure)
+
             fun withImage(
                 image: VMDImageResource,
                 state: Boolean,
@@ -217,6 +282,17 @@ object VMDComponents {
                     .apply { isOn = state }
                     .apply(closure)
 
+            fun withTextPair(
+                textPairFlow: VMDTextPairFlowContent,
+                state: Boolean,
+                coroutineScope: CoroutineScope,
+                closure: VMDToggleViewModelImpl<VMDTextPairContent>.() -> Unit = {}
+            ) =
+                VMDToggleViewModelImpl(coroutineScope, VMDTextPairContent("", ""))
+                    .apply { bindContent(flowOf(textPairFlow).asVMDTextPairContent()) }
+                    .apply { isOn = state }
+                    .apply(closure)
+
             fun withTextImage(
                 textImage: VMDTextImagePairContent,
                 state: Boolean,
@@ -224,6 +300,17 @@ object VMDComponents {
                 closure: VMDToggleViewModelImpl<VMDTextImagePairContent>.() -> Unit = {}
             ) =
                 VMDToggleViewModelImpl(coroutineScope, textImage)
+                    .apply { isOn = state }
+                    .apply(closure)
+
+            fun withTextImage(
+                textFlowImage: VMDTextFlowImagePairContent,
+                state: Boolean,
+                coroutineScope: CoroutineScope,
+                closure: VMDToggleViewModelImpl<VMDTextImagePairContent>.() -> Unit = {}
+            ) =
+                VMDToggleViewModelImpl(coroutineScope, VMDTextImagePairContent("", textFlowImage.image))
+                    .apply { bindContent(flowOf(textFlowImage).asVMDTextImagePairContent()) }
                     .apply { isOn = state }
                     .apply(closure)
         }

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/content/VMDTextFlowImagePairContent.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/content/VMDTextFlowImagePairContent.kt
@@ -1,0 +1,13 @@
+package com.mirego.trikot.viewmodels.declarative.content
+
+import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Utility class to represent a text and image pair as content of a component using flows.
+ * It is useful in buttons when using Flowi18N for example.
+ */
+data class VMDTextFlowImagePairContent(
+    val text: Flow<String>,
+    val image: VMDImageResource
+) : VMDContent

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/content/VMDTextPairFlowContent.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/content/VMDTextPairFlowContent.kt
@@ -1,0 +1,12 @@
+package com.mirego.trikot.viewmodels.declarative.content
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Utility class to represent a text pair as content of a component using flows.
+ * It is useful in buttons when using Flowi18N for example.
+ */
+data class VMDTextPairFlowContent(
+    val first: Flow<String>,
+    val second: Flow<String>
+) : VMDContent

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/extension/FlowExtensions.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/extension/FlowExtensions.kt
@@ -1,10 +1,18 @@
 package com.mirego.trikot.viewmodels.declarative.extension
 
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextFlowImagePairContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextImagePairContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextPairContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDTextPairFlowContent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -28,3 +36,23 @@ class VMDFlow<T : Any> internal constructor(
 }
 
 fun <T : Any> Flow<T>.wrap(): VMDFlow<T> = VMDFlow(this)
+
+fun Flow<String>.asVMDTextContent(): Flow<VMDTextContent> = flow {
+    this@asVMDTextContent.collect { emit(VMDTextContent(it)) }
+}
+
+fun Flow<VMDTextPairFlowContent>.asVMDTextPairContent(): Flow<VMDTextPairContent> = flow {
+    this@asVMDTextPairContent.collect { content ->
+        content.first.combine(content.second) { text1, text2 ->
+            VMDTextPairContent(text1, text2)
+        }.collect { emit(it) }
+    }
+}
+
+fun Flow<VMDTextFlowImagePairContent>.asVMDTextImagePairContent(): Flow<VMDTextImagePairContent> = flow {
+    this@asVMDTextImagePairContent.collect { content ->
+        flowOf(content.image).combine(content.text) { image, text ->
+            VMDTextImagePairContent(text, image)
+        }.collect { emit(it) }
+    }
+}


### PR DESCRIPTION
## Description
Creating a text component with Flowi18N was not supported since the component expects a String. This PR now adds support to either use a Flow<String> or simply String for text components

## Motivation and Context
In my project, I needed to use hacks to be able to show text using Flowi18N. This PR will simplify usage of the component factory.

## How Has This Been Tested?
This has been both tested in project and locally using samples. I did not push the modifications in the sample as to keep the sample light.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
