### PR TITLE
Fix animation in VMD Flow

### DIFF
--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDListViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDListViewModelImpl.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.declarative.components.impl
 
+import com.mirego.trikot.viewmodels.declarative.animation.VMDAnimation
 import com.mirego.trikot.viewmodels.declarative.components.VMDListViewModel
 import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 import com.mirego.trikot.viewmodels.declarative.viewmodel.internal.VMDFlowProperty
@@ -16,6 +17,10 @@ open class VMDListViewModelImpl<E : VMDIdentifiableContent>(coroutineScope: Coro
 
     fun bindElements(flow: Flow<List<E>>) {
         updateProperty(this::elements, flow)
+    }
+
+    fun bindElementsAnimated(flow: Flow<Pair<List<E>, VMDAnimation?>>) {
+        updateAnimatedPropertyPublisher(this::elements, flow)
     }
 
     override val propertyMapping: Map<String, VMDFlowProperty<*>> by lazy {


### PR DESCRIPTION
## Description

The VMDAnimationContext was completely broken in VMD Flow. The push / peek / pop sequence assumes that the willChange and didChange methods are synchronous, since they weren't, nothing was working.

I fixed that by use tryEmit on the MutableSharedFlow and changing buffer overflow strategy to avoid any failed emit.

## How Has This Been Tested?

In my project

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
