### PR TITLE
Make ContentDescription nullable on android

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -37,7 +37,7 @@ fun VMDImage(
     placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = "",
+    contentDescription: String? = null,
     allowHardware: Boolean = true,
     placeholder: @Composable ((placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, state ->
         RemoteImageDefaultPlaceholder(
@@ -78,7 +78,7 @@ fun VMDImage(
     placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = "",
+    contentDescription: String? = null,
     allowHardware: Boolean = true,
     placeholder: @Composable ((placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, state ->
         RemoteImageDefaultPlaceholder(
@@ -128,7 +128,7 @@ fun LocalImage(
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = ""
+    contentDescription: String? = null
 ) {
     Image(
         painter = painterResource(imageResource),
@@ -150,7 +150,7 @@ fun RemoteImage(
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = "",
+    contentDescription: String? = null,
     allowHardware: Boolean = true,
     asyncStateCallback: ((AsyncImagePainter.State) -> Unit)? = null
 ) {
@@ -192,7 +192,7 @@ private fun RemoteImageDefaultPlaceholder(
     modifier: Modifier = Modifier,
     contentScale: ContentScale,
     colorFilter: ColorFilter?,
-    contentDescription: String
+    contentDescription: String?
 ) {
     LocalImage(
         imageResource = imageResource,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -37,7 +37,7 @@ fun VMDImage(
     placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = "",
+    contentDescription: String? = null,
     allowHardware: Boolean = true,
     placeholder: @Composable ((placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, state ->
         RemoteImageDefaultPlaceholder(
@@ -78,7 +78,7 @@ fun VMDImage(
     placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = "",
+    contentDescription: String? = null,
     allowHardware: Boolean = true,
     placeholder: @Composable ((placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, state ->
         RemoteImageDefaultPlaceholder(
@@ -128,7 +128,7 @@ fun LocalImage(
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = ""
+    contentDescription: String? = null
 ) {
     Image(
         painter = painterResource(imageResource),
@@ -150,7 +150,7 @@ fun RemoteImage(
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     colorFilter: ColorFilter? = null,
-    contentDescription: String = "",
+    contentDescription: String? = null,
     allowHardware: Boolean = true,
     asyncStateCallback: ((AsyncImagePainter.State) -> Unit)? = null
 ) {
@@ -192,7 +192,7 @@ private fun RemoteImageDefaultPlaceholder(
     modifier: Modifier = Modifier,
     contentScale: ContentScale,
     colorFilter: ColorFilter?,
-    contentDescription: String
+    contentDescription: String?
 ) {
     LocalImage(
         imageResource = imageResource,


### PR DESCRIPTION
## Description

This change enables the developper to put nullable content descriptions for images

## Motivation and Context

Some images are not important enough to require talkback. When forcing an empty string, the talkback responds with "Unlabeled image". Using `null`, however, skips the talkback for that image

## How Has This Been Tested?

Tested using the sample with several values for contentDescription, such as "Hello", "", null. Everything works as expected

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
