### PR TITLE
[VMD-Compose] Fixed observe of a single field of a ViewModel without specifying an initial value explicitly. 

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ViewModelExtensions.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ViewModelExtensions.kt
@@ -61,7 +61,7 @@ fun <T, VM : VMDViewModel> VM.observeAsState(
     property: KProperty<T>,
     initialValue: T? = null
 ): State<T> {
-    val initial: T = initialValue ?: property.getter.call()
+    val initial: T = initialValue ?: property.getter.call(this)
     return flowForProperty(property).subscribeAsState(initial = initial, key = this)
 }
 
@@ -71,7 +71,7 @@ fun <VM : VMDViewModel, T> VM.observeAnimatedPropertyAsState(
     property: KProperty<T>,
     initialValue: T? = null
 ): State<VMDAnimatedPropertyChange<T, T>> {
-    val initial: T = (initialValue ?: property.getter.call())
+    val initial: T = (initialValue ?: property.getter.call(this))
     val initialPropertyChange = VMDAnimatedPropertyChange(initial, VMDPropertyChange(property = property, oldValue = initial, newValue = initial))
 
     return remember(this, property) {
@@ -93,7 +93,7 @@ fun <VM : VMDViewModel, T, V> VM.observeAnimatedPropertyAsState(
     initialValue: T? = null,
     transform: (T) -> V
 ): State<VMDAnimatedPropertyChange<V, T>> {
-    val initial: T = (initialValue ?: property.getter.call())
+    val initial: T = (initialValue ?: property.getter.call(this))
     val initialPropertyChange = VMDAnimatedPropertyChange(transform(initial), VMDPropertyChange(property = property, oldValue = initial, newValue = initial))
     return remember(this, property) {
         val propertyFlow = flowForProperty(property)

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ViewModelExtensions.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/ViewModelExtensions.kt
@@ -33,7 +33,7 @@ fun <T, VM : VMDViewModel> VM.observeAsState(
     property: KProperty<T>,
     initialValue: T? = null
 ): State<T> {
-    val initial: T = initialValue ?: property.getter.call()
+    val initial: T = initialValue ?: property.getter.call(this)
     return publisherForProperty(property).subscribeAsState(initial = initial, key = this)
 }
 
@@ -43,7 +43,7 @@ fun <VM : VMDViewModel, T> VM.observeAnimatedPropertyAsState(
     property: KProperty<T>,
     initialValue: T? = null
 ): State<VMDAnimatedPropertyChange<T, T>> {
-    val initial: T = (initialValue ?: property.getter.call())
+    val initial: T = (initialValue ?: property.getter.call(this))
     val initialPropertyChange = VMDAnimatedPropertyChange(initial, VMDPropertyChange(property = property, oldValue = initial, newValue = initial))
 
     val propertyPublisher = publisherForProperty(property)
@@ -71,7 +71,7 @@ fun <VM : VMDViewModel, T, V> VM.observeAnimatedPropertyAsState(
     initialValue: T? = null,
     transform: (T) -> V
 ): State<VMDAnimatedPropertyChange<V, T>> {
-    val initial: T = (initialValue ?: property.getter.call())
+    val initial: T = (initialValue ?: property.getter.call(this))
     val initialPropertyChange = VMDAnimatedPropertyChange(transform(initial), VMDPropertyChange(property = property, oldValue = initial, newValue = initial))
 
     val propertyPublisher = publisherForProperty(property)


### PR DESCRIPTION
## Description

In this case, reflection is used to call the getter. Calling it without any parameters doesn't work anymore, probably following an update of the Kotlin version at some point.
Adding the required param to the getter.


## Motivation and Context

Attempting to observe a single field without an initial value (which is optional) resulted in a crash:
```

java.lang.IllegalArgumentException: Callable expects 1 arguments, but 0 were provided.
at kotlin.reflect.jvm.internal.calls.Caller$DefaultImpls.checkArguments(Caller.kt:20)
at kotlin.reflect.jvm.internal.calls.CallerImpl.checkArguments(CallerImpl.kt:15)
at kotlin.reflect.jvm.internal.calls.CallerImpl$Method$Instance.call(CallerImpl.kt:112)
at kotlin.reflect.jvm.internal.KCallableImpl.call(KCallableImpl.kt:108)
at com.mirego.trikot.viewmodels.declarative.compose.extensions.ViewModelExtensionsKt.observeAsState(ViewModelExtensions.kt:64)
```

## How Has This Been Tested?

In a project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
