### PR TITLE
[Datasources] Improvement to BaseHotDataSource

### DIFF
--- a/trikot-datasources/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/BaseHotDataSource.kt
+++ b/trikot-datasources/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/BaseHotDataSource.kt
@@ -102,20 +102,28 @@ abstract class BaseHotDataSource<R : DataSourceRequest, T>(private val cacheData
                 if (data.value != null) {
                     data
                 } else {
-                    val newValue = NullableValue(cacheData)
-                    if (!cacheData.isPending()) {
-                        readIfNeeded(request, newValue, dataPublisher)
+                    val cachedValue = NullableValue(cacheData)
+                    if (cacheData.isPending()) {
+                        cachedValue
+                    } else {
+                        if (readIfNeeded(request, cachedValue, dataPublisher)) {
+                            NullableValue(null)
+                        } else {
+                            cachedValue
+                        }
                     }
-                    newValue
+
                 }
             } ?: dataPublisher
             )
     }
 
-    private fun readIfNeeded(request: R, currentData: NullableDataState<T>, dataPublisher: DataPublisher<T>) {
-        if (shouldRead(request, currentData)) {
+    private fun readIfNeeded(request: R, currentData: NullableDataState<T>, dataPublisher: DataPublisher<T>): Boolean {
+        val shouldRead = shouldRead(request, currentData)
+        if (shouldRead) {
             doInternalRead(request, currentData, dataPublisher)
         }
+        return shouldRead
     }
 
     private fun shouldRead(request: R, currentReadData: NullableDataState<T>): Boolean =

--- a/trikot-datasources/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/BaseHotDataSource.kt
+++ b/trikot-datasources/datasources/src/commonMain/kotlin/com/mirego/trikot/datasources/BaseHotDataSource.kt
@@ -112,7 +112,6 @@ abstract class BaseHotDataSource<R : DataSourceRequest, T>(private val cacheData
                             cachedValue
                         }
                     }
-
                 }
             } ?: dataPublisher
             )

--- a/trikot-datasources/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseExpiringDataSourceTests.kt
+++ b/trikot-datasources/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseExpiringDataSourceTests.kt
@@ -39,10 +39,16 @@ class BaseExpiringDataSourceTests {
         val initialData = ExpiringValue(TestData("value"), 0)
         val cacheDataSource = CacheTestDataSource(initialData)
         val error = Throwable()
-        val readPromise = Promise.reject<ExpiringValue<TestData>>(error)
+
+        val readPublisher: BehaviorSubject<ExpiringValue<TestData>> = Publishers.behaviorSubject()
+        val readPromise = Promise.from(readPublisher)
+
         val mainDataSource = TestDataSource(readPromise, cacheDataSource)
 
-        mainDataSource.read(requestUseCache1).assertEquals(DataState.error(error, initialData))
+        val publisher = mainDataSource.read(requestUseCache1)
+        readPublisher.error = error
+
+        publisher.assertEquals(DataState.error(error, initialData))
     }
 
     @Test

--- a/trikot-datasources/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseHotDataSourceTests.kt
+++ b/trikot-datasources/datasources/src/commonTest/kotlin/com/mirego/trikot/datasources/BaseHotDataSourceTests.kt
@@ -49,6 +49,15 @@ class BaseHotDataSourceTests {
     }
 
     @Test
+    fun givenErrorCacheDataThenPendingIsReturned() {
+        val cacheDataSource = CacheDataSource(Promise.reject(Throwable()))
+        val mainDataSource = MainDataSource(Promise.from(Publishers.behaviorSubject()), cacheDataSource)
+
+        val publisher = mainDataSource.read(requestUseCache)
+        publisher.assertEquals(DataState.pending())
+    }
+
+    @Test
     fun givenPendingCacheDataWhenReadWithRefreshAndCacheDataCompletedAndDataIsAvailableThenReturningTheNewDataAndSaveCalled() {
         val cacheReadPublisher: BehaviorSubject<DataSourceTestData> = Publishers.behaviorSubject()
         val cacheDataSource = CacheDataSource(Promise.from(cacheReadPublisher))


### PR DESCRIPTION
Changes the way `BaseHotDataSource` handles its first read() for cases where a cache datasource is used

## Description

The actual implementation of `BaseHotDataSource`, during its first read(), always returns the value returned by its internal cacheDataSource, no matter its state. This led to two unexpected behaviors:


**Error case**
If the cacheDataSource returns an "error" DataState (which is the case at first read() since cache file does not exist on disk), this error would be very briefly returned as the result of the actual read() method of the datasource (which is incorrect at that level). Usually this would go unnoticed since the internalRead() method quickly returns a pending state after. The sequence of the states emitted by the data source would be something like that:

1. Error state (no data)
2. Pending state (no data) - from internalRead
3. Data state (with data) - result from internal read

We want to avoid the first event.


**Normal case when read is needed**
Even for "normal" cases (when read is needed), the sequence of event of the actual implementation is not the best, since we always first returns the cache result, then a pending, then the data

1. Data state (with data) - from cache
2. Pending state (with data) - from internalRead
3. Data state (with data) - result from internalRead

Technically this is not wrong, but would result in useless changes of state downstream, which could be problematic if this impacts a UI state directly (flickering).

With the new implementation, if there is data in cache _and_ we know that a read is needed, we skip the first step, which would result in the following sequence:

1. Pending state (with data) - from internalRead
2. Data state (with data) - result from internalRead


## Motivation and Context

The error being returned when no cache exists yet causes an actual bug in a project, where a user-triggered operation would fail since it's based on the result of what is returned by a datasource.

## How Has This Been Tested?

- New unit test
- Tested in the project where the bug was happening.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
