### PR TITLE
[VMD-Flow] Compose: added optional support for XML Drawables and 9-patch

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -14,6 +14,7 @@ object Versions {
     const val OKIO = "3.2.0"
     const val KSP = "1.7.10-1.0.6"
     const val KOTLIN_POET = "1.12.0"
+    const val ACCOMPANIST = "0.28.0"
 
     object Android {
         const val TARGET_SDK = 33

--- a/trikot-viewmodels-declarative-flow/compose-flow/build.gradle.kts
+++ b/trikot-viewmodels-declarative-flow/compose-flow/build.gradle.kts
@@ -43,10 +43,11 @@ dependencies {
     api("androidx.compose.runtime:runtime:${Versions.JETPACK_COMPOSE}")
     api("androidx.compose.ui:ui-tooling:${Versions.JETPACK_COMPOSE}")
     api("androidx.compose.material3:material3:${Versions.JETPACK_COMPOSE_MATERIAL_3}")
-    api("androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1")
-    api("androidx.lifecycle:lifecycle-runtime-ktx:2.4.1")
+    api("androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1")
+    api("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
     api("io.coil-kt:coil-compose:${Versions.COIL}")
-
+    implementation("com.google.accompanist:accompanist-drawablepainter:${Versions.ACCOMPANIST}")
+    implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("org.jetbrains.kotlin:kotlin-reflect:${Versions.KOTLIN}")
 }
 

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ImageResourceExtensions.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ImageResourceExtensions.kt
@@ -1,13 +1,19 @@
 package com.mirego.trikot.viewmodels.declarative.compose.extensions
 
 import android.content.Context
+import android.util.TypedValue
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
+import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDeclarative
+import com.mirego.trikot.viewmodels.declarative.configuration.VMDImageProviderConfiguration.painterResourceLegacyDrawableSupport
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
 
 fun VMDImageResource.resourceId(context: Context): Int? {
     return TrikotViewModelDeclarative.imageProvider.resourceIdForResource(this, context)
@@ -18,8 +24,53 @@ fun painterResource(imageResource: VMDImageResource?): Painter {
     val context = LocalContext.current
     imageResource?.let { resource ->
         resource.resourceId(context)?.let { id ->
-            return androidx.compose.ui.res.painterResource(id = id)
+            return if (painterResourceLegacyDrawableSupport) {
+                legacyPainterResource(id, context)
+            } else {
+                androidx.compose.ui.res.painterResource(id = id)
+            }
         }
     }
     return BitmapPainter(ImageBitmap(1, 1))
 }
+
+@Composable
+private fun legacyPainterResource(id: Int, context: Context): Painter {
+    return if (isVectorResource(id, context)) {
+        // Using standard painterResource for vectors
+        androidx.compose.ui.res.painterResource(id = id)
+    } else {
+        // Using Accompanist for all other types
+        rememberDrawablePainter(AppCompatResources.getDrawable(context, id))
+    }
+}
+
+private fun isVectorResource(id: Int, context: Context): Boolean {
+    if (isXmlResource(id, context)) {
+        val parser = context.resources.getXml(id)
+        return parser.seekToStartTagInternal().name == "vector"
+    }
+    return false
+}
+
+private fun isXmlResource(id: Int, context: Context): Boolean {
+    val value = TypedValue()
+    context.resources.getValue(id, value, true)
+    return value.string?.endsWith(".xml") == true
+}
+
+/**
+ * Copied from androidx.compose.ui.graphics.vector.compat.XmlPullParser.seekToStartTag(), which is internal
+ */
+private fun XmlPullParser.seekToStartTagInternal(): XmlPullParser {
+    var type = next()
+    while (type != XmlPullParser.START_TAG && type != XmlPullParser.END_DOCUMENT) {
+        // Empty loop
+        type = next()
+    }
+    if (type != XmlPullParser.START_TAG) {
+        throw XmlPullParserException("No start tag found")
+    }
+    return this
+}
+

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProviderConfiguration.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProviderConfiguration.kt
@@ -1,0 +1,10 @@
+package com.mirego.trikot.viewmodels.declarative.configuration
+
+object VMDImageProviderConfiguration {
+    /**
+     * Setting this value to true will add support for XML Drawables (shape, layer-list, selector, etc.) and nine-patches
+     * to the supplied painterResource.
+     */
+    var painterResourceLegacyDrawableSupport = false
+}
+

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProviderConfiguration.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/androidMain/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProviderConfiguration.kt
@@ -7,4 +7,3 @@ object VMDImageProviderConfiguration {
      */
     var painterResourceLegacyDrawableSupport = false
 }
-


### PR DESCRIPTION

## Description
The default Jetpack Compose `painterResource` only handle vector drawables and rasterized assets. Attempting to use any other type of Drawable will result in this error:

```
java.lang.IllegalArgumentException: Only VectorDrawables and rasterized asset types are supported ex. PNG, JPG
  at androidx.compose.ui.res.PainterResources_androidKt.loadVectorResource(PainterResources.android.kt:94)
  at androidx.compose.ui.res.PainterResources_androidKt.painterResource(PainterResources.android.kt:65)
  at com.mirego.trikot.viewmodels.declarative.compose.extensions.ImageResourceExtensionsKt.painterResource(ImageResourceExtensions.kt:21)
```

Since our `VMDImageProvider` is generic and always uses the default `painterResource`, it is not allowed to map a `VMDImageResource` to an XML drawable or a nine-patch png.

There is now a flag to activate support for these types. It is an opt-in flag (default behavior is like before), since there may be a very slight performance impact, since we have to determine each time if the drawable is a vector or not.

This new feature relies on Google Accompanist library for the actual painter. 

## Implementation
At first look the easy solution to this problem seems to be "catch the Exception thrown and fallback to another painter when this happens. However, it is not possible to catch an Exception in a `@Composable` method. So we _have_ to detect the cases that would eventually throw the Exception before it happens. 

The method to detect resource type is largely inspired (AKA copy/pasted) from the compose `painterResource` code.

## Motivation and Context
A proper, recent declarative-based project usually never need XML drawables. But there are cases where we want to add this UI stack to an old project, and reuse the already existing image mapping. 

## How Has This Been Tested?
In a project that actually contains old XML drawables. But since this is an opt-in flag, behavior will not change for existing projects.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
