### PR TITLE
Remove publish gradle plugin

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,4 +45,4 @@ jobs:
         run: |
           ./gradlew writeDevVersion -i -s
           ./gradlew check publish -i -s
-          ./gradlew tagDevVersion -i -s
+          ./gradlew tagVersion -i -s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,5 @@ jobs:
           MAVEN_AWS_KEY: ${{ secrets.MIREGO_MAVEN_AWS_ACCESS_KEY_ID }}
           MAVEN_AWS_SECRET: ${{ secrets.MIREGO_MAVEN_AWS_SECRET_ACCESS_KEY }}
         run: |
-          ./gradlew check release -i -s
+          ./gradlew check publish -i -s
+          ./gradlew tagVersion -i -s

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: On-Demand
+name: Release
 
 on: workflow_dispatch
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ buildscript {
 
 plugins {
     id("mirego.publish").version("1.0")
-    id("mirego.release").version("2.0")
 }
 
 allprojects {
@@ -32,43 +31,6 @@ allprojects {
     }
 }
 
-release {
-    checkTasks = listOf(
-        "check"
-    )
-    buildTasks = listOf(
-        ":trikot-foundation:trikotFoundation:publish",
-        ":trikot-foundation:test-utils:publish",
-        ":trikot-streams:streams:publish",
-        ":trikot-streams:test-utils:publish",
-        ":trikot-streams:coroutines-interop:publish",
-        ":trikot-http:http:publish",
-        ":trikot-datasources:datasources-core:publish",
-        ":trikot-datasources:datasources-flow:publish",
-        ":trikot-datasources:datasources-streams:publish",
-        ":trikot-kword:kword:publish",
-        ":trikot-kword:kword-streams:publish",
-        ":trikot-kword:kword-flow:publish",
-        ":trikot-kword:kword-plugin:publish",
-        ":trikot-http:http:publish",
-        ":trikot-viewmodels:viewmodels:publish",
-        ":trikot-viewmodels-declarative:viewmodels-declarative:publish",
-        ":trikot-viewmodels-declarative:compose:publish",
-        ":trikot-viewmodels-declarative-flow:viewmodels-declarative-flow:publish",
-        ":trikot-viewmodels-declarative-flow:compose-flow:publish",
-        ":trikot-viewmodels-declarative-annotations:publish",
-        ":trikot-viewmodels-declarative-compiler:viewmodels-declarative-compiler-streams:publish",
-        ":trikot-viewmodels-declarative-compiler:viewmodels-declarative-compiler-flow:publish",
-        ":trikot-analytics:analytics:publish",
-        ":trikot-analytics:analytics-viewmodel:publish",
-        ":trikot-analytics:firebase-ktx:publish",
-        ":trikot-analytics:mixpanel-ktx:publish",
-        ":trikot-bluetooth:bluetooth:publish",
-        ":trikot-graphql:graphql:publish"
-    )
-    updateVersionPart = 2
-}
-
 tasks {
     val writeDevVersion by registering(WriteProperties::class) {
         outputFile = file("${rootDir}/gradle.properties")
@@ -77,7 +39,7 @@ tasks {
         val originalVersion = project.version.toString().replace("-dev\\w+".toRegex(), "")
         property("version", "$originalVersion-dev$gitCommits")
     }
-    val tagDevVersion by registering {
+    val tagVersion by registering {
         try {
             val version = project.property("version")
             "git tag $version".runCommand(workingDir = rootDir)


### PR DESCRIPTION
## Description
Stop using the release plugin, use publish and tag instead

## Motivation and Context
We were previously using the release plugin which was bumping versions automatically in git.
With the new release process, we want to manage the bumping of versions manually instead.

## How Has This Been Tested?
Not at all, we'll test after it's merged !

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
