### PR TITLE
Add distinctAppId to the AnalyticsService

### DIFF
--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.analytics
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.first
+import com.mirego.trikot.streams.reactive.promise.Promise
 import com.mirego.trikot.streams.reactive.subscribe
 import org.reactivestreams.Publisher
 
@@ -15,6 +16,11 @@ interface AnalyticsService {
     Enables/Disables the analytics collection
      */
     var isEnabled: Boolean
+
+    /*
+    The distinctId associated with the current device
+     */
+    val distinctId: Promise<String?>
 
     /*
     userId: Id of the logged in user
@@ -69,6 +75,8 @@ interface AnalyticsService {
             set(value) {
                 currentAnalyticsService().isEnabled = value
             }
+
+        override val distinctId = currentAnalyticsService().distinctId
 
         override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
             currentAnalyticsService().identifyUser(userId, properties)

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
@@ -18,9 +18,9 @@ interface AnalyticsService {
     var isEnabled: Boolean
 
     /*
-    The distinctId associated with the current device
+    The distinctAppId associated with the current device
      */
-    val distinctId: Promise<String?>
+    fun distinctAppId(): Promise<String?>
 
     /*
     userId: Id of the logged in user
@@ -76,7 +76,7 @@ interface AnalyticsService {
                 currentAnalyticsService().isEnabled = value
             }
 
-        override val distinctId = currentAnalyticsService().distinctId
+        override fun distinctAppId() = currentAnalyticsService().distinctAppId()
 
         override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
             currentAnalyticsService().identifyUser(userId, properties)

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
@@ -20,7 +20,7 @@ interface AnalyticsService {
     /*
     The distinctAppId associated with the current device
      */
-    fun distinctAppId(): Promise<String?>
+    fun distinctAppId(): Promise<String>
 
     /*
     userId: Id of the logged in user

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
@@ -14,7 +14,7 @@ class AnalyticsServiceLogger(private val analyticsService: AnalyticsService) : A
 
     private val superProperties = AtomicReference<AnalyticsPropertiesType>(mapOf())
 
-    override val distinctId = analyticsService.distinctId
+    override fun distinctAppId() = analyticsService.distinctAppId()
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
         println(

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
@@ -14,6 +14,8 @@ class AnalyticsServiceLogger(private val analyticsService: AnalyticsService) : A
 
     private val superProperties = AtomicReference<AnalyticsPropertiesType>(mapOf())
 
+    override val distinctId = analyticsService.distinctId
+
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
         println(
             """

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
@@ -7,7 +7,7 @@ class EmptyAnalyticsService : AnalyticsService {
 
     override var isEnabled = false
 
-    override val distinctId: Promise<String?> = Promise.reject(Throwable())
+    override val distinctId: Promise<String?> = Promise.resolve("ANALYTICS_SERVICE_NOT_CONFIGURED_DISTINCT_ID")
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
     }

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
@@ -7,7 +7,7 @@ class EmptyAnalyticsService : AnalyticsService {
 
     override var isEnabled = false
 
-    override fun distinctAppId(): Promise<String?> = Promise.resolve("ANALYTICS_SERVICE_NOT_CONFIGURED_DISTINCT_ID")
+    override fun distinctAppId() = Promise.resolve("ANALYTICS_SERVICE_NOT_CONFIGURED_DISTINCT_ID")
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
     }

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
@@ -7,7 +7,7 @@ class EmptyAnalyticsService : AnalyticsService {
 
     override var isEnabled = false
 
-    override val distinctId: Promise<String?> = Promise.resolve("ANALYTICS_SERVICE_NOT_CONFIGURED_DISTINCT_ID")
+    override fun distinctAppId(): Promise<String?> = Promise.resolve("ANALYTICS_SERVICE_NOT_CONFIGURED_DISTINCT_ID")
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
     }

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
@@ -1,9 +1,13 @@
 package com.mirego.trikot.analytics
 
+import com.mirego.trikot.streams.reactive.promise.Promise
+
 class EmptyAnalyticsService : AnalyticsService {
     override val name: String = "ANALYTICS SERVICE NOT CONFIGURED"
 
     override var isEnabled = false
+
+    override val distinctId: Promise<String?> = Promise.reject(Throwable())
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
     }

--- a/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
+++ b/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
@@ -3,6 +3,7 @@ package com.mirego.trikot.analytics
 import android.content.Context
 import android.os.Bundle
 import com.google.firebase.analytics.FirebaseAnalytics
+import com.mirego.trikot.streams.reactive.promise.Promise
 
 class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = true) :
     AnalyticsService {
@@ -21,6 +22,17 @@ class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = tru
     override val name: String = "FirebaseAnalytics"
 
     private var superProperties = emptyMap<String, Any>()
+
+    override val distinctId = Promise.create<String?> { resolve, reject ->
+        firebaseAnalytics.appInstanceId
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    resolve(task.result)
+                } else {
+                    reject(Throwable(task.exception))
+                }
+            }
+    }
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
         firebaseAnalytics.setUserId(userId)

--- a/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
+++ b/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
@@ -29,7 +29,7 @@ class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = tru
                 val result = task.result
                 if (task.isSuccessful && result != null) {
                     resolve(result)
-                } else if(!task.isSuccessful) {
+                } else if (!task.isSuccessful) {
                     reject(Throwable(task.exception))
                 } else {
                     reject(Throwable("Empty result"))

--- a/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
+++ b/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
@@ -32,6 +32,9 @@ class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = tru
                     reject(Throwable(task.exception))
                 }
             }
+            .addOnCanceledListener {
+                reject(Throwable("cancelled"))
+            }
     }
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {

--- a/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
+++ b/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
@@ -23,13 +23,16 @@ class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = tru
 
     private var superProperties = emptyMap<String, Any>()
 
-    override fun distinctAppId() = Promise.create<String?> { resolve, reject ->
+    override fun distinctAppId() = Promise.create<String> { resolve, reject ->
         firebaseAnalytics.appInstanceId
             .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    resolve(task.result)
-                } else {
+                val result = task.result
+                if (task.isSuccessful && result != null) {
+                    resolve(result)
+                } else if(!task.isSuccessful) {
                     reject(Throwable(task.exception))
+                } else {
+                    reject(Throwable("Empty result"))
                 }
             }
             .addOnCanceledListener {

--- a/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
+++ b/trikot-analytics/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
@@ -23,7 +23,7 @@ class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = tru
 
     private var superProperties = emptyMap<String, Any>()
 
-    override val distinctId = Promise.create<String?> { resolve, reject ->
+    override fun distinctAppId() = Promise.create<String?> { resolve, reject ->
         firebaseAnalytics.appInstanceId
             .addOnCompleteListener { task ->
                 if (task.isSuccessful) {
@@ -33,7 +33,7 @@ class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = tru
                 }
             }
             .addOnCanceledListener {
-                reject(Throwable("cancelled"))
+                reject(Throwable("Canceled"))
             }
     }
 

--- a/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
+++ b/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
@@ -25,7 +25,7 @@ class MixpanelAnalyticsService(
 
     override val name: String = "MixpanelAnalytics"
 
-    override val distinctId = Promise.resolve(mixpanelAnalytics.distinctId)
+    override fun distinctAppId() = Promise.resolve(mixpanelAnalytics.distinctId)
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
         mixpanelAnalytics.identify(userId)

--- a/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
+++ b/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
@@ -1,6 +1,7 @@
 package com.mirego.trikot.analytics
 
 import android.content.Context
+import com.mirego.trikot.streams.reactive.promise.Promise
 import com.mixpanel.android.mpmetrics.MixpanelAPI
 import org.json.JSONObject
 
@@ -23,6 +24,8 @@ class MixpanelAnalyticsService(
         }
 
     override val name: String = "MixpanelAnalytics"
+
+    override val distinctId = Promise.resolve(mixpanelAnalytics.distinctId)
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
         mixpanelAnalytics.identify(userId)

--- a/trikot-analytics/swift-extensions/firebase/FirebaseAnalyticsService.swift
+++ b/trikot-analytics/swift-extensions/firebase/FirebaseAnalyticsService.swift
@@ -16,6 +16,10 @@ public class FirebaseAnalyticsService: AnalyticsService {
         }
     }
 
+    public func distinctAppId() -> Promise<NSString>  {
+        PromiseCompanion().resolve(value: Analytics.appInstanceID) as! Promise<NSString>
+    }
+
     public func identifyUser(userId: String, properties: [String: Any]) {
         Analytics.setUserID(userId)
         properties.forEach { Analytics.setUserProperty(anyToString($0.value), forName: $0.key) }

--- a/trikot-analytics/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
+++ b/trikot-analytics/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
@@ -18,6 +18,10 @@ public class MixpanelAnalyticsService: AnalyticsService {
         }
     }
 
+    public func distinctAppId() -> Promise<NSString>  {
+        PromiseCompanion().resolve(value: Mixpanel.mainInstance().distinctId) as! Promise<NSString>
+    }
+
     public func identifyUser(userId: String, properties: [String: Any]) {
         Mixpanel.mainInstance().identify(distinctId: userId)
         Mixpanel.mainInstance().people.set(properties: properties.asMixpanelProperties)


### PR DESCRIPTION
## Description

This PR add a new function on the AnalyticsService that expose the distinct id that the external provider uses to identify a device. It needs to be exposed as a `Promise` since the Android Firebase implementation expose the property as a async Task.

## Motivation and Context

Some of `Mixpanel` APIs requires the distinctId.

## How Has This Been Tested?

This has been tested in my project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
