### PR TITLE
VMDViewModel Flow: Fix Swift isHidden binding

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDButton.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDButton.swift
@@ -30,6 +30,6 @@ public struct VMDButton<Label, Content: VMDContent>: View where Label: View {
             labelBuilder(viewModel.content)
         }
         .disabled(!viewModel.isEnabled)
-        .vmdModifier(viewModel)
+        .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDForEach.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDForEach.swift
@@ -44,6 +44,6 @@ public struct VMDForEach<RowContent, Identifiable, Content, DividerContent>: Dyn
                 }
             }
         }
-        .vmdModifier(viewModel)
+        .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDList.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDList.swift
@@ -28,6 +28,6 @@ public struct VMDList<RowContent, Identifiable, Content>: View where RowContent:
                 rowContentBuilder(content)
             }
         }
-        .vmdModifier(viewModel)
+        .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDPicker.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDPicker.swift
@@ -34,6 +34,6 @@ public struct VMDPicker<Label, Content: VMDContent>: View where Label: View {
                     .tag(index)
             }
         }
-        .vmdModifier(viewModel)
+        .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDProgressView.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDProgressView.swift
@@ -17,22 +17,22 @@ public struct VMDProgressView<Label, CurrentValueLabel>: View where Label : View
             let currentValueLabelBuilder = currentValueLabelBuilder {
 
             ProgressView(value: determination.progress, total: determination.total, label: labelBuilder, currentValueLabel: currentValueLabelBuilder)
-                .vmdModifier(viewModel)
+                .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
         } else if let labelBuilder = labelBuilder {
             if let determination = viewModel.determination {
                 ProgressView(value: determination.progressRatio, label: labelBuilder)
-                    .vmdModifier(viewModel)
+                    .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
             } else {
                 ProgressView(label: labelBuilder)
-                    .vmdModifier(viewModel)
+                    .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
             }
         } else {
             if let determination = viewModel.determination {
                 ProgressView(value: determination.progressRatio)
-                    .vmdModifier(viewModel)
+                    .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
             } else {
                 ProgressView()
-                    .vmdModifier(viewModel)
+                    .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
             }
         }
     }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDText.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDText.swift
@@ -20,7 +20,7 @@ public struct VMDText: View {
         configurations.reduce(text) { current, config in
             config(current)
         }
-        .vmdModifier(viewModel)
+        .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
     }
 
     private var text: Text {

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDTextField.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDTextField.swift
@@ -57,7 +57,7 @@ public struct VMDTextField<Label>: View where Label: View {
                             .textContentType(viewModel.contentType?.uiTextContentType)
                             .autocapitalization(viewModel.autoCapitalization.uiTextAutocapitalizationType)
                             .disableAutocorrection(!viewModel.autoCorrect)
-                            .vmdModifier(viewModel)
+                            .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
                     } else {
                         TextField(viewModel.placeholder, text: $text, prompt: prompt)
                             .onSubmit {
@@ -72,7 +72,7 @@ public struct VMDTextField<Label>: View where Label: View {
                             .textContentType(viewModel.contentType?.uiTextContentType)
                             .autocapitalization(viewModel.autoCapitalization.uiTextAutocapitalizationType)
                             .disableAutocorrection(!viewModel.autoCorrect)
-                            .vmdModifier(viewModel)
+                            .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
                     }
                 }
             }
@@ -101,7 +101,7 @@ public struct VMDTextField<Label>: View where Label: View {
             .onChange(of: text) { newValue in
                 handleTextTransformations(newValue)
             }
-            .vmdModifier(viewModel)
+            .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
         }
     }
 

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDToggle.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDToggle.swift
@@ -31,18 +31,18 @@ public struct VMDToggle<Label, Content>: View where Label: View, Content: VMDCon
                 Toggle(title, isOn: isOn)
                     .labelsHidden()
                     .disabled(!viewModel.isEnabled)
-                    .vmdModifier(viewModel)
+                    .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
             } else {
                 Toggle(title, isOn: isOn)
                     .disabled(!viewModel.isEnabled)
-                    .vmdModifier(viewModel)
+                    .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
             }
         } else {
             Toggle(isOn: isOn) {
                 labelBuilder?(viewModel.label)
             }
             .disabled(!viewModel.isEnabled)
-            .vmdModifier(viewModel)
+            .vmdModifier(isHidden: viewModel.isHidden, testIdentifier: viewModel.testIdentifier)
         }
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/ViewModifiers/VMDModifier.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/ViewModifiers/VMDModifier.swift
@@ -2,22 +2,23 @@ import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 
 struct VmdModifier: ViewModifier {
-    var viewModel: VMDViewModel
-    
+    let isHidden: Bool
+    let testIdentifier: String?
+
     func body(content: Content) -> some View {
         content
-            .hidden(viewModel.isHidden)
-            .applyIfNotNull(viewModel.testIdentifier) { view, testIdentifier in
+            .hidden(isHidden)
+            .applyIfNotNull(testIdentifier) { view, testIdentifier in
                 view.accessibilityIdentifier(testIdentifier)
             }
     }
 }
 
 public extension View {
-    func vmdModifier(_ viewModel: VMDViewModel) -> some View {
-        modifier(VmdModifier(viewModel: viewModel))
+    func vmdModifier(isHidden: Bool, testIdentifier: String?) -> some View {
+        modifier(VmdModifier(isHidden: isHidden, testIdentifier: testIdentifier))
     }
-    
+
     @ViewBuilder
     internal func applyIfNotNull<Value: Any, Content: View>(_ value: Value?, block: (Self, Value) -> Content) -> some View {
          if let value {


### PR DESCRIPTION
## Description

I found a regression in VMDViewModel Flow SwiftUI components, the field "isHidden" is no longer binded.

I choose to pass the 2 fields to the vmdModifier instead of observing the VM in the ViewModifier to avoid any small performance issue of observing the propertyWillChange 2 times for each component.

## How Has This Been Tested?

Tested in my project.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
