### PR TITLE
Added step in CD workflow to add a tag when publishing a new DEV version (needed for cocoapod)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,3 +45,4 @@ jobs:
         run: |
           ./gradlew writeDevVersion -i -s
           ./gradlew check publish -i -s
+          ./gradlew tagDevVersion -i -s

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,15 @@ tasks {
         val originalVersion = project.version.toString().replace("-dev\\w+".toRegex(), "")
         property("version", "$originalVersion-dev$gitCommits")
     }
+    val tagDevVersion by registering {
+        try {
+            val version = project.property("version")
+            "git tag $version".runCommand(workingDir = rootDir)
+            "git push origin --tags".runCommand(workingDir = rootDir)
+        } catch (e: Exception) {
+            println("Unable to tag: ${e.message}")
+        }
+    }
 }
 
 // Node.js 16.0.0 is needed on Apple Silicon


### PR DESCRIPTION
## Description

In the current CD workflow, a new dev version is built and published for each new commit in master branch. However, this would only release the "maven" artefacts. For project using cocoapod, the new release would not be available since it requires that a tag is added on github.
This adds an extra step to properly create and push the tag.

## Motivation and Context

The usual flow was manually create a tag each time a new releases was needed. Now it is automatic.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
