### PR TITLE
Fix SharedProcessor interop with Flow

### DIFF
--- a/trikot-streams/coroutines-interop/src/commonTest/kotlin/kotlinx/coroutines/reactive/FlowAsPublisherTest.kt
+++ b/trikot-streams/coroutines-interop/src/commonTest/kotlin/kotlinx/coroutines/reactive/FlowAsPublisherTest.kt
@@ -5,11 +5,8 @@
 package kotlinx.coroutines.reactive
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
-import com.mirego.trikot.streams.reactive.Publishers
-import com.mirego.trikot.streams.reactive.map
 import com.mirego.trikot.streams.reactive.shared
 import com.mirego.trikot.streams.reactive.subscribe
-import kotlin.math.exp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
@@ -18,13 +15,8 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 
 class FlowAsPublisherTest : TestBase() {
     @Test
@@ -90,7 +82,6 @@ class FlowAsPublisherTest : TestBase() {
         })
         finish(3)
     }
-
 
     @Test
     fun testFlowWithSharedResultIsShared() = runTest {

--- a/trikot-streams/coroutines-interop/src/commonTest/kotlin/kotlinx/coroutines/reactive/FlowAsPublisherTest.kt
+++ b/trikot-streams/coroutines-interop/src/commonTest/kotlin/kotlinx/coroutines/reactive/FlowAsPublisherTest.kt
@@ -4,6 +4,12 @@
 
 package kotlinx.coroutines.reactive
 
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.streams.reactive.Publishers
+import com.mirego.trikot.streams.reactive.map
+import com.mirego.trikot.streams.reactive.shared
+import com.mirego.trikot.streams.reactive.subscribe
+import kotlin.math.exp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
@@ -12,6 +18,13 @@ import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectIndexed
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 class FlowAsPublisherTest : TestBase() {
     @Test
@@ -76,6 +89,23 @@ class FlowAsPublisherTest : TestBase() {
             }
         })
         finish(3)
+    }
+
+
+    @Test
+    fun testFlowWithSharedResultIsShared() = runTest {
+        val publisher = flowOf(1)
+            .map { n ->
+                expect(1)
+                n
+            }
+            .asPublisher()
+            .shared()
+
+        publisher.subscribe(CancellableManager()) {}
+        publisher.subscribe(CancellableManager()) {}
+
+        finish(2)
     }
 
     @Test

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/SharedProcessor.kt
@@ -28,7 +28,10 @@ class SharedProcessor<T>(private val parentPublisher: Publisher<T>) : BehaviorSu
         }
     }
 
-    override fun onSubscribe(s: Subscription) = with(subscriptionCancellableManager.value) { add { s.cancel() } }
+    override fun onSubscribe(s: Subscription) = with(subscriptionCancellableManager.value) {
+        add { s.cancel() }
+        s.request(Long.MAX_VALUE)
+    }
 
     override fun onNext(t: T) = let { value = t }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I had a case where this flow as publisher below wasn't emitting any values. 
```        
val publisher = flowOf(1)
    .map { n ->
            n
        }
        .asPublisher()
        .shared()

publisher.subscribe(CancellableManager()) {
   //No emmited value
}
```

Our `SharedProcessor` is a subscriber, therefore it should call `request(n: Long)` on its subscription. 

## Motivation and Context

We use a lot of interoperability between flow and publisher, and this was causing several issues with our shared publishers. 

## How Has This Been Tested?

Test has been added into `FlowAsPublisherTest` to make sure the behaviour of the `SharedProcessor` hasn't changed after the interop. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
