### PR TITLE
Apply the text transofrm also in the initial value

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDTextField.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDTextField.swift
@@ -28,14 +28,14 @@ public struct VMDTextField<Label>: View where Label: View {
         self.observableViewModel = viewModel.asObservable()
         self.labelBuilder = nil
         self.onFocusChange = onFocusChange
-        _text = State(initialValue: viewModel.text)
+        _text = State(initialValue: viewModel.transformText(viewModel.text))
     }
 
     public init(_ viewModel: VMDTextFieldViewModel, onFocusChange: ((Bool) -> Void)? = nil, @ViewBuilder label: @escaping () -> Label) {
         self.observableViewModel = viewModel.asObservable()
         self.labelBuilder = label
         self.onFocusChange = onFocusChange
-        _text = State(initialValue: viewModel.text)
+        _text = State(initialValue: viewModel.transformText(viewModel.text))
     }
 
     public var body: some View {

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDTextField.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDTextField.swift
@@ -28,14 +28,14 @@ public struct VMDTextField<Label>: View where Label: View {
         self.observableViewModel = viewModel.asObservable()
         self.labelBuilder = nil
         self.onFocusChange = onFocusChange
-        _text = State(initialValue: viewModel.text)
+        _text = State(initialValue: viewModel.transformText(viewModel.text))
     }
 
     public init(_ viewModel: VMDTextFieldViewModel, onFocusChange: ((Bool) -> Void)? = nil, @ViewBuilder label: @escaping () -> Label) {
         self.observableViewModel = viewModel.asObservable()
         self.labelBuilder = label
         self.onFocusChange = onFocusChange
-        _text = State(initialValue: viewModel.text)
+        _text = State(initialValue: viewModel.transformText(viewModel.text))
     }
 
     public var body: some View {


### PR DESCRIPTION
## Description

The initial value displayed in the SwiftUI TextField wasn't transform with the transform, now it is ! 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
