### PR TITLE
Update Bluetooth permission requirements for Android depending on OS version

### DIFF
--- a/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
+++ b/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
@@ -39,21 +39,25 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
 
     fun refreshPermissions() {
         val missingPermissions = mutableListOf<BluetoothManager.Permission>()
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED &&
-            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
+            isPermissionDisabled(Manifest.permission.ACCESS_FINE_LOCATION) &&
+            isPermissionDisabled(Manifest.permission.ACCESS_COARSE_LOCATION)
         ) {
             missingPermissions.add(BluetoothManager.Permission.LOCATION)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
             (
-                ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED ||
-                    ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED
+                isPermissionDisabled(Manifest.permission.BLUETOOTH_CONNECT) ||
+                    isPermissionDisabled(Manifest.permission.BLUETOOTH_SCAN)
                 )
         ) {
             missingPermissions.add(BluetoothManager.Permission.BLUETOOTH)
         }
         missingPermissionsPublisher.value = missingPermissions
     }
+
+    private fun isPermissionDisabled(permissionManifest: String): Boolean =
+        ContextCompat.checkSelfPermission(context, permissionManifest) != PackageManager.PERMISSION_GRANTED
 
     init {
         refreshPermissions()


### PR DESCRIPTION
Location is not required for **all** versions of Android to access Bluetooth devices.

## Description

For Android 12 and above, location is not required to scan Bluetooth devices. So it doesn't have to be considered a "missing permission".

I followed the [Bluetooth permissions documentation](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions) provided by Android

## Motivation and Context

We have an application that is using Bluetooth on Android 12 and 13 and we want to avoid having to request the location permission when it's not required.

We're using the  `missingPermissionsPublisher` to check if we can start scanning, and since it's not empty we can't scan. We could build a workaround on our side but the proper way should be to have the right "missing" permissions in Trikot.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
