### PR TITLE
Add configurableMockTimerFactory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ release {
     )
     buildTasks = listOf(
         ":trikot-foundation:trikotFoundation:publish",
+        ":trikot-foundation:test-utils:publish",
         ":trikot-streams:streams:publish",
         ":trikot-streams:test-utils:publish",
         ":trikot-streams:coroutines-interop:publish",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ pluginManagement {
 rootProject.name = "trikot"
 
 include(":trikot-foundation:trikotFoundation")
+include(":trikot-foundation:test-utils")
 include(":trikot-streams:streams")
 include(":trikot-streams:test-utils")
 include(":trikot-streams:coroutines-interop")

--- a/trikot-foundation/test-utils/build.gradle.kts
+++ b/trikot-foundation/test-utils/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    kotlin("multiplatform")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("mirego.publish")
+}
+
+group = "com.mirego.trikot.trikotFoundation"
+
+kotlin {
+    jvm()
+    ios()
+    iosArm32("iosArm32")
+    iosSimulatorArm64()
+    tvos()
+    watchos()
+    macosX64()
+    js(IR) {
+        browser()
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(Project.TRIKOT_FOUNDATION))
+                implementation("org.jetbrains.kotlin:kotlin-test-common")
+                implementation("org.jetbrains.kotlin:kotlin-test-annotations-common")
+            }
+        }
+
+        val jvmMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-test")
+                implementation("org.jetbrains.kotlin:kotlin-test-junit")
+            }
+        }
+
+        val jsMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-test-js")
+            }
+        }
+    }
+}

--- a/trikot-foundation/test-utils/src/commonMain/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactory.kt
+++ b/trikot-foundation/test-utils/src/commonMain/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactory.kt
@@ -2,20 +2,24 @@ import com.mirego.trikot.foundation.timers.Timer
 import com.mirego.trikot.foundation.timers.TimerFactory
 import kotlin.test.assertTrue
 import kotlin.time.Duration
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
+import kotlin.time.Duration.Companion.milliseconds
 
-data class TimerData(val timer: MockTimer, val fireOffTime: Duration, val repeatTime: Duration = fireOffTime, val repeatable: Boolean = false) {
+data class TimerData(
+    val timer: MockTimer,
+    val fireOffTime: Duration,
+    val repeatTime: Duration = fireOffTime,
+    val repeatable: Boolean = false
+) {
     var fired = false
 }
 
-class ConfigurableMockTimerFactory(initialTime: Duration = 0.toDuration(DurationUnit.MILLISECONDS)) : TimerFactory {
+class ConfigurableMockTimerFactory(initialTime: Duration = 0.milliseconds) : TimerFactory {
     var singleCall = 0
     var repeatableCall = 0
     val timers = mutableListOf<TimerData>()
     private var currentTime = initialTime
 
-    fun addToTime(timeToAdd: Duration) = setTime(currentTime + timeToAdd)
+    fun add(timeToAdd: Duration) = setTime(currentTime + timeToAdd)
 
     fun setTime(toTime: Duration) {
         if (toTime == currentTime) return

--- a/trikot-foundation/test-utils/src/commonMain/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactory.kt
+++ b/trikot-foundation/test-utils/src/commonMain/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactory.kt
@@ -1,0 +1,71 @@
+import com.mirego.trikot.foundation.timers.Timer
+import com.mirego.trikot.foundation.timers.TimerFactory
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+data class TimerData(val timer: MockTimer, val fireOffTime: Duration, val repeatTime: Duration = fireOffTime, val repeatable: Boolean = false) {
+    var fired = false
+}
+
+class ConfigurableMockTimerFactory(initialTime: Duration = 0.toDuration(DurationUnit.MILLISECONDS)) : TimerFactory {
+    var singleCall = 0
+    var repeatableCall = 0
+    val timers = mutableListOf<TimerData>()
+    private var currentTime = initialTime
+
+    fun addToTime(timeToAdd: Duration) = setTime(currentTime + timeToAdd)
+
+    fun setTime(toTime: Duration) {
+        if (toTime == currentTime) return
+        assertTrue(toTime > currentTime)
+        currentTime = toTime
+        do {
+            val initialTimersSize = timers.size
+            timers
+                .filterNot { it.fired }
+                .forEach {
+                    val expired = it.fireOffTime <= toTime
+                    if (expired) {
+                        it.timer.executeBlock()
+                        it.fired = true
+                        if (it.repeatable) {
+                            timers.add(TimerData(it.timer, it.fireOffTime + it.repeatTime, it.repeatTime, repeatable = true))
+                        }
+                    }
+                }
+        } while (timers.size != initialTimersSize)
+    }
+
+    override fun repeatable(delay: Duration, block: () -> Unit): Timer {
+        repeatableCall++
+
+        return MockTimer(block).also {
+            timers.add(TimerData(it, delay + currentTime, delay, repeatable = true))
+        }
+    }
+
+    override fun single(delay: Duration, block: () -> Unit): Timer {
+        singleCall++
+
+        return MockTimer(block).also {
+            timers.add(TimerData(it, delay + currentTime))
+        }
+    }
+}
+
+class MockTimer(private val block: () -> Unit) : Timer {
+    var isCancelled = false
+        private set
+
+    fun executeBlock() {
+        if (!isCancelled) {
+            block.invoke()
+        }
+    }
+
+    override fun cancel() {
+        isCancelled = true
+    }
+}

--- a/trikot-foundation/test-utils/src/commonTest/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactoryTest.kt
+++ b/trikot-foundation/test-utils/src/commonTest/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactoryTest.kt
@@ -19,13 +19,13 @@ class ConfigurableMockTimerFactoryTest {
     }
 
     @Test
-    fun singleAddTime() {
+    fun singleAdd() {
         val mockTimer = ConfigurableMockTimerFactory()
         var fired = false
         mockTimer.single(500.milliseconds) {
             fired = true
         }
-        mockTimer.addToTime(500.milliseconds)
+        mockTimer.add(500.milliseconds)
         assertTrue(fired)
     }
 
@@ -44,16 +44,16 @@ class ConfigurableMockTimerFactoryTest {
     }
 
     @Test
-    fun repeatableWithAddToTime() {
+    fun repeatableWithAdd() {
         val mockTimer = ConfigurableMockTimerFactory()
         var counter = 0
         mockTimer.repeatable(500.milliseconds) {
             counter++
         }
-        mockTimer.addToTime(500.milliseconds)
+        mockTimer.add(500.milliseconds)
         assertEquals(1, counter)
 
-        mockTimer.addToTime(500.milliseconds)
+        mockTimer.add(500.milliseconds)
         assertEquals(2, counter)
     }
 }

--- a/trikot-foundation/test-utils/src/commonTest/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactoryTest.kt
+++ b/trikot-foundation/test-utils/src/commonTest/kotlin/com/mirego/trikot/foundation/timers/ConfigurableMockTimerFactoryTest.kt
@@ -1,0 +1,59 @@
+package com.mirego.trikot.foundation.timers
+
+import ConfigurableMockTimerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+class ConfigurableMockTimerFactoryTest {
+    @Test
+    fun singleWithSetTime() {
+        val mockTimer = ConfigurableMockTimerFactory()
+        var fired = false
+        mockTimer.single(500.milliseconds) {
+            fired = true
+        }
+        mockTimer.setTime(500.milliseconds)
+        assertTrue(fired)
+    }
+
+    @Test
+    fun singleAddTime() {
+        val mockTimer = ConfigurableMockTimerFactory()
+        var fired = false
+        mockTimer.single(500.milliseconds) {
+            fired = true
+        }
+        mockTimer.addToTime(500.milliseconds)
+        assertTrue(fired)
+    }
+
+    @Test
+    fun repeatableWithSetTime() {
+        val mockTimer = ConfigurableMockTimerFactory()
+        var counter = 0
+        mockTimer.repeatable(500.milliseconds) {
+            counter++
+        }
+        mockTimer.setTime(500.milliseconds)
+        assertEquals(1, counter)
+
+        mockTimer.setTime(1000.milliseconds)
+        assertEquals(2, counter)
+    }
+
+    @Test
+    fun repeatableWithAddToTime() {
+        val mockTimer = ConfigurableMockTimerFactory()
+        var counter = 0
+        mockTimer.repeatable(500.milliseconds) {
+            counter++
+        }
+        mockTimer.addToTime(500.milliseconds)
+        assertEquals(1, counter)
+
+        mockTimer.addToTime(500.milliseconds)
+        assertEquals(2, counter)
+    }
+}


### PR DESCRIPTION
## Description

Add new ConfigurableMockTimerFactory that allows to simulate the time of timer. This allows to not ignore timers in test and assert that a certain delay has passed. 

`setTIme()` : Allows to set the timerFactory to a specific duration
`addToTime()`: Allows to add a certain duration to the timerFactory

## Motivation and Context

In my project, I needed to assert something was null after a certain delay. After discussing with @mathieularue, he showed me he had this MockTimerFactory in another project. This motivated us to then move this code in Trikot since there was a need in two projects.

## How Has This Been Tested?

This has been both tested in this repo with a test class named `ConfirableMockTimerFactoryTest` and in my project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
