### PR TITLE
Fix couroutine interop macos test configuration

### DIFF
--- a/trikot-streams/coroutines-interop/build.gradle.kts
+++ b/trikot-streams/coroutines-interop/build.gradle.kts
@@ -60,6 +60,30 @@ kotlin {
         val iosSimulatorArm64Test by getting {
             dependsOn(nativeTest)
         }
+
+        val macosX64Test by getting {
+            dependsOn(nativeTest)
+        }
+
+        val tvosArm64Test by getting {
+            dependsOn(nativeTest)
+        }
+
+        val tvosX64Test by getting {
+            dependsOn(nativeTest)
+        }
+
+        val watchos32Test by creating {
+            dependsOn(nativeTest)
+        }
+
+        val watchosArm64Test by getting {
+            dependsOn(nativeTest)
+        }
+
+        val watchosX64Test by getting {
+            dependsOn(nativeTest)
+        }
     }
 }
 


### PR DESCRIPTION
## Description
We fix couroutine interop test execution on a macos host by adding missing sourcesets configurations.

It wasn't failing previously on the CI pipeline as it is executed in a linux container.
Now, the CD pipeline uses a macos container so it runs tests on that platform targets.

## Motivation and Context
Should fix CD

## How Has This Been Tested?
Locally on a macos host.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
