### PR TITLE
[VMD] VMDButton button role on Android

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import com.mirego.trikot.viewmodels.declarative.components.VMDButtonViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
@@ -25,6 +26,7 @@ fun <C : VMDContent> VMDButton(
     propagateMinConstraints: Boolean = false,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     indication: Indication? = rememberRipple(),
+    role: Role? = Role.Button,
     content: @Composable (BoxScope.(field: C) -> Unit)
 ) {
     val buttonViewModel: VMDButtonViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
@@ -35,7 +37,8 @@ fun <C : VMDContent> VMDButton(
                 enabled = buttonViewModel.isEnabled,
                 onClick = viewModel.actionBlock,
                 interactionSource = interactionSource,
-                indication = indication
+                indication = indication,
+                role = role
             ),
         contentAlignment = contentAlignment,
         propagateMinConstraints = propagateMinConstraints,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import com.mirego.trikot.viewmodels.declarative.components.VMDButtonViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
@@ -25,6 +26,7 @@ fun <C : VMDContent> VMDButton(
     propagateMinConstraints: Boolean = false,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     indication: Indication? = rememberRipple(),
+    role: Role? = Role.Button,
     content: @Composable (BoxScope.(field: C) -> Unit)
 ) {
     val buttonViewModel: VMDButtonViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
@@ -37,7 +39,8 @@ fun <C : VMDContent> VMDButton(
                 enabled = buttonViewModel.isEnabled,
                 onClick = viewModel.actionBlock,
                 interactionSource = interactionSource,
-                indication = indication
+                indication = indication,
+                role = role
             ),
         contentAlignment = contentAlignment,
         propagateMinConstraints = propagateMinConstraints,


### PR DESCRIPTION
## Description
Assign Role.Button semantics by default for VMDButton and allow customization

## Motivation and Context
On android, VMDButton implementation uses a Box and a clickable modifier. By default the role on the clickable modifier is null (no role). This will give Button role to all VMDButton by default and allow to override it if needed instead of the contrary (needing to set Button role each time).

## How Has This Been Tested?
In sample

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
