### PR TITLE
[DataSourceFlow] Change delete/clear cache cancellation behavior

### DIFF
--- a/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSource.kt
+++ b/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSource.kt
@@ -5,7 +5,6 @@ import com.mirego.trikot.datasources.extensions.value
 import com.mirego.trikot.datasources.flow.extensions.withPreviousDataStateValue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSource.kt
+++ b/trikot-datasources/datasources-flow/src/commonMain/kotlin/com/mirego/trikot/datasources/flow/BaseFlowDataSource.kt
@@ -99,17 +99,17 @@ abstract class BaseFlowDataSource<R : FlowDataSourceRequest, T>(
     }
 
     override suspend fun delete(cacheableId: String) {
-        upstreamDataSource?.delete(cacheableId)
         cacheMutex.withLock {
             cache.remove(cacheableId)
         }
+        upstreamDataSource?.delete(cacheableId)
     }
 
     override suspend fun clear() {
-        upstreamDataSource?.clear()
         cacheMutex.withLock {
             cache.clear()
         }
+        upstreamDataSource?.clear()
     }
 
     internal fun cacheableIds(): List<Any> {


### PR DESCRIPTION
## Description
Previously we were cancelling the cached data flow job when invalidating the cache via delete or clear. 

That had the side effect to cancel all pending reads as well if both were launched at the same time (since the Cancellation did bubble up to the parent scope).

We found that this behavior was not really what we wanted to achieve. Now we no longer cancel the child job so that concurrent reads can continue. We also now start by clearing the cache before clearing the upstream so that local cache is cleared faster.

## Motivation and Context
In some cases we did call clear and followed quickly by read. The clear did take some time to complete (due to IO with a file datasource) and read started while clear was running. Once clear completed, it cancelled the job, and the read was cancelled because of that.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
