### PR TITLE
Trikot VMD iOS: Update Kingfisher required version to 7.6.2

### DIFF
--- a/Trikot.podspec
+++ b/Trikot.podspec
@@ -75,7 +75,7 @@ Pod::Spec.new do |spec|
     subspec.source_files = 'trikot-viewmodels-declarative/swift/swiftui/**/*.swift'
     subspec.dependency 'Trikot/viewmodels.declarative'
     subspec.dependency 'Trikot/viewmodels.declarative.Combine'
-    subspec.dependency 'Kingfisher', '~> 7.1'
+    subspec.dependency 'Kingfisher', '~> 7.6.2'
     subspec.dependency 'Introspect', '~> 0.1'
   end
 
@@ -87,7 +87,7 @@ Pod::Spec.new do |spec|
     spec.subspec 'viewmodels.declarative.SwiftUI.flow' do |subspec|
       subspec.source_files = 'trikot-viewmodels-declarative-flow/swift/swiftui/**/*.swift'
       subspec.dependency 'Trikot/viewmodels.declarative.flow'
-      subspec.dependency 'Kingfisher', '~> 7.1'
+      subspec.dependency 'Kingfisher', '~> 7.6.2'
       subspec.dependency 'Introspect', '~> 0.1'
     end
 

--- a/trikot-viewmodels-declarative-flow/sample/ios/Podfile.lock
+++ b/trikot-viewmodels-declarative-flow/sample/ios/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - Introspect (0.1.4)
-  - Kingfisher (7.2.4)
+  - Kingfisher (7.6.2)
   - SwiftLint (0.43.1)
-  - Trikot/kword (4.2.0):
+  - Trikot/kword (4.4.0):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.flow (4.2.0):
+  - Trikot/viewmodels.declarative.flow (4.4.0):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.SwiftUI.flow (4.2.0):
+  - Trikot/viewmodels.declarative.SwiftUI.flow (4.4.0):
     - Introspect (~> 0.1)
-    - Kingfisher (~> 7.1)
+    - Kingfisher (~> 7.6.2)
     - Trikot/viewmodels.declarative.flow
     - TRIKOT_FRAMEWORK_NAME
-  - TRIKOT_FRAMEWORK_NAME (4.2.0)
+  - TRIKOT_FRAMEWORK_NAME (4.4.0)
 
 DEPENDENCIES:
   - SwiftLint
@@ -34,10 +34,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Introspect: b62c4dd2063072327c21d618ef2bedc3c87bc366
-  Kingfisher: 2457be2121734e69e54a2312ecc0150eb9ae70b3
+  Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
-  Trikot: 3cbee37c11407e001f57349cf47908e45da65636
-  TRIKOT_FRAMEWORK_NAME: 488f5da86225bb8b3efac2b78164b8dffca3faf8
+  Trikot: 1004d1cf1f8a54dc1da02e14f6c652545a9abd0c
+  TRIKOT_FRAMEWORK_NAME: cc175b65dec796b0e5e75597e4179c6c571c993f
 
 PODFILE CHECKSUM: 3ea922a40d3e15204de5e4af30076387b6e5f2c9
 

--- a/trikot-viewmodels-declarative/sample/ios/Podfile.lock
+++ b/trikot-viewmodels-declarative/sample/ios/Podfile.lock
@@ -1,32 +1,32 @@
 PODS:
   - Introspect (0.1.3)
-  - Kingfisher (7.1.2)
+  - Kingfisher (7.6.2)
   - ReachabilitySwift (5.0.0)
   - SwiftLint (0.43.1)
-  - Trikot/http (4.2.0):
+  - Trikot/http (4.4.0):
     - ReachabilitySwift (~> 5.0)
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/kword (4.2.0):
+  - Trikot/kword (4.4.0):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/streams (4.2.0):
+  - Trikot/streams (4.4.0):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative (4.2.0):
+  - Trikot/viewmodels.declarative (4.4.0):
     - Trikot/streams
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.Combine (4.2.0):
+  - Trikot/viewmodels.declarative.Combine (4.4.0):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.SwiftUI (4.2.0):
+  - Trikot/viewmodels.declarative.SwiftUI (4.4.0):
     - Introspect (~> 0.1)
-    - Kingfisher (~> 7.1)
+    - Kingfisher (~> 7.6.2)
     - Trikot/viewmodels.declarative
     - Trikot/viewmodels.declarative.Combine
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.declarative.UIKit (4.2.0):
+  - Trikot/viewmodels.declarative.UIKit (4.4.0):
     - Kingfisher (>= 5.0)
     - Trikot/streams
     - Trikot/viewmodels.declarative
     - TRIKOT_FRAMEWORK_NAME
-  - TRIKOT_FRAMEWORK_NAME (4.2.0)
+  - TRIKOT_FRAMEWORK_NAME (4.4.0)
 
 DEPENDENCIES:
   - SwiftLint
@@ -53,11 +53,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Introspect: 2be020f30f084ada52bb4387fff83fa52c5c400e
-  Kingfisher: 44ed6a8504763f27bab46163adfac83f5deb240c
+  Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
-  Trikot: 3cbee37c11407e001f57349cf47908e45da65636
-  TRIKOT_FRAMEWORK_NAME: a05aa88ba2a695bac7b741b9b54a4f1a61fc696f
+  Trikot: 1004d1cf1f8a54dc1da02e14f6c652545a9abd0c
+  TRIKOT_FRAMEWORK_NAME: 98522350bf03cb427378e654289db636afde3944
 
 PODFILE CHECKSUM: 8057f57ba2a2db77f33517422839afd5282c408e
 


### PR DESCRIPTION
## Description

Update Kingfisher required version to 7.6.2

## Motivation and Context

Kingfisher dependency now fails compilation following a Swift compiler bug fix. [Fix](https://github.com/onevcat/Kingfisher/commit/75041a4e0c6a5ac6f16e5ff7fdd975d92ec32c10)

## How Has This Been Tested?

Both VMD sample apps build and run on Xcode 14.3 RC2 (same as release).

## Types of changes

Updated a dependency

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
