### PR TITLE
Bind VMDPickerViewModel to Picker swiftUI

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDPicker.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDPicker.swift
@@ -34,5 +34,6 @@ public struct VMDPicker<Label, Content: VMDContent>: View where Label: View {
                     .tag(index)
             }
         }
+        .vmdModifier(viewModel)
     }
 }


### PR DESCRIPTION
## Description

Add missing binding of the Picker component in SwiftUI

## Motivation and Context

Add missing binding from #170 
<!--- Why is those changes required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Within the demo app

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
