### PR TITLE
[Datasource flow] Fix pending state while refreshing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=4.0.0-dev1
+version=4.0.0-dev2-SNAPSHOT
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=4.0.0-dev2-SNAPSHOT
+version=4.0.0-dev1
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSource.kt
+++ b/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSource.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
@@ -134,6 +135,8 @@ private class CachedDataFlow<R : FlowDataSourceRequest, T>(
 
     init {
         scope.launch {
+            // Start subscribing only when dataStateFlow has subscriptions
+            dataStateFlow.subscriptionCount.first { it > 0 }
             blockData.collect {
                 dataStateFlow.value = it
             }

--- a/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/DiskCacheFlowDataSource.kt
+++ b/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/DiskCacheFlowDataSource.kt
@@ -22,7 +22,7 @@ class DiskCacheFlowDataSource<R : FlowDataSourceRequest, T : Any>(
             json.decodeFromString(dataSerializer, fileManager.getFileAsString(getPath(request.cacheableId)))
         } catch (e: SerializationException) {
             if (deleteOnSerializationError) {
-                delete(request.cacheableId)
+                fileManager.deleteFile(getPath(request.cacheableId))
             }
             throw e
         }


### PR DESCRIPTION
## Description
Fix an issue where we did not emit pending while refreshing the data

## Motivation and Context
In some cases, we want to be notified that the data is refreshing.

## How Has This Been Tested?
Added a unit test

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
