### PR TITLE
Cleanup sourcesJar tasks definition

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/build.gradle.kts
+++ b/trikot-viewmodels-declarative-flow/compose-flow/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
-
 plugins {
     id("com.android.library")
     id("kotlin-android")
@@ -52,21 +50,16 @@ dependencies {
 }
 
 tasks {
-    val sourcesJar by registering(Jar::class) {
-        val sourceSet = android.sourceSets.getByName("main").kotlin as DefaultAndroidSourceDirectorySet
-        from(sourceSet.srcDirs)
+    val sourcesJar by creating(Jar::class) {
         archiveClassifier.set("sources")
-    }
-
-    artifacts {
-        archives(sourcesJar)
+        from(kotlin.sourceSets["main"].kotlin.srcDirs)
     }
 }
 
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("composeAar") {
+            create<MavenPublication>("release") {
                 from(components["release"])
                 artifactId = "viewmodels-declarative-compose-flow"
                 artifact(tasks["sourcesJar"])

--- a/trikot-viewmodels-declarative/compose/build.gradle.kts
+++ b/trikot-viewmodels-declarative/compose/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet
-
 plugins {
     id("com.android.library")
     id("kotlin-android")
@@ -51,21 +49,16 @@ dependencies {
 }
 
 tasks {
-    val sourcesJar by registering(Jar::class) {
-        val sourceSet = android.sourceSets.getByName("main").kotlin as DefaultAndroidSourceDirectorySet
-        from(sourceSet.srcDirs)
+    val sourcesJar by creating(Jar::class) {
         archiveClassifier.set("sources")
-    }
-
-    artifacts {
-        archives(sourcesJar)
+        from(kotlin.sourceSets["main"].kotlin.srcDirs)
     }
 }
 
 afterEvaluate {
     publishing {
         publications {
-            create<MavenPublication>("composeAar") {
+            create<MavenPublication>("release") {
                 from(components["release"])
                 artifactId = "viewmodels-declarative-compose"
                 artifact(tasks["sourcesJar"])


### PR DESCRIPTION
## Description
The two modules had an un-conventional way of declaring the sourcesJas tasks. With this PR the maven metadata file is now also generated directly in the version folder, which could help locating sources inside the IDE.

## How Has This Been Tested?
Tested locally with another project and confirmed that the sources are still bundled correctly

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
