### PR TITLE
iOS: Add VMDForEach and externalActionHandler on VMDButton

### DIFF
--- a/trikot-viewmodels-declarative-flow/sample/common/build.gradle.kts
+++ b/trikot-viewmodels-declarative-flow/sample/common/build.gradle.kts
@@ -37,7 +37,12 @@ kotlin {
         homepage = "www.mirego.com"
         license = "BSD-3"
         extraSpecAttributes = mutableMapOf(
-            "resources" to "\"src/commonMain/resources/translations/*\""
+            "resources" to "\"src/commonMain/resources/translations/*\"",
+            "prepare_command" to """
+                <<-CMD
+                    ../gradlew :common:generateDummyFramework
+                CMD
+            """.trimIndent()
         )
 
         framework {

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDButton+Configuration.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDButton+Configuration.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import TRIKOT_FRAMEWORK_NAME
+
+public extension VMDButton {
+    func externalActionHandler(_ action: @escaping (_ action: () -> Void) -> Void) -> VMDButton {
+        var button = self
+        button.externalActionHandler = action
+        return button
+    }
+}

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDButton.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDButton.swift
@@ -4,6 +4,8 @@ import TRIKOT_FRAMEWORK_NAME
 public struct VMDButton<Label, Content: VMDContent>: View where Label: View {
     private let labelBuilder: (Content) -> Label
 
+    var externalActionHandler: ((_ action: () -> Void) -> Void)?
+
     @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDButtonViewModel<Content>>
 
     private var viewModel: VMDButtonViewModel<Content> {
@@ -16,12 +18,18 @@ public struct VMDButton<Label, Content: VMDContent>: View where Label: View {
     }
 
     public var body: some View {
-        Button(action: {
-            self.viewModel.actionBlock()
-        }, label: {
+        Button {
+            if let externalActionHandler = externalActionHandler {
+                externalActionHandler {
+                    viewModel.actionBlock()
+                }
+            } else {
+                viewModel.actionBlock()
+            }
+        } label: {
             labelBuilder(viewModel.content)
-        })
-            .disabled(!viewModel.isEnabled)
-            .hidden(viewModel.isHidden)
+        }
+        .disabled(!viewModel.isEnabled)
+        .hidden(viewModel.isHidden)
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDForEach.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDForEach.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import TRIKOT_FRAMEWORK_NAME
+import Trikot
+
+public struct VMDForEach<RowContent, Identifiable, Content, DividerContent>: View where RowContent: View, DividerContent: View, Identifiable: VMDIdentifiableContent, Content: VMDContent {
+    private let rowContentBuilder: (Content) -> RowContent
+    private let dividedBy: () -> DividerContent
+
+    @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDListViewModel<Identifiable>>
+
+    private var viewModel: VMDListViewModel<Identifiable> {
+        observableViewModel.viewModel
+    }
+
+    public init(_ viewModel: VMDListViewModel<Identifiable>, @ViewBuilder dividedBy: @escaping () -> DividerContent, @ViewBuilder rowContentBuilder: @escaping (Content) -> RowContent) where Identifiable == Content {
+        self.observableViewModel = viewModel.asObservable()
+        self.rowContentBuilder = rowContentBuilder
+        self.dividedBy = dividedBy
+    }
+
+    public init(_ viewModel: VMDListViewModel<Identifiable>, @ViewBuilder rowContentBuilder: @escaping (Content) -> RowContent) where Identifiable == Content, DividerContent == EmptyView {
+        self.observableViewModel = viewModel.asObservable()
+        self.rowContentBuilder = rowContentBuilder
+        self.dividedBy = { EmptyView() }
+    }
+
+    public init(_ viewModel: VMDListViewModel<Identifiable>, @ViewBuilder rowContentBuilder: @escaping (Content) -> RowContent) where Identifiable: VMDIdentifiableContentAbstract<Content>, DividerContent == EmptyView {
+        self.observableViewModel = viewModel.asObservable()
+        self.rowContentBuilder = rowContentBuilder
+        self.dividedBy = { EmptyView() }
+    }
+
+    public var body: some View {
+        ForEach(viewModel.elements, id: \Identifiable.identifier) {
+            if let content = $0 as? Content {
+                rowContentBuilder(content)
+
+                if $0.identifier != viewModel.elements.last?.identifier {
+                    dividedBy()
+                }
+            }
+        }
+        .hidden(viewModel.isHidden)
+    }
+}

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDButton+Configuration.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDButton+Configuration.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import TRIKOT_FRAMEWORK_NAME
+
+public extension VMDButton {
+    func externalActionHandler(_ action: @escaping (_ action: () -> Void) -> Void) -> VMDButton {
+        var button = self
+        button.externalActionHandler = action
+        return button
+    }
+}

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDButton.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDButton.swift
@@ -4,6 +4,8 @@ import TRIKOT_FRAMEWORK_NAME
 public struct VMDButton<Label, Content: VMDContent>: View where Label: View {
     private let labelBuilder: (Content) -> Label
 
+    var externalActionHandler: ((_ action: () -> Void) -> Void)?
+
     @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDButtonViewModel<Content>>
 
     private var viewModel: VMDButtonViewModel<Content> {
@@ -16,12 +18,18 @@ public struct VMDButton<Label, Content: VMDContent>: View where Label: View {
     }
 
     public var body: some View {
-        Button(action: {
-            self.viewModel.actionBlock()
-        }, label: {
+        Button {
+            if let externalActionHandler = externalActionHandler {
+                externalActionHandler {
+                    viewModel.actionBlock()
+                }
+            } else {
+                viewModel.actionBlock()
+            }
+        } label: {
             labelBuilder(viewModel.content)
-        })
-            .disabled(!viewModel.isEnabled)
-            .hidden(viewModel.isHidden)
+        }
+        .disabled(!viewModel.isEnabled)
+        .hidden(viewModel.isHidden)
     }
 }

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDForEach.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDForEach.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import TRIKOT_FRAMEWORK_NAME
+import Trikot
+
+public struct VMDForEach<RowContent, Identifiable, Content, DividerContent>: View where RowContent: View, DividerContent: View, Identifiable: VMDIdentifiableContent, Content: VMDContent {
+    private let rowContentBuilder: (Content) -> RowContent
+    private let dividedBy: () -> DividerContent
+
+    @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDListViewModel<Identifiable>>
+
+    private var viewModel: VMDListViewModel<Identifiable> {
+        observableViewModel.viewModel
+    }
+
+    public init(_ viewModel: VMDListViewModel<Identifiable>, @ViewBuilder dividedBy: @escaping () -> DividerContent, @ViewBuilder rowContentBuilder: @escaping (Content) -> RowContent) where Identifiable == Content {
+        self.observableViewModel = viewModel.asObservable()
+        self.rowContentBuilder = rowContentBuilder
+        self.dividedBy = dividedBy
+    }
+
+    public init(_ viewModel: VMDListViewModel<Identifiable>, @ViewBuilder rowContentBuilder: @escaping (Content) -> RowContent) where Identifiable == Content, DividerContent == EmptyView {
+        self.observableViewModel = viewModel.asObservable()
+        self.rowContentBuilder = rowContentBuilder
+        self.dividedBy = { EmptyView() }
+    }
+
+    public init(_ viewModel: VMDListViewModel<Identifiable>, @ViewBuilder rowContentBuilder: @escaping (Content) -> RowContent) where Identifiable: VMDIdentifiableContentAbstract<Content>, DividerContent == EmptyView {
+        self.observableViewModel = viewModel.asObservable()
+        self.rowContentBuilder = rowContentBuilder
+        self.dividedBy = { EmptyView() }
+    }
+
+    public var body: some View {
+        ForEach(viewModel.elements, id: \Identifiable.identifier) {
+            if let content = $0 as? Content {
+                rowContentBuilder(content)
+
+                if $0.identifier != viewModel.elements.last?.identifier {
+                    dividedBy()
+                }
+            }
+        }
+        .hidden(viewModel.isHidden)
+    }
+}


### PR DESCRIPTION
## Description

**VMDForEach**
Useful when you want to display a VMDListViewModel in SwiftUI but you don't want to put it in a List (VMDList)

**New VMDButton feature**
Sometime we need to trigger some native code when a VMDButton action is triggered. The new externalActionHandler allow the caller, when the button is tapped, to do stuff before or after the VMDButton action.

PS: Modification done in VMD and VMD-flow

## Motivation and Context

I was using these 2 features in all of my projects so why not moins that in Trikot.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
