### PR TITLE
Bump node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 10.17.x
+          node-version: 18
 
       - name: Run prettier
         run: npx prettier --check .


### PR DESCRIPTION
## Description
This updates the node action and bump the version to 18

## Motivation and Context
Prettier needed a more recent version

## How Has This Been Tested?
If CI passes, it's fine.
