### PR TITLE
[VMD-flow] Use of the viewModelScope on Android

### DIFF
--- a/trikot-viewmodels-declarative-flow/sample/common/TRIKOT_FRAMEWORK_NAME.podspec
+++ b/trikot-viewmodels-declarative-flow/sample/common/TRIKOT_FRAMEWORK_NAME.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'TRIKOT_FRAMEWORK_NAME'
-    spec.version                  = '4.0.0-dev1'
+    spec.version                  = '4.1.0-dev1'
     spec.homepage                 = 'www.mirego.com'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/home/HomeViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/home/HomeViewModelController.kt
@@ -11,7 +11,7 @@ class HomeViewModelController(i18N: I18N) :
     VMDViewModelController<HomeViewModel, HomeNavigationDelegate>() {
 
     override val viewModel: HomeViewModel =
-        object : VMDViewModelImpl(viewModelControllerScope), HomeViewModel {
+        object : VMDViewModelImpl(viewModelScope), HomeViewModel {
             override val title = i18N[KWordTranslation.HOME_TITLE]
 
             override val sections: VMDListViewModel<HomeSectionViewModel> =
@@ -21,72 +21,72 @@ class HomeViewModelController(i18N: I18N) :
                         elements = listOf(
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_TEXT],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToTextShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_BUTTON],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToButtonShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_IMAGE],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToImageShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_TEXTFIELD],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToTextFieldShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_TOGGLE],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToToggleShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_PROGRESS],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToProgressShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_LIST],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToListShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_PICKER],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToPickerShowcase() }
                             },
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_COMPONENT_SNACKBAR],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToSnackbarShowcase() }
                             }
                         ),
-                        coroutineScope = viewModelControllerScope
+                        coroutineScope = coroutineScope
                     ),
                     HomeSectionViewModelImpl(
                         text = i18N[KWordTranslation.HOME_ANIMATIONS_TITLE],
                         elements = listOf(
                             HomeSectionElementViewModelImpl(
                                 text = i18N[KWordTranslation.HOME_ANIMATION_EASING],
-                                coroutineScope = viewModelControllerScope
+                                coroutineScope = coroutineScope
                             ) {
                                 setAction { navigationDelegate?.navigateToAnimationTypesShowcase() }
                             }
                         ),
-                        coroutineScope = viewModelControllerScope
+                        coroutineScope = coroutineScope
                     )
                 )
         }

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/animation/types/AnimationTypesShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/animation/types/AnimationTypesShowcaseViewModelController.kt
@@ -8,7 +8,7 @@ import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelControlle
 import kotlin.time.Duration.Companion.seconds
 
 class AnimationTypesShowcaseViewModelController(i18N: I18N) : VMDViewModelController<AnimationTypesShowcaseViewModel, AnimationTypesShowcaseNavigationDelegate>() {
-    override val viewModel: AnimationTypesShowcaseViewModelImpl = AnimationTypesShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: AnimationTypesShowcaseViewModelImpl = AnimationTypesShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/button/ButtonShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/button/ButtonShowcaseViewModelController.kt
@@ -6,7 +6,7 @@ import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelControlle
 import kotlinx.coroutines.flow.flowOf
 
 class ButtonShowcaseViewModelController(i18N: I18N) : VMDViewModelController<ButtonShowcaseViewModel, ButtonShowcaseNavigationDelegate>() {
-    override val viewModel: ButtonShowcaseViewModelImpl = ButtonShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: ButtonShowcaseViewModelImpl = ButtonShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/image/ImageShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/image/ImageShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class ImageShowcaseViewModelController(i18N: I18N) : VMDViewModelController<ImageShowcaseViewModel, ImageShowcaseNavigationDelegate>() {
-    override val viewModel: ImageShowcaseViewModelImpl = ImageShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: ImageShowcaseViewModelImpl = ImageShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/list/ListShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class ListShowcaseViewModelController(i18N: I18N) : VMDViewModelController<ListShowcaseViewModel, ListShowcaseNavigationDelegate>() {
-    override val viewModel: ListShowcaseViewModelImpl = ListShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: ListShowcaseViewModelImpl = ListShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class PickerShowcaseViewModelController(i18N: I18N) : VMDViewModelController<PickerShowcaseViewModel, PickerShowcaseNavigationDelegate>() {
-    override val viewModel = PickerShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel = PickerShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/progress/ProgressShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/progress/ProgressShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class ProgressShowcaseViewModelController(i18N: I18N) : VMDViewModelController<ProgressShowcaseViewModel, ProgressShowcaseNavigationDelegate>() {
-    override val viewModel: ProgressShowcaseViewModelImpl = ProgressShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: ProgressShowcaseViewModelImpl = ProgressShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/snackbar/SnackbarShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/snackbar/SnackbarShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class SnackbarShowcaseViewModelController(i18N: I18N) : VMDViewModelController<SnackbarShowcaseViewModel, SnackbarShowcaseNavigationDelegate>() {
-    override val viewModel: SnackbarShowcaseViewModelImpl = SnackbarShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: SnackbarShowcaseViewModelImpl = SnackbarShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class TextShowcaseViewModelController(i18N: I18N) : VMDViewModelController<TextShowcaseViewModel, TextShowcaseNavigationDelegate>() {
-    override val viewModel: TextShowcaseViewModelImpl = TextShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: TextShowcaseViewModelImpl = TextShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/textfield/TextFieldShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/textfield/TextFieldShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class TextFieldShowcaseViewModelController(i18N: I18N) : VMDViewModelController<TextFieldShowcaseViewModel, TextFieldShowcaseNavigationDelegate>() {
-    override val viewModel: TextFieldShowcaseViewModelImpl = TextFieldShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: TextFieldShowcaseViewModelImpl = TextFieldShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/toggle/ToggleShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/toggle/ToggleShowcaseViewModelController.kt
@@ -4,7 +4,7 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
 
 class ToggleShowcaseViewModelController(i18N: I18N) : VMDViewModelController<ToggleShowcaseViewModel, ToggleShowcaseNavigationDelegate>() {
-    override val viewModel: ToggleShowcaseViewModelImpl = ToggleShowcaseViewModelImpl(i18N, viewModelControllerScope)
+    override val viewModel: ToggleShowcaseViewModelImpl = ToggleShowcaseViewModelImpl(i18N, viewModelScope)
 
     override fun onCreate() {
         super.onCreate()

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/build.gradle.kts
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
             dependsOn(commonMain)
             dependencies {
                 implementation("androidx.appcompat:appcompat:1.2.0")
+                implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.ANDROIDX_LIFECYCLE}")
             }
         }
 

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,6 +1,11 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
 
 @Suppress("NO_ACTUAL_CLASS_MEMBER_FOR_EXPECTED_CLASS")
 actual typealias VMDPlatformViewModelController = ViewModel
+
+actual val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope
+    get() = viewModelScope

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/factory/AndroidViewModelProviderFactory.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/factory/AndroidViewModelProviderFactory.kt
@@ -59,7 +59,7 @@ class AndroidViewModelProviderFactory {
             (application as ViewModelControllerFactoryProvidingApplication).viewModelControllerFactory
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             val getters = internalFactory::class.java.declaredMethods
                 .filter {
                     it.returnType == modelClass && it.parameterTypes.map { javaClass ->

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,5 +1,9 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
+import kotlinx.coroutines.CoroutineScope
+
 expect abstract class VMDPlatformViewModelController() {
     open fun onCleared()
 }
+
+expect val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDViewModelController.kt
@@ -3,24 +3,16 @@ package com.mirego.trikot.viewmodels.declarative.controller
 import com.mirego.trikot.foundation.concurrent.atomic
 import com.mirego.trikot.foundation.ref.weakAtomicReference
 import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModel
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 abstract class VMDViewModelController<VM : VMDViewModel, N : VMDNavigationDelegate> :
     VMDPlatformViewModelController() {
 
     var navigationDelegate: N? by weakAtomicReference()
 
-    open val exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        println("CoroutineExceptionHandler got $throwable")
-    }
-
-    protected val viewModelControllerScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob() + exceptionHandler)
-
     abstract val viewModel: VM
+
+    val viewModelScope: CoroutineScope = platformViewModelScope
 
     private var hasAppeared by atomic(false)
 
@@ -43,10 +35,5 @@ abstract class VMDViewModelController<VM : VMDViewModel, N : VMDNavigationDelega
     }
 
     open fun onDisappear() {
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        viewModelControllerScope.cancel()
     }
 }

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/iosArm32Main/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,7 +1,22 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
 actual abstract class VMDPlatformViewModelController {
+    private val exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        println("CoroutineExceptionHandler got $throwable")
+    }
+
+    val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob() + exceptionHandler)
+
     actual open fun onCleared() {
-        // No-op
+        coroutineScope.cancel()
     }
 }
+
+actual val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope
+    get() = coroutineScope

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/iosMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/iosMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,7 +1,22 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
 actual abstract class VMDPlatformViewModelController {
+    private val exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        println("CoroutineExceptionHandler got $throwable")
+    }
+
+    val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob() + exceptionHandler)
+
     actual open fun onCleared() {
-        // No-op
+        coroutineScope.cancel()
     }
 }
+
+actual val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope
+    get() = coroutineScope

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/iosSimulatorArm64Main/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/iosSimulatorArm64Main/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,7 +1,22 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
 actual abstract class VMDPlatformViewModelController {
+    private val exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        println("CoroutineExceptionHandler got $throwable")
+    }
+
+    val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob() + exceptionHandler)
+
     actual open fun onCleared() {
-        // No-op
+        coroutineScope.cancel()
     }
 }
+
+actual val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope
+    get() = coroutineScope

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/jsMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/jsMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,7 +1,22 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
 actual abstract class VMDPlatformViewModelController {
+    private val exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        println("CoroutineExceptionHandler got $throwable")
+    }
+
+    val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob() + exceptionHandler)
+
     actual open fun onCleared() {
-        // No-op
+        coroutineScope.cancel()
     }
 }
+
+actual val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope
+    get() = coroutineScope

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/jvmMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/jvmMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,7 +1,22 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
 actual abstract class VMDPlatformViewModelController {
+    private val exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        println("CoroutineExceptionHandler got $throwable")
+    }
+
+    val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob() + exceptionHandler)
+
     actual open fun onCleared() {
-        // No-op
+        coroutineScope.cancel()
     }
 }
+
+actual val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope
+    get() = coroutineScope

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/tvosMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/tvosMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/VMDPlatformViewModelController.kt
@@ -1,7 +1,22 @@
 package com.mirego.trikot.viewmodels.declarative.controller
 
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
 actual abstract class VMDPlatformViewModelController {
+    private val exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        println("CoroutineExceptionHandler got $throwable")
+    }
+
+    val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob() + exceptionHandler)
+
     actual open fun onCleared() {
-        // No-op
+        coroutineScope.cancel()
     }
 }
+
+actual val VMDPlatformViewModelController.platformViewModelScope: CoroutineScope
+    get() = coroutineScope


### PR DESCRIPTION
## Description

VMDViewModelController on Android was managing its own coroutineScope instead of using the lifecycle provided scope.

## Motivation and Context

Ensure that a lifecycle managed scope is used on Android.

## How Has This Been Tested?

In the sample app.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Breaking change is mostly due to the renaming of the scope, to fix, rename `viewModelControllerScope` to `viewModelScope`. The new name is more consistent with what the scope does, view model controller manages the lifecycle events for the view model, providing a scope to the view model. It's therefore the scope of the view model.