### PR TITLE
Force github action builds on macos 11

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   cd:
     name: Build library CD
-    runs-on: macos-latest
+    # simulator names changed in macos-12 . Waiting on this to be released
+    # https://github.com/JetBrains/kotlin/commit/10947e2c45255cf89b8cee1598017b6fc61b0079
+    runs-on: macos-11
     continue-on-error: false
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on: workflow_dispatch
 jobs:
   release:
     name: Release library
-    runs-on: macos-latest
+    # simulator names changed in macos-12 . Waiting on this to be released
+    # https://github.com/JetBrains/kotlin/commit/10947e2c45255cf89b8cee1598017b6fc61b0079
+    runs-on: macos-11
     continue-on-error: false
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
We changed CD and release jobs to run on macos-11 since it doesn't work on macos-12

The actual problem is the similator name now having parenthesis according to this :
https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md
https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md

And the kotlin gradle plugin requires the name without parenthesis

it was fixed in https://github.com/JetBrains/kotlin/commit/10947e2c45255cf89b8cee1598017b6fc61b0079
but it is not released yet.

## Motivation and Context
Fixes builds on github action

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
