### PR TITLE
[VMD-swift] Prefixed Animation usage to avoid name clash

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Extensions/VMDAnimation+Extensions.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Extensions/VMDAnimation+Extensions.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 
 public extension VMDAnimation {
-    var animation: Animation? {
+    var animation: SwiftUI.Animation? {
         if let tweenAnimation = self as? VMDAnimationTween {
             if let standardEasing = tweenAnimation.easing as? VMDAnimationEasingStandard {
                 switch standardEasing {

--- a/trikot-viewmodels-declarative/swift/swiftui/Extensions/VMDAnimation+Extensions.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Extensions/VMDAnimation+Extensions.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 
 public extension VMDAnimation {
-    var animation: Animation? {
+    var animation: SwiftUI.Animation? {
         if let tweenAnimation = self as? VMDAnimationTween {
             if let standardEasing = tweenAnimation.easing as? VMDAnimationEasingStandard {
                 switch standardEasing {


### PR DESCRIPTION
## Description

The name `Animation` can clash with the same name from other libraries. Prefixing it to avoid clashing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
