### PR TITLE
[VMD-Flow Android] Add toggleable to VMDCheckbox and VMDSwitch

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxColors
 import androidx.compose.material.CheckboxDefaults
@@ -10,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import com.mirego.trikot.viewmodels.declarative.components.VMDToggleViewModel
 import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
@@ -50,16 +52,22 @@ fun <C : VMDContent> VMDCheckbox(
     val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDLabeledComponent(
-        modifier = modifier.vmdModifier(toggleViewModel),
+        modifier = modifier
+            .toggleable(
+                value = toggleViewModel.isOn,
+                role = Role.Checkbox,
+                onValueChange = { checked -> viewModel.onValueChange(checked) },
+            )
+            .vmdModifier(toggleViewModel),
         label = { label(toggleViewModel.label) },
         content = {
             Checkbox(
-                onCheckedChange = { checked -> viewModel.onValueChange(checked) },
+                onCheckedChange = null,
                 modifier = componentModifier,
                 enabled = toggleViewModel.isEnabled,
                 checked = toggleViewModel.isOn,
                 interactionSource = interactionSource,
-                colors = colors
+                colors = colors,
             )
         }
     )

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Switch
 import androidx.compose.material.SwitchColors
 import androidx.compose.material.SwitchDefaults
@@ -10,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import com.mirego.trikot.viewmodels.declarative.components.VMDToggleViewModel
 import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
@@ -33,6 +35,7 @@ fun VMDSwitch(
         componentModifier = componentModifier,
         viewModel = viewModel,
         label = {},
+        interactionSource = interactionSource,
         colors = colors
     )
 }
@@ -49,7 +52,13 @@ fun <C : VMDContent> VMDSwitch(
     val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDLabeledComponent(
-        modifier = modifier.vmdModifier(toggleViewModel),
+        modifier = modifier
+            .toggleable(
+                value = toggleViewModel.isOn,
+                role = Role.Switch,
+                onValueChange = { checked -> viewModel.onValueChange(checked) },
+            )
+            .vmdModifier(toggleViewModel),
         label = { label(toggleViewModel.label) },
         content = {
             Switch(
@@ -58,7 +67,7 @@ fun <C : VMDContent> VMDSwitch(
                 checked = toggleViewModel.isOn,
                 colors = colors,
                 interactionSource = interactionSource,
-                onCheckedChange = { checked -> viewModel.onValueChange(checked) }
+                onCheckedChange = null
             )
         }
     )


### PR DESCRIPTION
## Description
Toggleable semantic was added to the parent composable (VMDLabeledComponent) in order to make the whole component tappable and selectable via TalkBack.

## Motivation and Context
This change was done to properly support A11y talkback on VMDToggleButton.

## How Has This Been Tested?
In sample app

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
