### PR TITLE
Use ConcurrentHashMap instead of normal HashMap in trikot.bluetooth

### DIFF
--- a/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
+++ b/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
@@ -26,6 +26,7 @@ import com.mirego.trikot.streams.reactive.subscribe
 import org.reactivestreams.Publisher
 import java.util.Timer
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
 import kotlin.concurrent.schedule
 
@@ -95,7 +96,7 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
         val devicesPublisher = Publishers.behaviorSubject<List<BluetoothScanResult>>(emptyList())
 
         val callback = object : ScanCallback() {
-            val foundDevice = HashMap<String, BluetoothScanResult>()
+            val foundDevice = ConcurrentHashMap<String, BluetoothScanResult>()
 
             override fun onBatchScanResults(results: MutableList<ScanResult>?) {
                 super.onBatchScanResults(results)


### PR DESCRIPTION
## Description

We have several crashes with a project that uses trikot.bluetooth.

## Motivation and Context

Here are different errors that all happen at the same place :

- Fatal Exception: java.util.ConcurrentModificationException
- Fatal Exception: java.util.NoSuchElementException
- Fatal Exception: java.lang.NegativeArraySizeException: -1

```
foundDevice.remove(result.device.address)
devicesPublisher.value = foundDevice.values.toList()
```

It seems to be a concurrency problem and since the standard HashMap doesn't handle access from multiple thread correctly, I changed the HashMap to use a ConcurrentHashMap instead.

## How Has This Been Tested?

In client app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
