### PR TITLE
[VMD] Bind VMDImage with coil AsyncImage when complex placeholder is not required

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutModifier
 import androidx.compose.ui.layout.Measurable
@@ -20,6 +21,7 @@ import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Constraints
+import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
@@ -42,6 +44,81 @@ import kotlinx.coroutines.flow.mapNotNull
 
 private const val TAG = "VMDImage"
 private const val MAX_BITMAP_SIZE = 100 * 1024 * 1024 // 100 MB, taken from android.graphics.RecordingCanvas
+
+@Composable
+fun VMDImage(
+    viewModel: VMDImageViewModel,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    allowHardware: Boolean = true
+) {
+    val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDImage(
+        imageDescriptor = imageViewModel.image,
+        modifier = Modifier
+            .hidden(imageViewModel.isHidden)
+            .then(modifier),
+        contentDescription = imageViewModel.contentDescription,
+        alignment = alignment,
+        onState = onState,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        allowHardware = allowHardware
+    )
+}
+
+@Composable
+fun VMDImage(
+    imageDescriptor: VMDImageDescriptor,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    alignment: Alignment = Alignment.Center,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    allowHardware: Boolean = true
+) {
+    when (imageDescriptor) {
+        is Local -> {
+            LocalImage(
+                modifier = modifier,
+                imageResource = imageDescriptor.imageResource,
+                alignment = alignment,
+                contentScale = contentScale,
+                alpha = alpha,
+                colorFilter = colorFilter,
+                contentDescription = contentDescription
+            )
+        }
+
+        is Remote -> {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(imageDescriptor.url)
+                    .allowHardware(allowHardware)
+                    .build(),
+                contentDescription = contentDescription,
+                modifier = modifier,
+                transform = imageDescriptor.placeholderImageResource
+                    .takeUnless { it == VMDImageResource.None }
+                    ?.let { transformOf(painterResource(it)) }
+                    ?: AsyncImagePainter.DefaultTransform,
+                onState = onState,
+                contentScale = contentScale,
+                alignment = alignment,
+                alpha = alpha,
+                colorFilter = colorFilter
+            )
+        }
+    }
+}
 
 @Composable
 fun VMDImage(
@@ -247,7 +324,7 @@ private class ConstraintsSizeResolver : SizeResolver, LayoutModifier {
 
 @Stable
 private val ContentScale.scale: Scale
-    get() = when(this) {
+    get() = when (this) {
         ContentScale.Fit, ContentScale.Inside -> Scale.FIT
         else -> Scale.FILL
     }
@@ -259,4 +336,15 @@ private fun Constraints.toSizeOrNull() = when {
         width = if (hasBoundedWidth) Dimension(maxWidth) else Dimension.Original,
         height = if (hasBoundedHeight) Dimension(maxHeight) else Dimension.Original
     )
+}
+
+@Stable
+private fun transformOf(
+    placeholder: Painter
+): (AsyncImagePainter.State) -> AsyncImagePainter.State = { state ->
+    when (state) {
+        is AsyncImagePainter.State.Loading -> state.copy(painter = placeholder)
+        is AsyncImagePainter.State.Error -> state.copy(painter = placeholder)
+        else -> state
+    }
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -94,8 +94,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                 .aspectRatio(imageAspectRatio)
                 .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
             viewModel = viewModel.placeholderImage,
-            contentScale = ContentScale.Crop,
-            placeholderContentScale = ContentScale.Crop
+            contentScale = ContentScale.Crop
         )
 
         ComponentShowcaseTitle(viewModel.complexPlaceholderImageTitle)
@@ -112,13 +111,17 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
             placeholderContentScale = ContentScale.Crop,
             placeholder = { placeholderImageResource, state ->
                 Column(
-                    modifier = Modifier.matchParentSize().background(Color.LightGray.copy(alpha = 0.5f)),
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(Color.LightGray.copy(alpha = 0.5f)),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     LocalImage(
                         imageResource = placeholderImageResource,
-                        modifier = Modifier.size(width = (50 * imageAspectRatio).dp, height = 50.dp).padding(bottom = 10.dp),
+                        modifier = Modifier
+                            .size(width = (50 * imageAspectRatio).dp, height = 50.dp)
+                            .padding(bottom = 10.dp),
                         contentScale = ContentScale.Crop
                     )
 

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -94,8 +94,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                 .aspectRatio(imageAspectRatio)
                 .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
             viewModel = viewModel.placeholderImage,
-            contentScale = ContentScale.Crop,
-            placeholderContentScale = ContentScale.Crop
+            contentScale = ContentScale.Crop
         )
 
         ComponentShowcaseTitle(viewModel.complexPlaceholderImageTitle)
@@ -112,13 +111,17 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
             placeholderContentScale = ContentScale.Crop,
             placeholder = { placeholderImageResource, state ->
                 Column(
-                    modifier = Modifier.matchParentSize().background(Color.LightGray.copy(alpha = 0.5f)),
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(Color.LightGray.copy(alpha = 0.5f)),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     LocalImage(
                         imageResource = placeholderImageResource,
-                        modifier = Modifier.size(width = (50 * imageAspectRatio).dp, height = 50.dp).padding(bottom = 10.dp),
+                        modifier = Modifier
+                            .size(width = (50 * imageAspectRatio).dp, height = 50.dp)
+                            .padding(bottom = 10.dp),
                         contentScale = ContentScale.Crop
                     )
 


### PR DESCRIPTION
## Description
When complex placeholder is not required, rely on AsyncImage.

Using AsyncImage from coil is more efficient at measures and drawing. When there's no need to use a complex placeholder, we use this instead of having our own rendering with rememberAsyncImagePainter.

The placeholder is handled with a painter.

## Motivation and Context
We're profiling and testing VMDImage with different Constraints. Turns out AsyncImage handles most of the constraints out of the box and is generally more efficient than we we currently have in VMD.

## How Has This Been Tested?
Tested in sample app and in another app.

Changes should be ABI compatible and no changes should be needed to use the most efficient binding.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
