### PR TITLE
[trikot-viewmodels-declarative-flow] Fix crash in FlowExtensions wrap method

### DIFF
--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/extension/FlowExtensions.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/extension/FlowExtensions.kt
@@ -20,7 +20,7 @@ fun interface Closeable {
     fun close()
 }
 
-class VMDFlow<T : Any> internal constructor(
+class VMDFlow<T : Any?> internal constructor(
     private val origin: Flow<T>,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
 ) : Flow<T> by origin {
@@ -35,7 +35,7 @@ class VMDFlow<T : Any> internal constructor(
     }
 }
 
-fun <T : Any> Flow<T>.wrap(): VMDFlow<T> = VMDFlow(this)
+fun <T : Any?> Flow<T>.wrap(): VMDFlow<T> = VMDFlow(this)
 
 fun Flow<String>.asVMDTextContent(): Flow<VMDTextContent> = flow {
     this@asVMDTextContent.collect { emit(VMDTextContent(it)) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix a crash that could occurred on iOS with the FlowExtensions wrap method if the flow value type is nullable.

In order to fix that, we add support for nullable type.

## Motivation and Context

<!--- Why is those changes required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To fix a crash on iOS.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
