### PR TITLE
[streams-interop] Bump kotlinx.coroutines to 1.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <p>Trikot is a framework that helps building Kotlin Multiplatform applications.<br />iOS, Android and Web are the primary targets.</p>
   <a href="https://github.com/mirego/trikot/tags"><img src="https://img.shields.io/github/tag/mirego/trikot.svg?label=latest%20release"></a>
   <img src="https://img.shields.io/maven-metadata/v?label=latest%20dev&metadataUrl=https%3A%2F%2Fmirego-maven.s3.amazonaws.com%2Fpublic%2Fcom%2Fmirego%2Ftrikot%2FtrikotFoundation%2Fmaven-metadata.xml" />
-  <a href="http://kotlinlang.org"><img src="https://img.shields.io/badge/kotlin-1.8.10-blue.svg?logo=kotlin" /></a>
+  <a href="http://kotlinlang.org"><img src="https://img.shields.io/badge/kotlin-1.8.22-blue.svg?logo=kotlin" /></a>
   <a href="https://github.com/mirego/trikot/actions/workflows/ci.yml"><img src="https://github.com/mirego/trikot/actions/workflows/ci.yml/badge.svg" /></a>
   <a href="https://github.com/mirego/trikot/actions/workflows/cd.yml"><img src="https://github.com/mirego/trikot/actions/workflows/cd.yml/badge.svg" /></a>
   <a href="https://opensource.org/licenses/BSD-3-Clause"><img src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg" /></a>

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -11,7 +11,7 @@ object Versions {
     const val COIL = "2.0.0-rc03"
     const val KTLINT = "11.3.2"
     const val KOTLINX_SERIALIZATION = "1.5.0"
-    const val KOTLINX_COROUTINES = "1.6.4"
+    const val KOTLINX_COROUTINES = "1.7.3"
     const val KTOR = "2.0.3"
     const val KOTLIN_WRAPPERS_EXTENSIONS = "1.0.1-pre.459"
     const val ANDROIDX_LIFECYCLE = "2.6.0-rc01"

--- a/trikot-streams/coroutines-interop/src/commonMain/kotlin/kotlinx/coroutines/reactive/Await.kt
+++ b/trikot-streams/coroutines-interop/src/commonMain/kotlin/kotlinx/coroutines/reactive/Await.kt
@@ -2,7 +2,6 @@
  * Copyright 2016-2021 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
-
 package kotlinx.coroutines.reactive
 
 import kotlinx.atomicfu.locks.SynchronizedObject

--- a/trikot-streams/coroutines-interop/src/commonMain/kotlin/kotlinx/coroutines/reactive/Publish.kt
+++ b/trikot-streams/coroutines-interop/src/commonMain/kotlin/kotlinx/coroutines/reactive/Publish.kt
@@ -72,11 +72,9 @@ class PublisherCoroutine<in T>(
     parentContext: CoroutineContext,
     private val subscriber: Subscriber<T>,
     private val exceptionOnCancelHandler: (Throwable, CoroutineContext) -> Unit
-) : AbstractCoroutine<Unit>(parentContext, false, true), ProducerScope<T>, Subscription, SelectClause2<T, SendChannel<T>> {
+) : AbstractCoroutine<Unit>(parentContext, false, true), ProducerScope<T>, Subscription {
     override val channel: SendChannel<T> get() = this
 
-    // Mutex is locked when either nRequested == 0 or while subscriber.onXXX is being invoked
-    private val mutex = Mutex(locked = true)
     private val _nRequested = atomic(0L) // < 0 when closed (CLOSED or SIGNALLED)
 
     @Volatile
@@ -86,6 +84,42 @@ class PublisherCoroutine<in T>(
     override fun close(cause: Throwable?): Boolean = cancelCoroutine(cause)
     override fun invokeOnClose(handler: (Throwable?) -> Unit): Nothing =
         throw UnsupportedOperationException("PublisherCoroutine doesn't support invokeOnClose")
+
+    // Mutex is locked when either nRequested == 0 or while subscriber.onXXX is being invoked
+    private val mutex: Mutex = Mutex(locked = true)
+
+    @Suppress("UNCHECKED_CAST", "INVISIBLE_MEMBER")
+    override val onSend: SelectClause2<T, SendChannel<T>> get() = SelectClause2Impl(
+        clauseObject = this,
+        regFunc = PublisherCoroutine<*>::registerSelectForSend as RegistrationFunction,
+        processResFunc = PublisherCoroutine<*>::processResultSelectSend as ProcessResultFunction
+    )
+
+    @Suppress("UNCHECKED_CAST", "UNUSED_PARAMETER")
+    private fun registerSelectForSend(select: SelectInstance<*>, element: Any?) {
+        // Try to acquire the mutex and complete in the registration phase.
+        if (mutex.tryLock()) {
+            select.selectInRegistrationPhase(Unit)
+            return
+        }
+        // Start a new coroutine that waits for the mutex, invoking `trySelect(..)` after that.
+        // Please note that at the point of the `trySelect(..)` invocation the corresponding
+        // `select` can still be in the registration phase, making this `trySelect(..)` bound to fail.
+        // In this case, the `onSend` clause will be re-registered, which alongside with the mutex
+        // manipulation makes the resulting solution obstruction-free.
+        launch {
+            mutex.lock()
+            if (!select.trySelect(this@PublisherCoroutine, Unit)) {
+                mutex.unlock()
+            }
+        }
+    }
+
+    @Suppress("RedundantNullableReturnType", "UNUSED_PARAMETER", "UNCHECKED_CAST")
+    private fun processResultSelectSend(element: Any?, selectResult: Any?): Any? {
+        doLockedNext(element as T)?.let { throw it }
+        return this@PublisherCoroutine
+    }
 
     override fun trySend(element: T): ChannelResult<Unit> =
         if (!mutex.tryLock()) {
@@ -97,32 +131,9 @@ class PublisherCoroutine<in T>(
             }
         }
 
-    override suspend fun send(element: T) {
+    public override suspend fun send(element: T) {
         mutex.lock()
         doLockedNext(element)?.let { throw it }
-    }
-
-    override val onSend: SelectClause2<T, SendChannel<T>>
-        get() = this
-
-    // registerSelectSend
-    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
-    override fun <R> registerSelectClause2(select: SelectInstance<R>, element: T, block: suspend (SendChannel<T>) -> R) {
-        val clause = suspend {
-            doLockedNext(element)?.let { throw it }
-            block(this)
-        }
-
-        launch(start = CoroutineStart.UNDISPATCHED) {
-            mutex.lock()
-            // Already selected -- bail out
-            if (!select.trySelect()) {
-                mutex.unlock()
-                return@launch
-            }
-
-            clause.startCoroutineCancellable(select.completion)
-        }
     }
 
     /*
@@ -217,7 +228,7 @@ class PublisherCoroutine<in T>(
          * We have to recheck `isCompleted` after `unlock` anyway.
          */
         mutex.unlock()
-        // check isCompleted and and try to regain lock to signal completion
+        // check isCompleted and try to regain lock to signal completion
         if (isCompleted && mutex.tryLock()) {
             doLockedSignalCompleted(completionCause, completionCauseHandled)
         }

--- a/trikot-streams/coroutines-interop/src/commonMain/kotlin/kotlinx/coroutines/reactive/Publish.kt
+++ b/trikot-streams/coroutines-interop/src/commonMain/kotlin/kotlinx/coroutines/reactive/Publish.kt
@@ -131,7 +131,7 @@ class PublisherCoroutine<in T>(
             }
         }
 
-    public override suspend fun send(element: T) {
+    override suspend fun send(element: T) {
         mutex.lock()
         doLockedNext(element)?.let { throw it }
     }

--- a/trikot-streams/coroutines-interop/src/commonTest/kotlin/kotlinx/coroutines/reactive/AwaitCancellationStressTest.kt
+++ b/trikot-streams/coroutines-interop/src/commonTest/kotlin/kotlinx/coroutines/reactive/AwaitCancellationStressTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+package kotlinx.coroutines.reactive
+
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscription
+import kotlin.test.Test
+
+/**
+ * This test checks implementation of rule 2.7 for await methods - serial execution of subscription methods
+ */
+class AwaitCancellationStressTest : TestBase() {
+    private val iterations = 10_000 * stressTestMultiplier
+
+    @Test
+    fun testAwaitCancellationOrder() = runTest {
+        repeat(iterations) {
+            val job = launch(Dispatchers.Default) {
+                testPublisher().awaitFirst()
+            }
+            job.cancelAndJoin()
+        }
+    }
+
+    private fun testPublisher() = Publisher { s ->
+        val lock = reentrantLock()
+        s.onSubscribe(object : Subscription {
+            override fun request(n: Long) {
+                check(lock.tryLock())
+                s.onNext(42)
+                lock.unlock()
+            }
+
+            override fun cancel() {
+                check(lock.tryLock())
+                lock.unlock()
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Description
Bump kotlinx.coroutines to 1.7.3
Cherry pick relevant changes from jetbrains upstreams reactive sources.

Note: 1.6.4 and 1.7.3 are incompatible due to internal `LinkedListChannel` having been removed but this should be invisible to consumers of the lib.

## Motivation and Context
Keeping things up to date.

## How Has This Been Tested?
Via Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
