### PR TITLE
Add missing lifecycle methods in ViewModelFragment

### DIFF
--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/ViewModelFragment.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/ViewModelFragment.kt
@@ -39,6 +39,16 @@ abstract class ViewModelFragment<VMC : VMDViewModelController<VM, N>, VM : VMDVi
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModelController.onAppear()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        viewModelController.onDisappear()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         viewModelController.navigationDelegate = null

--- a/trikot-viewmodels-declarative/viewmodels-declarative/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/ViewModelFragment.kt
+++ b/trikot-viewmodels-declarative/viewmodels-declarative/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/controller/ViewModelFragment.kt
@@ -39,6 +39,16 @@ abstract class ViewModelFragment<VMC : VMDViewModelController<VM, N>, VM : VMDVi
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModelController.onAppear()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        viewModelController.onDisappear()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         viewModelController.navigationDelegate = null


### PR DESCRIPTION
## Description
We override onResume() and onPause() in ViewModelFragment in order to call the matching methods on VMDViewModelController.

## Motivation and Context
The onAppear() and onDisappear() methods were not plugged in the ViewModelFragment class. They were only called in ViewModelActivity.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
