### PR TITLE
Dispatch Android Lifecycle addObserver and removeObserver on main thread

### DIFF
--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/lifecycle/ApplicationStatePublisher.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.UIThreadDispatchQueue
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 import org.reactivestreams.Publisher
 
@@ -21,11 +22,17 @@ actual class ApplicationStatePublisher :
 
     override fun onFirstSubscription() {
         super.onFirstSubscription()
-        lifecycle.addObserver(this)
+
+        UIThreadDispatchQueue().dispatch {
+            lifecycle.addObserver(this)
+        }
     }
 
     override fun onNoSubscription() {
-        lifecycle.removeObserver(this)
+        UIThreadDispatchQueue().dispatch {
+            lifecycle.removeObserver(this)
+        }
+
         super.onNoSubscription()
     }
 


### PR DESCRIPTION
## Description

Android `Lifecycle::addObserver` and `Lifecycle::removeObserver` should only be called on the main thread, this PR makes sure that these functions are always called on the main thread.

## Motivation and Context

This was somewhat unclear in Trikot and could cause crashes in apps subscribing to the ApplicationStatePublisher when subscribing/unsubscribing. Trikot should make sure that these functions are called from the main thread.

## How Has This Been Tested?

Tested in my application.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
