### PR TITLE
iOS: Make `VMDForEach` conform to `DynamicViewContent`

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDForEach.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDForEach.swift
@@ -2,11 +2,15 @@ import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 import Trikot
 
-public struct VMDForEach<RowContent, Identifiable, Content, DividerContent>: View where RowContent: View, DividerContent: View, Identifiable: VMDIdentifiableContent, Content: VMDContent {
+public struct VMDForEach<RowContent, Identifiable, Content, DividerContent>: DynamicViewContent where RowContent: View, DividerContent: View, Identifiable: VMDIdentifiableContent, Content: VMDContent {
     private let rowContentBuilder: (Content) -> RowContent
     private let dividedBy: () -> DividerContent
 
     @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDListViewModel<Identifiable>>
+
+    public var data: [VMDIdentifiableContent] {
+        viewModel.elements
+    }
 
     private var viewModel: VMDListViewModel<Identifiable> {
         observableViewModel.viewModel

--- a/trikot-viewmodels-declarative/swift/swiftui/Components/VMDForEach.swift
+++ b/trikot-viewmodels-declarative/swift/swiftui/Components/VMDForEach.swift
@@ -2,11 +2,15 @@ import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 import Trikot
 
-public struct VMDForEach<RowContent, Identifiable, Content, DividerContent>: View where RowContent: View, DividerContent: View, Identifiable: VMDIdentifiableContent, Content: VMDContent {
+public struct VMDForEach<RowContent, Identifiable, Content, DividerContent>: DynamicViewContent where RowContent: View, DividerContent: View, Identifiable: VMDIdentifiableContent, Content: VMDContent {
     private let rowContentBuilder: (Content) -> RowContent
     private let dividedBy: () -> DividerContent
 
     @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDListViewModel<Identifiable>>
+
+    public var data: [VMDIdentifiableContent] {
+        viewModel.elements
+    }
 
     private var viewModel: VMDListViewModel<Identifiable> {
         observableViewModel.viewModel


### PR DESCRIPTION
iOS `VMDForEach` conformance change.

## Description

`DynamicViewContent` is a SwiftUI protocol introduced in iOS 13. It is documented as:

> A type of view that generates views from an underlying collection of data.

Making `VMDForEach` conform to `DynamicViewContent` enables access to the following SwiftUI APIs:

- `func onDelete(perform: Optional<(IndexSet) -> Void>) -> some DynamicViewContent`
- `func onInsert(of: [UTType], perform: (Int, [NSItemProvider]) -> Void) -> some DynamicViewContent`
- `func onMove(perform: Optional<(IndexSet, Int) -> Void>) -> some DynamicViewContent`

[API Documentation](https://developer.apple.com/documentation/swiftui/dynamicviewcontent)

Its sole requirement is exposing a public [data property](https://developer.apple.com/documentation/swiftui/dynamicviewcontent).

## Motivation and Context

This enables access to the SwiftUI APIs listed above. In our case, access to `onDelete` was desired in order to support iOS's default swipe to delete.

## How Has This Been Tested?

- `VMDForEach` continues producing views for all of its elements.
- The `HomeViewModel` implementation was modified locally to add a `fun removeItemAt(index: Int)` method.
- I was able to remove `HomeViewModel` entries from the list by performing a swipe gesture. See the video.
- This was done on both `trikot-viewmodels-declarative` and `trikot-viewmodels-declarative-flow`

https://github.com/mirego/trikot/assets/2136338/2e1675f6-cc1b-48cb-a736-007578dfbe40

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
