### PR TITLE
[Kword-plugin] Update kotlin poet to latest + fix code generation

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -17,7 +17,7 @@ object Versions {
     const val ANDROIDX_LIFECYCLE = "2.6.0-rc01"
     const val OKIO = "3.2.0"
     const val KSP = "1.8.10-1.0.9"
-    const val KOTLIN_POET = "1.12.0"
+    const val KOTLIN_POET = "1.14.2"
     const val ACCOMPANIST = "0.28.0"
 
     object Android {

--- a/trikot-kword/kword-plugin/build.gradle.kts
+++ b/trikot-kword/kword-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ java {
 dependencies {
     implementation(gradleApi())
     implementation(localGroovy())
-    implementation("com.squareup:kotlinpoet:1.6.0")
+    implementation("com.squareup:kotlinpoet:${Versions.KOTLIN_POET}")
 }
 
 tasks {

--- a/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
+++ b/trikot-kword/kword-plugin/src/main/groovy/com/mirego/kword/KWordEnumGenerate.groovy
@@ -26,10 +26,10 @@ class KWordEnumGenerate extends DefaultTask {
         TypeSpec.enumBuilder(generatedClassName)
             .primaryConstructor(
                 FunSpec.constructorBuilder()
-                    .addParameter("translationKey", KOTLIN_STRING, KModifier.OVERRIDE)
+                    .addParameter("translationKey", KOTLIN_STRING)
                     .build())
             .addProperty(
-                PropertySpec.builder("translationKey", KOTLIN_STRING)
+                PropertySpec.builder("translationKey", KOTLIN_STRING, KModifier.OVERRIDE)
                     .initializer("translationKey")
                     .build())
             .addSuperinterface(ClassName.bestGuess('com.mirego.trikot.kword.KWordKey'), CodeBlock.EMPTY)


### PR DESCRIPTION
## Description
Fix issue with kotlin poet recent versions which no longer accept override modifier on the constructor parameter, which is legit. We move it to the property which result in the same generated code.

## Motivation and Context
Fixes https://github.com/mirego/trikot/issues/174

## How Has This Been Tested?
Was able to reproduce locally with kotlin poet latest version, validated the fix too.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
