### PR TITLE
Prevent crashing on too large bitmap in VMDImage on Android

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -145,8 +145,7 @@ fun RemoteImage(
     contentScale: ContentScale = ContentScale.Fit,
     colorFilter: ColorFilter? = null,
     contentDescription: String = "",
-    allowHardware: Boolean = true,
-    displayPlaceholderOnError: Boolean = true
+    allowHardware: Boolean = true
 ) {
     val coilPainter = rememberAsyncImagePainter(
         ImageRequest.Builder(LocalContext.current)
@@ -170,10 +169,7 @@ fun RemoteImage(
                 )
             } else {
                 Log.e(TAG, "Unable to load bitmap: size too large (${drawable.bitmap.allocationByteCount})")
-
-                if (displayPlaceholderOnError) {
-                    placeholder(placeholderImage, state)
-                }
+                placeholder(placeholderImage, state)
             }
         }
         else -> placeholder(placeholderImage, state)

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -1,5 +1,7 @@
 package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
 
+import android.graphics.drawable.BitmapDrawable
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,6 +24,9 @@ import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor.Local
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor.Remote
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
+
+private const val TAG = "VMDImage"
+private const val MAX_BITMAP_SIZE = 100 * 1024 * 1024 // 100 MB, taken from android.graphics.RecordingCanvas
 
 @Composable
 fun VMDImage(
@@ -140,7 +145,8 @@ fun RemoteImage(
     contentScale: ContentScale = ContentScale.Fit,
     colorFilter: ColorFilter? = null,
     contentDescription: String = "",
-    allowHardware: Boolean = true
+    allowHardware: Boolean = true,
+    displayPlaceholderOnError: Boolean = true
 ) {
     val coilPainter = rememberAsyncImagePainter(
         ImageRequest.Builder(LocalContext.current)
@@ -150,16 +156,27 @@ fun RemoteImage(
             .build()
     )
 
-    when (coilPainter.state) {
-        is AsyncImagePainter.State.Success -> Image(
-            painter = coilPainter,
-            modifier = modifier,
-            alignment = alignment,
-            colorFilter = colorFilter,
-            contentScale = contentScale,
-            contentDescription = contentDescription
-        )
-        else -> placeholder(placeholderImage, coilPainter.state)
+    when (val state = coilPainter.state) {
+        is AsyncImagePainter.State.Success -> {
+            val drawable = state.result.drawable
+            if (drawable !is BitmapDrawable || drawable.bitmap.allocationByteCount <= MAX_BITMAP_SIZE) {
+                Image(
+                    painter = coilPainter,
+                    modifier = modifier,
+                    alignment = alignment,
+                    colorFilter = colorFilter,
+                    contentScale = contentScale,
+                    contentDescription = contentDescription
+                )
+            } else {
+                Log.e(TAG, "Unable to load bitmap: size too large (${drawable.bitmap.allocationByteCount})")
+
+                if (displayPlaceholderOnError) {
+                    placeholder(placeholderImage, state)
+                }
+            }
+        }
+        else -> placeholder(placeholderImage, state)
     }
 }
 


### PR DESCRIPTION
## Description
We add a check on the bitmap size too prevent crashing later in the drawing process if the size exceeds the limit set by Android.

## Motivation and Context
When downloading remote images there was no check on the resulting drawable size, so anywhere using remote images it could crash due to this limitation.

## How Has This Been Tested?
This has been tested in an ongoing development app that we encountered the issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
