### PR TITLE
Fix kmp-boilerplate link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@
 
 ## Getting started
 
-To start a new kotlin-multiplatform project, we suggest using our _ready-to-run_ [https://github.com/mirego/kmp-boilerplate](kmp-boilerplate) template
-on which you can add all the specific dependencies you need for your project.
+To start a new Kotlin Multiplatform project, we suggest using our _ready-to-run_ [kmp-boilerplate](https://github.com/mirego/kmp-boilerplate) template on which you can add all the specific dependencies you need for your project.
 
 ### Samples
 


### PR DESCRIPTION
## Description

Our link had the content and URL parts mixed up. I also took the time to tweak the whole sentence 🙂
