### PR TITLE
[VMD-flow] Fix ButtonViewModel setAction staying subscribed

### DIFF
--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
@@ -7,7 +7,6 @@ import com.mirego.trikot.viewmodels.declarative.viewmodel.internal.VMDFlowProper
 import com.mirego.trikot.viewmodels.declarative.viewmodel.internal.emit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
@@ -31,8 +31,7 @@ open class VMDButtonViewModelImpl<C : VMDContent>(
     fun <T> setAction(flow: Flow<T>, action: (T) -> Unit) {
         actionBlock = {
             coroutineScope.launch {
-                val value = flow.firstOrNull()
-                value?.let { action(it) }
+                flow.firstOrNull()?.let { action(it) }
             }
         }
     }

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl.kt
@@ -7,6 +7,8 @@ import com.mirego.trikot.viewmodels.declarative.viewmodel.internal.VMDFlowProper
 import com.mirego.trikot.viewmodels.declarative.viewmodel.internal.emit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 @Suppress("LeakingThis")
@@ -29,7 +31,8 @@ open class VMDButtonViewModelImpl<C : VMDContent>(
     fun <T> setAction(flow: Flow<T>, action: (T) -> Unit) {
         actionBlock = {
             coroutineScope.launch {
-                flow.collect { action(it) }
+                val value = flow.firstOrNull()
+                value?.let { action(it) }
             }
         }
     }


### PR DESCRIPTION
## Description
Fix an issue with setAction with a flow where it would stay subscribed to the flow and potentially re-trigger the action.
VMD (publishers) dealt with this by using first() so similarly we do get the first value (if available) and call the action with it.

## Motivation and Context
When migrating our project from VMD to VMD-flow, this bug was found and it had the side effect to re-trigger our actions multiple times.

## How Has This Been Tested?
It no longer stay subscribed after the fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
