### PR TITLE
[TrikotHttp] cachePolicy and followRedirects values were lost in HttpRequestPublisher

### DIFF
--- a/trikot-http/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/HttpRequestPublisher.kt
+++ b/trikot-http/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/HttpRequestPublisher.kt
@@ -88,6 +88,8 @@ abstract class HttpRequestPublisher<T>(
             it.method = builder.method
             it.timeout = builder.timeout
             it.parameters = builder.parameters
+            it.cachePolicy = builder.cachePolicy
+            it.followRedirects = builder.followRedirects
         }
     }
 }


### PR DESCRIPTION
## Description

In TrikotHttp, when using HttpRequestPublisher the values of cachePolicy and followRedirects were always fallback back to the default values.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
