### PR TITLE
Fix/vmd labeled component fill max width

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
@@ -15,7 +15,7 @@ fun VMDLabeledComponent(
     content: @Composable RowScope.() -> Unit
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().then(modifier),
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -50,7 +50,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textToggle,
             label = { Text(it.text, style = SampleTextStyle.body) }
         )
@@ -58,7 +60,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.imageToggle,
             label = { content ->
                 LocalImage(
@@ -71,7 +75,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textImageToggle,
             label = { content ->
                 Row(
@@ -92,7 +98,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textPairToggle,
             label = { content ->
                 Column(
@@ -120,7 +128,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textToggle,
             label = { Text(it.text, style = SampleTextStyle.body) }
         )
@@ -128,7 +138,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.imageSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.imageToggle,
             label = { content ->
                 LocalImage(
@@ -141,7 +153,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textImageToggle,
             label = { content ->
                 Row(
@@ -163,7 +177,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textPairToggle,
             label = { content ->
                 Column(

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
@@ -15,7 +15,7 @@ fun VMDLabeledComponent(
     content: @Composable RowScope.() -> Unit
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth().then(modifier),
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -50,7 +50,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textToggle,
             label = { Text(it.text, style = SampleTextStyle.body) }
         )
@@ -58,7 +60,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.imageToggle,
             label = { content ->
                 LocalImage(
@@ -71,7 +75,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textImageToggle,
             label = { content ->
                 Row(
@@ -92,7 +98,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
 
         VMDCheckbox(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textPairToggle,
             label = { content ->
                 Column(
@@ -120,7 +128,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textToggle,
             label = { Text(it.text, style = SampleTextStyle.body) }
         )
@@ -128,7 +138,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.imageSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.imageToggle,
             label = { content ->
                 LocalImage(
@@ -141,7 +153,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textImageToggle,
             label = { content ->
                 Row(
@@ -163,7 +177,9 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
         ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
 
         VMDSwitch(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                .fillMaxWidth(),
             viewModel = viewModel.textPairToggle,
             label = { content ->
                 Column(


### PR DESCRIPTION
## Description

Removed the fillMaxWidth() from VMDLabeledComponent to give more control to the app

## Motivation and Context

VMDSwitch and VMDCheckbox were forced to take the fullWidth when it's not always needed.

## How Has This Been Tested?

The changes were tested in both sample apps

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

*** Projects need to add fillMaxWidth to the modifier like it was added in the sample projects 
