### PR TITLE
[ViewModels] Fix binary compatibility with viewmodels

### DIFF
--- a/trikot-viewmodels/viewmodels/build.gradle.kts
+++ b/trikot-viewmodels/viewmodels/build.gradle.kts
@@ -72,7 +72,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.mirego.trikot.viewmodels"
+    namespace = "com.mirego.trikot.viewmodels.android"
     defaultConfig {
         compileSdk = Versions.Android.COMPILE_SDK
         minSdk = Versions.Android.MIN_SDK

--- a/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/InputTextViewModelBinder.kt
+++ b/trikot-viewmodels/viewmodels/src/androidMain/kotlin/com/mirego/trikot/viewmodels/InputTextViewModelBinder.kt
@@ -20,6 +20,7 @@ import androidx.databinding.BindingAdapter
 import androidx.databinding.adapters.ListenerUtil
 import com.mirego.trikot.streams.reactive.just
 import com.mirego.trikot.streams.reactive.observe
+import com.mirego.trikot.viewmodels.android.R
 import com.mirego.trikot.viewmodels.mutable.MutableInputTextViewModel
 import com.mirego.trikot.viewmodels.properties.Color
 import com.mirego.trikot.viewmodels.properties.InputTextType


### PR DESCRIPTION
## Description
Fix binary compatibility with viewmodels that was broken in #177
The R class and databinding class was generated in package `com.mirego.trikot.viewmodels` instead of `com.mirego.trikot.viewmodels.android`

## Motivation and Context
We want to preserve binary compatibility

## How Has This Been Tested?
Opened the jar file. But we really need to add binary compatibility checks.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
