### PR TITLE
Deprecate com.mirego.trikot.foundation.date in favor of kotlinx-datetime

### DIFF
--- a/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.foundation.date
 
 import kotlin.time.Duration
 
+@Deprecated("Use official Kotlin library kotlinx-datetime (https://kotlinlang.org/api/kotlinx-datetime) instead")
 expect class Date {
     val epoch: Long
 

--- a/trikot-foundation/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikot-foundation/trikotFoundation/src/iosMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -10,6 +10,7 @@ import platform.Foundation.dateByAddingTimeInterval
 import platform.Foundation.timeIntervalSince1970
 import kotlin.time.Duration
 
+@Deprecated("Use official Kotlin library kotlinx-datetime (https://kotlinlang.org/api/kotlinx-datetime) instead")
 actual class Date(val nsDate: NSDate) {
     actual val epoch: Long = (nsDate.timeIntervalSince1970 * 1000).toLong()
 

--- a/trikot-foundation/trikotFoundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikot-foundation/trikotFoundation/src/jsMain/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.foundation.date
 
 import kotlin.time.Duration
 
+@Deprecated("Use official Kotlin library kotlinx-datetime (https://kotlinlang.org/api/kotlinx-datetime) instead")
 actual class Date(val date: kotlin.js.Date) {
     actual val epoch: Long = date.getTime().toLong()
 

--- a/trikot-foundation/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/date/Date.kt
+++ b/trikot-foundation/trikotFoundation/src/jvmShared/kotlin/com/mirego/trikot/foundation/date/Date.kt
@@ -11,6 +11,7 @@ private val dateFormat =
     DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
         .withZone(ZoneOffset.UTC)
 
+@Deprecated("Use official Kotlin library kotlinx-datetime (https://kotlinlang.org/api/kotlinx-datetime) instead")
 actual class Date(val instant: Instant) {
     actual val epoch: Long
         get() {


### PR DESCRIPTION
Deprecate `com.mirego.trikot.foundation.date` in favor of [`kotlinx-datetime`](https://kotlinlang.org/api/kotlinx-datetime)

## Description, Motivation and Context

As `com.mirego.trikot.foundation.date` doesn't offer much flexibility and we don't we to recreate the official Kotlin library, we recommend to use [`kotlinx-datetime`](https://kotlinlang.org/api/kotlinx-datetime)

### References: 

See Mirego Slack discussions:
* [#Trikot](https://mirego.slack.com/archives/CK4CXSXLM/p1682591710066669)
* [#Kotlin](https://mirego.slack.com/archives/C5B1UTKUH/p1682545911551079)

## How Has This Been Tested?

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
