### PR TITLE
Lowering Android min SDK to 21

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,5 +9,5 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
-    implementation("com.android.tools.build:gradle:7.3.1")
+    implementation("com.android.tools.build:gradle:7.4.0")
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val KOTLIN = "1.8.10"
     const val ATOMIC_FU = "0.20.0"
-    const val ANDROID_GRADLE_PLUGIN = "7.3.1"
+    const val ANDROID_GRADLE_PLUGIN = "7.4.0"
     const val JETPACK_COMPOSE_COMPILER = "1.4.3"
     const val JETPACK_COMPOSE_RUNTIME = "1.3.3"
     const val JETPACK_COMPOSE_FOUNDATION = "1.3.1"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -23,6 +23,6 @@ object Versions {
     object Android {
         const val TARGET_SDK = 33
         const val COMPILE_SDK = 33
-        const val MIN_SDK = 24
+        const val MIN_SDK = 21
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Dec 15 11:24:02 EST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
+++ b/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
@@ -60,7 +60,7 @@ class MixpanelAnalyticsService(
     }
 
     override fun unsetSuperProperties(propertyNames: List<String>) {
-        propertyNames.iterator().forEach { name ->
+        propertyNames.forEach { name ->
             mixpanelAnalytics.unregisterSuperProperty(name)
         }
     }

--- a/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
+++ b/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
@@ -60,7 +60,7 @@ class MixpanelAnalyticsService(
     }
 
     override fun unsetSuperProperties(propertyNames: List<String>) {
-        propertyNames.forEach { name ->
+        propertyNames.iterator().forEach { name ->
             mixpanelAnalytics.unregisterSuperProperty(name)
         }
     }

--- a/trikot-viewmodels-declarative-flow/sample/android/build.gradle.kts
+++ b/trikot-viewmodels-declarative-flow/sample/android/build.gradle.kts
@@ -57,6 +57,12 @@ android {
             resources.srcDir("../common/src/commonMain/resources/")
         }
     }
+
+    lint {
+        abortOnError = true
+        checkReleaseBuilds = true
+        disable.add("NotificationPermission")
+    }
 }
 
 dependencies {

--- a/trikot-viewmodels-declarative/sample/android/build.gradle.kts
+++ b/trikot-viewmodels-declarative/sample/android/build.gradle.kts
@@ -53,6 +53,12 @@ android {
             resources.srcDir("../common/src/commonMain/resources/")
         }
     }
+
+    lint {
+        abortOnError = true
+        checkReleaseBuilds = true
+        disable.add("NotificationPermission")
+    }
 }
 
 dependencies {

--- a/trikot-viewmodels/sample/android/build.gradle.kts
+++ b/trikot-viewmodels/sample/android/build.gradle.kts
@@ -60,6 +60,7 @@ android {
     lint {
         abortOnError = true
         checkReleaseBuilds = true
+        disable.add("NotificationPermission")
     }
 }
 


### PR DESCRIPTION
## Description

Trikot should try to keep minimum android version requirements as low as possible, so that legacy projects that still use 21 as their min SDK can use it.

There is nothing in the code that actually requires a min SDK of 24.

## Motivation and Context

Some older projects still have their min SDK set at 21, and this should not prevent us from including Trikot.

## How Has This Been Tested?

Android samples are still running, all check tasks still pass, lib can be included in a 21+ project with success.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
