### PR TITLE
[VMD] Fix binary compatiblity with Text Component Factory

### DIFF
--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
@@ -44,7 +44,18 @@ object VMDComponents {
 
             fun withContent(
                 content: String,
-                spans: KotlinList<VMDRichTextSpan> = emptyList(),
+                coroutineScope: CoroutineScope,
+                closure: VMDTextViewModelImpl.() -> Unit = {}
+            ) =
+                VMDTextViewModelImpl(coroutineScope)
+                    .apply {
+                        text = content
+                    }
+                    .apply(closure)
+
+            fun withSpans(
+                content: String,
+                spans: KotlinList<VMDRichTextSpan>,
                 coroutineScope: CoroutineScope,
                 closure: VMDTextViewModelImpl.() -> Unit = {}
             ) =
@@ -56,6 +67,17 @@ object VMDComponents {
                     .apply(closure)
 
             fun withContent(
+                contentFlow: Flow<String>,
+                coroutineScope: CoroutineScope,
+                closure: VMDTextViewModelImpl.() -> Unit = {}
+            ) =
+                VMDTextViewModelImpl(coroutineScope)
+                    .apply {
+                        bindText(contentFlow)
+                    }
+                    .apply(closure)
+
+            fun withSpans(
                 contentFlow: Flow<String>,
                 spansFlow: Flow<KotlinList<VMDRichTextSpan>>,
                 coroutineScope: CoroutineScope,

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL.kt
@@ -30,7 +30,7 @@ interface VMDViewModelDSL {
 }
 
 fun VMDViewModelDSL.text(content: String = "", spans: List<VMDRichTextSpan> = emptyList(), closure: VMDTextViewModelImpl.() -> Unit = {}) =
-    VMDComponents.Text.withContent(content, spans, coroutineScope, closure)
+    VMDComponents.Text.withSpans(content, spans, coroutineScope, closure)
 
 fun VMDViewModelDSL.localImage(image: VMDImageResource = VMDImageResource.None, contentDescription: String? = null, closure: VMDImageViewModelImpl.() -> Unit = {}) =
     VMDComponents.Image.local(image, coroutineScope, contentDescription, closure)


### PR DESCRIPTION
## Description
Fix binary compatibility with text component factory

## Motivation and Context
The method signature changes in #149 made the API not binary compatible with the previous releases.
With a slight change, the API is now binary compatible.

## How Has This Been Tested?
Tested for binary compatibility with another project

## Note
One day we should really put some time and define the public API + validate it against https://github.com/Kotlin/binary-compatibility-validator

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
