### PR TITLE
[VMD] Fix image sampling on android

### DIFF
--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -112,7 +112,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
             placeholderContentScale = ContentScale.Crop,
             placeholder = { placeholderImageResource, state ->
                 Column(
-                    modifier = imageModifier.background(Color.LightGray.copy(alpha = 0.5f)),
+                    modifier = Modifier.matchParentSize().background(Color.LightGray.copy(alpha = 0.5f)),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -3,18 +3,30 @@ package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
 import android.graphics.drawable.BitmapDrawable
 import android.util.Log
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Constraints
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
+import coil.size.Dimension
+import coil.size.Scale
 import coil.size.Size
+import coil.size.SizeResolver
 import com.mirego.trikot.viewmodels.declarative.components.VMDImageViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
@@ -24,6 +36,9 @@ import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor.Local
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageDescriptor.Remote
 import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
 
 private const val TAG = "VMDImage"
 private const val MAX_BITMAP_SIZE = 100 * 1024 * 1024 // 100 MB, taken from android.graphics.RecordingCanvas
@@ -38,11 +53,11 @@ fun VMDImage(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     allowHardware: Boolean = true,
-    placeholder: @Composable ((placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, _ ->
+    placeholder: @Composable (BoxScope.(placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, _ ->
         val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
         RemoteImageDefaultPlaceholder(
             imageResource = imageResource,
-            modifier = modifier,
+            modifier = Modifier.matchParentSize(),
             contentScale = placeholderContentScale,
             colorFilter = colorFilter,
             contentDescription = imageViewModel.contentDescription
@@ -80,7 +95,7 @@ fun VMDImage(
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
     allowHardware: Boolean = true,
-    placeholder: @Composable ((placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, _ ->
+    placeholder: @Composable (BoxScope.(placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit) = { imageResource, _ ->
         RemoteImageDefaultPlaceholder(
             imageResource = imageResource,
             modifier = modifier,
@@ -103,6 +118,7 @@ fun VMDImage(
                 contentDescription = contentDescription
             )
         }
+
         is Remote -> {
             RemoteImage(
                 modifier = modifier,
@@ -146,7 +162,7 @@ fun RemoteImage(
     modifier: Modifier = Modifier,
     imageUrl: String?,
     placeholderImage: VMDImageResource = VMDImageResource.None,
-    placeholder: @Composable ((placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit),
+    placeholder: @Composable (BoxScope.(placeholderImageResource: VMDImageResource, state: AsyncImagePainter.State) -> Unit),
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     colorFilter: ColorFilter? = null,
@@ -154,35 +170,42 @@ fun RemoteImage(
     allowHardware: Boolean = true,
     asyncStateCallback: ((AsyncImagePainter.State) -> Unit)? = null
 ) {
+    val sizeResolver = remember { ConstraintsSizeResolver() }
     val coilPainter = rememberAsyncImagePainter(
         ImageRequest.Builder(LocalContext.current)
             .data(imageUrl)
             .allowHardware(allowHardware)
-            .apply { if (imageUrl != null) size(Size.ORIGINAL) }
+            .size(sizeResolver)
+            .scale(contentScale.scale)
             .build()
     )
 
     val state = coilPainter.state
     asyncStateCallback?.invoke(state)
 
-    when (state) {
-        is AsyncImagePainter.State.Success -> {
-            val drawable = state.result.drawable
-            if (drawable !is BitmapDrawable || drawable.bitmap.allocationByteCount <= MAX_BITMAP_SIZE) {
-                Image(
-                    painter = coilPainter,
-                    modifier = modifier,
-                    alignment = alignment,
-                    colorFilter = colorFilter,
-                    contentScale = contentScale,
-                    contentDescription = contentDescription
-                )
-            } else {
-                Log.e(TAG, "Unable to load bitmap: size too large (${drawable.bitmap.allocationByteCount})")
-                placeholder(placeholderImage, state)
+    Box(
+        modifier = modifier.then(sizeResolver)
+    ) {
+        when (state) {
+            is AsyncImagePainter.State.Success -> {
+                val drawable = state.result.drawable
+                if (drawable !is BitmapDrawable || drawable.bitmap.allocationByteCount <= MAX_BITMAP_SIZE) {
+                    Image(
+                        painter = coilPainter,
+                        modifier = Modifier.matchParentSize(),
+                        alignment = alignment,
+                        colorFilter = colorFilter,
+                        contentScale = contentScale,
+                        contentDescription = contentDescription
+                    )
+                } else {
+                    Log.e(TAG, "Unable to load bitmap: size too large (${drawable.bitmap.allocationByteCount})")
+                    placeholder(placeholderImage, state)
+                }
             }
+
+            else -> placeholder(placeholderImage, state)
         }
-        else -> placeholder(placeholderImage, state)
     }
 }
 
@@ -200,5 +223,40 @@ private fun RemoteImageDefaultPlaceholder(
         colorFilter = colorFilter,
         contentScale = contentScale,
         contentDescription = contentDescription
+    )
+}
+
+private class ConstraintsSizeResolver : SizeResolver, LayoutModifier {
+
+    private val cachedConstraints = MutableStateFlow(Constraints.fixed(0, 0))
+
+    override suspend fun size() = cachedConstraints.mapNotNull(Constraints::toSizeOrNull).first()
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        cachedConstraints.value = constraints
+        
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
+}
+
+@Stable
+private val ContentScale.scale: Scale
+    get() = when(this) {
+        ContentScale.Fit, ContentScale.Inside -> Scale.FIT
+        else -> Scale.FILL
+    }
+
+@Stable
+private fun Constraints.toSizeOrNull() = when {
+    isZero -> null
+    else -> Size(
+        width = if (hasBoundedWidth) Dimension(maxWidth) else Dimension.Original,
+        height = if (hasBoundedHeight) Dimension(maxHeight) else Dimension.Original
     )
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -112,7 +112,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
             placeholderContentScale = ContentScale.Crop,
             placeholder = { placeholderImageResource, state ->
                 Column(
-                    modifier = imageModifier.background(Color.LightGray.copy(alpha = 0.5f)),
+                    modifier = Modifier.matchParentSize().background(Color.LightGray.copy(alpha = 0.5f)),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {


### PR DESCRIPTION
## Description
Since we are using coil `rememberAsyncImagePainter` instead of `AsyncImage`, we are losing a few built-in features such as sampling in the image request decoding.

This passes `size` and `scale` parameters in the image request which will later be used to calculate the sample size. The size is a `ConstraintsSizeResolver` which will passed as a modifier for contraints to be resolved. This is a similar strategy employed in coil with `AsyncImage`.

**NOTE:** The `Image` is now nested within a `Box` and takes a block with a `BoxScope` as a receiver. If you are using that, you might want to switch your placeholder modifiers to match parent `Box`.

## Motivation and Context
When large source images are provided, the image decoding could be slower and take more memory. This was due to the whole image being loaded even though the target size was be significantly smaller.

## How Has This Been Tested?
Tested both in sample app and in another app.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
