### PR TITLE
[Bluetooth] Make found devices copy thread safe.

### DIFF
--- a/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
+++ b/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
@@ -132,11 +132,10 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
                     foundDevice[result.device.address] = result.toBluetoothScanResult(context)
                         .also {
                             it.lostHeartbeatCallback = {
-                                foundDevice.remove(result.device.address)
-                                devicesPublisher.value = foundDevice.values.toList()
+                                removeResult(result)
                             }
                         }
-                    devicesPublisher.value = foundDevice.values.toList()
+                    devicesPublisher.value = ConcurrentHashMap(foundDevice).values.toList()
                 } else {
                     (foundDevice[result.device.address] as AndroidBluetoothScanResult).doHeartbeat()
                 }
@@ -144,7 +143,7 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
 
             private fun removeResult(result: ScanResult) {
                 foundDevice.remove(result.device.address)
-                devicesPublisher.value = foundDevice.values.toList()
+                devicesPublisher.value = ConcurrentHashMap(foundDevice).values.toList()
             }
         }
 


### PR DESCRIPTION
Make toList conversion thread safe by cloning map before converting its values to list.

## Motivation and Context

When we had a single element that we were removing from the map because we lost its signal, we would sometimes try to convert values to list in a non-thread-safe access.
The `toList()` implementation works like this:

```
public fun <T> Iterable<T>.toList(): List<T> {
    if (this is Collection) {
        return when (size) {
            0 -> emptyList()
            1 -> listOf(if (this is List) get(0) else iterator().next())
            else -> this.toMutableList()
        }
    }
    return this.toMutableList().optimizeReadOnlyList()
}
```

In the case where the size of `values` was determined to be 1, if we lost the signal at that point, the value would be removed in the map, and `iterator().next()` would crash.

## Solution

The solution is to use the copy-constructor to copy the maps value to a separate map instance, and **then** to convert those to a list since they won't be accessed anywhere else.

## How Has This Been Tested?

Tested in an app.

## Types of changes
 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
