### PR TITLE
TrackableViewModelAction wasn't calling the analytics when execute was called without arguments

### DIFF
--- a/trikot-analytics/analytics-viewmodel/src/commonMain/kotlin/com/mirego/trikot/analytics/TrackableViewModelAction.kt
+++ b/trikot-analytics/analytics-viewmodel/src/commonMain/kotlin/com/mirego/trikot/analytics/TrackableViewModelAction.kt
@@ -9,6 +9,11 @@ open class TrackableViewModelAction(private val event: AnalyticsEvent, private v
     ViewModelAction(actionBlock) {
     constructor(event: AnalyticsEvent, properties: AnalyticsPropertiesType, actionBlock: ViewModelActionBlock) : this(event, properties.just(), actionBlock)
 
+    override fun execute() {
+        super.execute()
+        AnalyticsConfiguration.analyticsManager.trackEvent(event, properties)
+    }
+
     override fun execute(actionContext: Any?) {
         super.execute(actionContext)
         AnalyticsConfiguration.analyticsManager.trackEvent(event, properties)

--- a/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/ViewModelAction.kt
+++ b/trikot-viewmodels/viewmodels/src/commonMain/kotlin/com/mirego/trikot/viewmodels/properties/ViewModelAction.kt
@@ -6,7 +6,7 @@ import kotlin.js.JsName
 typealias ViewModelActionBlock = (actionContext: Any?) -> Unit
 
 open class ViewModelAction(private var action: ViewModelActionBlock) {
-    fun execute() {
+    open fun execute() {
         action(null)
     }
 


### PR DESCRIPTION
See title☝️ 

## Motivation and Context

To fix a bug 😏 

## How Has This Been Tested?

Tested in my project

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
