### PR TITLE
Support Gradle configuration cache for KWord plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=4.0.0-SNAPSHOT
+version=4.0.0-dev1
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ kotlin.native.binary.freezing=disabled
 org.gradle.parallel=true
 kotlin.native.enableDependencyPropagation=false
 org.gradle.jvmargs=-Xmx3072m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
-version=4.0.0-dev1
+version=4.0.0-SNAPSHOT
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official

--- a/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordExtension.groovy
+++ b/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordExtension.groovy
@@ -33,7 +33,7 @@ class KWordExtension {
     }
 
     void translationFiles(Object... translationFiles) {
-        this.translationFiles = projectDirectory.files(translationFiles)
+        this.translationFiles = projectDirectory.files(translationFiles).toList()
     }
 
     String getEnumClassName() {

--- a/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordExtension.groovy
+++ b/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordExtension.groovy
@@ -1,11 +1,10 @@
 package com.mirego.kword
 
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
 import org.gradle.api.tasks.Input
 
 class KWordExtension {
-    private Project project
-
     @Input
     File translationFile
     @Input
@@ -15,8 +14,10 @@ class KWordExtension {
     @Input
     File generatedDir
 
+    private Directory projectDirectory
+
     KWordExtension(Project project) {
-        this.project = project
+        projectDirectory = project.layout.projectDirectory
     }
 
     File getTranslationFile() {
@@ -24,7 +25,7 @@ class KWordExtension {
     }
 
     void translationFile(Object translationFile) {
-        this.translationFile = project.file(translationFile)
+        this.translationFile = projectDirectory.files(translationFile).singleFile
     }
 
     List<File> getTranslationFiles() {
@@ -32,7 +33,7 @@ class KWordExtension {
     }
 
     void translationFiles(Object... translationFiles) {
-        this.translationFiles = project.files(translationFiles).toList()
+        this.translationFiles = projectDirectory.files(translationFiles)
     }
 
     String getEnumClassName() {
@@ -48,6 +49,6 @@ class KWordExtension {
     }
 
     void generatedDir(Object generatedDir) {
-        this.generatedDir = project.file(generatedDir)
+        this.generatedDir = projectDirectory.files(generatedDir).singleFile
     }
 }


### PR DESCRIPTION
## Description
We change the way the project is stored inside the extension. Previously we kept the whole project in member, but this is prohibited when enabling the configuration cache feature since Project is not serializable.

## Motivation and Context
In order to enable configuration cache in a project, every plugins used need to be compatible.

## How Has This Been Tested?
This has been tested locally on another project

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
