### PR TITLE
[VMD] Fix Android progress views configuration propagation

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
@@ -28,7 +28,11 @@ fun VMDCircularProgressIndicator(
     val animatedProgress by animateFloatAsState(targetValue = progressViewModel.determination?.progressRatio ?: 0f)
 
     if (viewModel.determination == null) {
-        CircularProgressIndicator(modifier = modifier.hidden(progressViewModel.isHidden))
+        CircularProgressIndicator(
+            modifier = modifier.hidden(progressViewModel.isHidden),
+            color = color,
+            strokeWidth = strokeWidth
+        )
     } else {
         CircularProgressIndicator(
             modifier = modifier.hidden(progressViewModel.isHidden),

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
@@ -26,9 +26,12 @@ fun VMDLinearProgressIndicator(
 ) {
     val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
     val animatedProgress by animateFloatAsState(targetValue = viewModel.determination?.progressRatio ?: 0f)
+
     if (viewModel.determination == null) {
         LinearProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden)
+            modifier = modifier.hidden(progressViewModel.isHidden),
+            color = color,
+            backgroundColor = backgroundColor
         )
     } else {
         LinearProgressIndicator(

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
@@ -28,7 +28,11 @@ fun VMDCircularProgressIndicator(
     val animatedProgress by animateFloatAsState(targetValue = progressViewModel.determination?.progressRatio ?: 0f)
 
     if (viewModel.determination == null) {
-        CircularProgressIndicator(modifier = modifier.hidden(progressViewModel.isHidden))
+        CircularProgressIndicator(
+            modifier = modifier.hidden(progressViewModel.isHidden),
+            color = color,
+            strokeWidth = strokeWidth
+        )
     } else {
         CircularProgressIndicator(
             modifier = modifier.hidden(progressViewModel.isHidden),

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
@@ -26,9 +26,12 @@ fun VMDLinearProgressIndicator(
 ) {
     val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
     val animatedProgress by animateFloatAsState(targetValue = viewModel.determination?.progressRatio ?: 0f)
+
     if (viewModel.determination == null) {
         LinearProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden)
+            modifier = modifier.hidden(progressViewModel.isHidden),
+            color = color,
+            backgroundColor = backgroundColor
         )
     } else {
         LinearProgressIndicator(


### PR DESCRIPTION
## Description
`VMDCircularProgressIndicator` was ignoring `color` and `strokeWidth` and `VMDLinearProgressIndicator` was ignoring `color` and `backgroundColor` properties when the progress was indeterminate.

## Motivation and Context
Fix an incorrect behaviour

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
