### PR TITLE
VMDFlow declaration change and optional values handling on iOS

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/core/VMDFlowUtils.swift
+++ b/trikot-viewmodels-declarative-flow/swift/core/VMDFlowUtils.swift
@@ -2,7 +2,7 @@ import Foundation
 import TRIKOT_FRAMEWORK_NAME
 
 public class ObservableFlowWrapper<T: AnyObject>: ObservableObject {
-    @Published public var value: T
+    @Published public var value: T?
     
     private var watcher: Closeable?
     

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/Snackbar/VMDSnackBarStateObject.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/Snackbar/VMDSnackBarStateObject.swift
@@ -11,19 +11,23 @@ public class VMDSnackBarStateObject: ObservableObject {
 
     public func startWatching(_ flow: VMDFlow<VMDSnackbarViewData>) {
         flow.watch { [weak self] viewData, closeable in
-            self?.message = viewData?.message ?? ""
-            self?.duration = viewData?.duration.toTimeInterval() ?? VMDSnackbarDuration.short_.toTimeInterval()
-            self?.isVisible = true
-            self?.withDismissAction = viewData?.withDismissAction ?? true
+            guard let self else { return }
 
-            if self?.closeableExecuter == nil {
-                self?.closeableExecuter = VMDCloseableExecuter(closeable: closeable)
+            if self.closeableExecuter == nil {
+                self.closeableExecuter = VMDCloseableExecuter(closeable: closeable)
             }
 
-            guard viewData?.duration != VMDSnackbarDuration.indefinite, let duration = self?.duration else { return }
+            guard let viewData else { return }
 
-            let delayTime = DispatchTime.now() + duration
-            DispatchQueue.main.asyncAfter(deadline: delayTime) {
+            self.message = viewData.message
+            self.duration = viewData.duration.toTimeInterval()
+            self.isVisible = true
+            self.withDismissAction = viewData.withDismissAction
+
+            guard viewData.duration != VMDSnackbarDuration.indefinite else { return }
+
+            let delayTime = DispatchTime.now() + self.duration
+            DispatchQueue.main.asyncAfter(deadline: delayTime) { [weak self] in
                 self?.isVisible = false
             }
         }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/Snackbar/VMDSnackBarStateObject.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/Snackbar/VMDSnackBarStateObject.swift
@@ -11,16 +11,16 @@ public class VMDSnackBarStateObject: ObservableObject {
 
     public func startWatching(_ flow: VMDFlow<VMDSnackbarViewData>) {
         flow.watch { [weak self] viewData, closeable in
-            self?.message = viewData.message
-            self?.duration = viewData.duration.toTimeInterval()
+            self?.message = viewData?.message ?? ""
+            self?.duration = viewData?.duration.toTimeInterval() ?? VMDSnackbarDuration.short_.toTimeInterval()
             self?.isVisible = true
-            self?.withDismissAction = viewData.withDismissAction
+            self?.withDismissAction = viewData?.withDismissAction ?? true
 
             if self?.closeableExecuter == nil {
                 self?.closeableExecuter = VMDCloseableExecuter(closeable: closeable)
             }
 
-            guard viewData.duration != VMDSnackbarDuration.indefinite, let duration = self?.duration else { return }
+            guard viewData?.duration != VMDSnackbarDuration.indefinite, let duration = self?.duration else { return }
 
             let delayTime = DispatchTime.now() + duration
             DispatchQueue.main.asyncAfter(deadline: delayTime) {

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Utilities/ObservableViewModelAdapter.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Utilities/ObservableViewModelAdapter.swift
@@ -10,7 +10,7 @@ public class ObservableViewModelAdapter<VM: VMDViewModel>: ObservableObject {
         self.viewModel = viewModel
         viewModel.propertyWillChange.watch { [weak self] propertyChange, closeable in
             self?.closeable = closeable
-            if let propertyChangeAnimation = propertyChange.animation {
+            if let propertyChangeAnimation = propertyChange?.animation {
                 withAnimation(propertyChangeAnimation.animation) {
                     self?.objectWillChange.send()
                 }

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/extension/FlowExtensions.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/extension/FlowExtensions.kt
@@ -20,7 +20,7 @@ fun interface Closeable {
     fun close()
 }
 
-class VMDFlow<T : Any?> internal constructor(
+class VMDFlow<out T> internal constructor(
     private val origin: Flow<T>,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
 ) : Flow<T> by origin {
@@ -35,7 +35,7 @@ class VMDFlow<T : Any?> internal constructor(
     }
 }
 
-fun <T : Any?> Flow<T>.wrap(): VMDFlow<T> = VMDFlow(this)
+fun <T> Flow<T>.wrap(): VMDFlow<T> = VMDFlow(this)
 
 fun Flow<String>.asVMDTextContent(): Flow<VMDTextContent> = flow {
     this@asVMDTextContent.collect { emit(VMDTextContent(it)) }


### PR DESCRIPTION
## Description

Tag `5.0.0-dev2660` introduced a breaking change to `VMDFlow` for iOS apps.

The generated Objective-C header for VMDFlow's watchBlock method now always specifies that the value argument is an optional:

```
- (void)watchBlock:(void (^)(T _Nullable, id<PREFIXCloseable>))block __attribute__((swift_name("watch(block:)")));
```

This PR:

- Changes VMDFlow's kotlin signature from `class VMDFlow<T : Any?>` to `class VMDFlow<out T>`
- Fixes trikot-viewmodels-declarative-flow swift files to account for this change.
- **It does not remove the nullability of watched values.**

## Motivation and Context

Fixes compilation issues on iOS apps.

## How Has This Been Tested?

Changes were built locally and tested against a production project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
