### PR TITLE
[VMD-FLOW] Improved handling of lifecycle on both android and iOS

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLifecycleView.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLifecycleView.kt
@@ -2,25 +2,37 @@ package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDLifecycleViewModel
-import kotlinx.coroutines.CoroutineScope
 
+/**
+ * For views backed by a VMDLifecycleViewModel, wrap your content with VMDLifecycleView to properly bind the lifecycle.
+ */
 @Composable
 fun VMDLifecycleView(
-    viewModel: VMDLifecycleViewModel,
-    preOnAppear: suspend (CoroutineScope) -> Unit = {},
+    lifecycleViewModel: VMDLifecycleViewModel,
     content: @Composable () -> Unit
 ) {
+    val lifecycleOwner by rememberUpdatedState(LocalLifecycleOwner.current)
     content()
-    LaunchedEffect(LocalLifecycleOwner.current) {
-        preOnAppear(this)
-        viewModel.onAppear()
-    }
-    DisposableEffect(LocalLifecycleOwner.current) {
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_START) {
+                lifecycleViewModel.onAppear()
+            } else if (event == Lifecycle.Event.ON_STOP) {
+                lifecycleViewModel.onDisappear()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
-            viewModel.onDisappear()
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                lifecycleViewModel.onDisappear()
+            }
         }
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Extensions/VMDView+Lifecycle.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Extensions/VMDView+Lifecycle.swift
@@ -1,11 +1,44 @@
 import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 
-extension View {
-    @ViewBuilder
-    func handleLifecycle(_ viewModel: VMDLifecycleViewModel) -> some View {
-        self
-            .onAppear { viewModel.onAppear() }
-            .onDisappear { viewModel.onDisappear() }
+struct LifecycleModifier: ViewModifier {
+
+    @Environment(\.scenePhase) var scenePhase
+
+    let viewModel: VMDLifecycleViewModel
+
+    @State private var skipFirstScenePhase = true
+    @State private var isDisplayed = false
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: scenePhase) { newPhase in
+                if skipFirstScenePhase {
+                    skipFirstScenePhase = false
+                } else {
+                    if isDisplayed {
+                        if newPhase == .active {
+                            viewModel.onAppear()
+                        } else if newPhase == .background {
+                            viewModel.onDisappear()
+                        }
+                    }
+                }
+            }
+            .onAppear {
+                isDisplayed = true
+                viewModel.onAppear()
+            }
+            .onDisappear {
+                isDisplayed = false
+                viewModel.onDisappear()
+            }
     }
 }
+
+public extension View {
+    func handleLifecycle(_ viewModel: VMDLifecycleViewModel) -> some View {
+        modifier(LifecycleModifier(viewModel: viewModel))
+    }
+}
+


### PR DESCRIPTION
## Description

Lifecycle handling in VMD flow platform code was not properly reacting to "background / foreground" switch.

## Motivation and Context

Putting an app in background didn't call `onDisappear()`, and bringing it back to foreground didn't call `onAppear()`. These two cases are valid and should be handled properly.

Side-note: the iOS implementation wasn't even usable, it was not `public`.

## How Has This Been Tested?

Code extracted from a projet currently in production.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
