### PR TITLE
[DataSource.flow] Fix a race condition with clear+read and delete+read

### DIFF
--- a/trikot-datasources/datasources-flow/src/commonTest/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSourceTests.kt
+++ b/trikot-datasources/datasources-flow/src/commonTest/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSourceTests.kt
@@ -257,14 +257,13 @@ class BaseFlowDataSourceTests {
         val readMutex = Mutex(locked = true)
         val clearMutex = Mutex(locked = true)
         val cacheDataSource = CacheDataSource({ initialData }, testDispatcher, clearFunction = {
-            clearMutex.withLock {  }
+            clearMutex.withLock { }
         })
         val mainDataSource = MainDataSource({
             readMutex.withLock {
                 data
             }
         }, cacheDataSource = cacheDataSource, coroutineContext = testDispatcher)
-
 
         val values = mutableListOf<DataState<DataSourceTestData, Throwable>>()
 


### PR DESCRIPTION
## Description
We had an issue with ExecutableDataFlow with an upstream datasource of DiskCacheDataSource where it would not return the data after the read if someone called clear concurrently

The following happened:

coroutine 1 - ExecutableDataFlow.clear()
coroutine 2 - ExecutableDataFlow.read()
clear cancels the previous cached flow
cancellation of the cached flow bubbles up to our read job.

read emited pending but no data

Now we make sure everything is behind the mutex so that it waits until clear is complete to perform the read which will create a new cached flow since the previous one was removed.

## Motivation and Context
We had a race condition which prevented the data from receiving data.

## How Has This Been Tested?
Added a unit test that reproduced the original issue, it now passes.
Also tested in the read code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
