### PR TITLE
Android Hidden behavior fix

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
@@ -29,8 +29,9 @@ fun <C : VMDContent> VMDButton(
     val buttonViewModel: VMDButtonViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .hidden(buttonViewModel.isHidden)
+            .then(modifier)
             .clickable(
                 enabled = buttonViewModel.isEnabled,
                 onClick = viewModel.actionBlock,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
@@ -45,8 +45,9 @@ fun <C : VMDContent> VMDCheckbox(
     val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDLabeledComponent(
-        modifier = modifier
-            .hidden(viewModel.isHidden),
+        modifier = Modifier
+            .hidden(viewModel.isHidden)
+            .then(modifier),
         label = { label(toggleViewModel.label) },
         content = {
             Checkbox(

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
@@ -27,15 +27,19 @@ fun VMDCircularProgressIndicator(
     val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
     val animatedProgress by animateFloatAsState(targetValue = progressViewModel.determination?.progressRatio ?: 0f)
 
+    val newModifier = Modifier
+        .hidden(progressViewModel.isHidden)
+        .then(modifier)
+
     if (viewModel.determination == null) {
         CircularProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             color = color,
             strokeWidth = strokeWidth
         )
     } else {
         CircularProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             progress = animatedProgress,
             color = color,
             strokeWidth = strokeWidth

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -53,7 +53,9 @@ fun VMDImage(
     val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDImage(
-        modifier = modifier.hidden(imageViewModel.isHidden),
+        modifier = Modifier
+            .hidden(imageViewModel.isHidden)
+            .then(modifier),
         alpha = alpha,
         alignment = alignment,
         contentScale = contentScale,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
@@ -62,8 +62,9 @@ fun <C : VMDIdentifiableContent> VMDLazyColumnIndexed(
     val listViewModel: VMDListViewModel<C> by viewModel.observeAsState()
 
     LazyColumn(
-        modifier = modifier
-            .hidden(listViewModel.isHidden),
+        modifier = Modifier
+            .hidden(listViewModel.isHidden)
+            .then(modifier),
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
@@ -63,8 +63,9 @@ fun <C : VMDIdentifiableContent> VMDLazyRowIndexed(
     val listViewModel: VMDListViewModel<C> by viewModel.observeAsState()
 
     LazyRow(
-        modifier = modifier
-            .hidden(listViewModel.isHidden),
+        modifier = Modifier
+            .hidden(listViewModel.isHidden)
+            .then(modifier),
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
@@ -27,15 +27,19 @@ fun VMDLinearProgressIndicator(
     val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
     val animatedProgress by animateFloatAsState(targetValue = viewModel.determination?.progressRatio ?: 0f)
 
+    val newModifier = Modifier
+        .hidden(progressViewModel.isHidden)
+        .then(modifier)
+
     if (viewModel.determination == null) {
         LinearProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             color = color,
             backgroundColor = backgroundColor
         )
     } else {
         LinearProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             progress = animatedProgress,
             color = color,
             backgroundColor = backgroundColor

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
@@ -64,8 +64,9 @@ fun <C : VMDIdentifiableContent> VMDSectionedList(
     val listViewModel: VMDListViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     LazyColumn(
-        modifier = modifier
-            .hidden(listViewModel.isHidden),
+        modifier = Modifier
+            .hidden(listViewModel.isHidden)
+            .then(modifier),
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
@@ -45,8 +45,9 @@ fun <C : VMDContent> VMDSwitch(
     val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDLabeledComponent(
-        modifier = modifier
-            .hidden(toggleViewModel.isHidden),
+        modifier = Modifier
+            .hidden(toggleViewModel.isHidden)
+            .then(modifier),
         label = { label(toggleViewModel.label) },
         content = {
             Switch(

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDText.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDText.kt
@@ -43,8 +43,9 @@ fun VMDText(
 
     Text(
         text = textViewModel.text,
-        modifier = modifier
-            .hidden(textViewModel.isHidden),
+        modifier = Modifier
+            .hidden(textViewModel.isHidden)
+            .then(modifier),
         color = color,
         fontSize = fontSize,
         fontStyle = fontStyle,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
@@ -38,8 +38,9 @@ fun VMDTextField(
     val keyboardActionsDelegate = buildKeyboardActions(viewModel, keyboardActions)
 
     TextField(
-        modifier = modifier
-            .hidden(textFieldViewModel.isHidden),
+        modifier = Modifier
+            .hidden(textFieldViewModel.isHidden)
+            .then(modifier),
         value = textFieldViewModel.text,
         onValueChange = { value ->
             viewModel.onValueChange(value)

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
@@ -29,8 +29,9 @@ fun <C : VMDContent> VMDButton(
     val buttonViewModel: VMDButtonViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     Box(
-        modifier = modifier
+        modifier = Modifier
             .hidden(buttonViewModel.isHidden)
+            .then(modifier)
             .clickable(
                 enabled = buttonViewModel.isEnabled,
                 onClick = viewModel.actionBlock,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
@@ -45,8 +45,9 @@ fun <C : VMDContent> VMDCheckbox(
     val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDLabeledComponent(
-        modifier = modifier
-            .hidden(viewModel.isHidden),
+        modifier = Modifier
+            .hidden(viewModel.isHidden)
+            .then(modifier),
         label = { label(toggleViewModel.label) },
         content = {
             Checkbox(

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
@@ -27,15 +27,19 @@ fun VMDCircularProgressIndicator(
     val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
     val animatedProgress by animateFloatAsState(targetValue = progressViewModel.determination?.progressRatio ?: 0f)
 
+    val newModifier = Modifier
+        .hidden(progressViewModel.isHidden)
+        .then(modifier)
+
     if (viewModel.determination == null) {
         CircularProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             color = color,
             strokeWidth = strokeWidth
         )
     } else {
         CircularProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             progress = animatedProgress,
             color = color,
             strokeWidth = strokeWidth

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -53,7 +53,9 @@ fun VMDImage(
     val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDImage(
-        modifier = modifier.hidden(imageViewModel.isHidden),
+        modifier = Modifier
+            .hidden(imageViewModel.isHidden)
+            .then(modifier),
         alpha = alpha,
         alignment = alignment,
         contentScale = contentScale,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
@@ -62,8 +62,9 @@ fun <C : VMDIdentifiableContent> VMDLazyColumnIndexed(
     val listViewModel: VMDListViewModel<C> by viewModel.observeAsState()
 
     LazyColumn(
-        modifier = modifier
-            .hidden(listViewModel.isHidden),
+        modifier = Modifier
+            .hidden(listViewModel.isHidden)
+            .then(modifier),
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
@@ -63,8 +63,9 @@ fun <C : VMDIdentifiableContent> VMDLazyRowIndexed(
     val listViewModel: VMDListViewModel<C> by viewModel.observeAsState()
 
     LazyRow(
-        modifier = modifier
-            .hidden(listViewModel.isHidden),
+        modifier = Modifier
+            .hidden(listViewModel.isHidden)
+            .then(modifier),
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
@@ -27,15 +27,19 @@ fun VMDLinearProgressIndicator(
     val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
     val animatedProgress by animateFloatAsState(targetValue = viewModel.determination?.progressRatio ?: 0f)
 
+    val newModifier = Modifier
+        .hidden(progressViewModel.isHidden)
+        .then(modifier)
+
     if (viewModel.determination == null) {
         LinearProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             color = color,
             backgroundColor = backgroundColor
         )
     } else {
         LinearProgressIndicator(
-            modifier = modifier.hidden(progressViewModel.isHidden),
+            modifier = newModifier,
             progress = animatedProgress,
             color = color,
             backgroundColor = backgroundColor

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
@@ -64,8 +64,9 @@ fun <C : VMDIdentifiableContent> VMDSectionedList(
     val listViewModel: VMDListViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     LazyColumn(
-        modifier = modifier
-            .hidden(listViewModel.isHidden),
+        modifier = Modifier
+            .hidden(listViewModel.isHidden)
+            .then(modifier),
         state = state,
         contentPadding = contentPadding,
         reverseLayout = reverseLayout,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
@@ -46,8 +46,9 @@ fun <C : VMDContent> VMDSwitch(
     val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDLabeledComponent(
-        modifier = modifier
-            .hidden(toggleViewModel.isHidden),
+        modifier = Modifier
+            .hidden(toggleViewModel.isHidden)
+            .then(modifier),
         label = { label(toggleViewModel.label) },
         content = {
             Switch(

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDText.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDText.kt
@@ -43,8 +43,9 @@ fun VMDText(
 
     Text(
         text = textViewModel.text,
-        modifier = modifier
-            .hidden(textViewModel.isHidden),
+        modifier = Modifier
+            .hidden(textViewModel.isHidden)
+            .then(modifier),
         color = color,
         fontSize = fontSize,
         fontStyle = fontStyle,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
@@ -38,8 +38,9 @@ fun VMDTextField(
     val keyboardActionsDelegate = buildKeyboardActions(viewModel, keyboardActions)
 
     TextField(
-        modifier = modifier
-            .hidden(textFieldViewModel.isHidden),
+        modifier = Modifier
+            .hidden(textFieldViewModel.isHidden)
+            .then(modifier),
         value = textFieldViewModel.text,
         onValueChange = { value ->
             viewModel.onValueChange(value)


### PR DESCRIPTION
## Description

When using Modifiers to hide a view, it is important that the `.hidden` modifier be at the beginning of the train, or else anything after will be ignored. Consider this VMDButton:
```kotlin
VMDButton(
        Modifier
            .fillMaxWidth()
            .align(Alignment.Center)
            .background(Color.Yellow)
            .padding(32.dp),
        viewModel = viewModel.myButton
    ) { content ->
        Text(content.text)
    }
```
If `myButton` has `isHidden` set to true, you will not see the button contents but you will see a big yellow rectangle on the screen, because `Modifier.hidden` is applied at the end of the chain.

By using `Modifier.hidden(...).then(modifier)`, we ensure that `.hidden` is at the beginning of the chain, thus hiding everything

## Motivation and Context

This fixes the problem that components that are hidden in the viewModel were not completely hidden in the UI

## How Has This Been Tested?

By adding `hidden` in the samples, I was able to confirm that components were effectively completely hidden

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
