### PR TITLE
Fix Bluetooth iOS compile errors

### DIFF
--- a/trikot-bluetooth/swift-extensions/TrikotAttributeProfileCharacteristic.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotAttributeProfileCharacteristic.swift
@@ -4,7 +4,7 @@ import CoreBluetooth
 class TrikotAttributeProfileCharacteristic: NSObject, AttributeProfileCharacteristic {
     private let characteristic: CBCharacteristic
     private let peripheral: CBPeripheral
-    let event = frozenSubject()
+    let event: Publisher = Publishers().publishSubject()
 
     var newValue: Data? {
         didSet {

--- a/trikot-bluetooth/swift-extensions/TrikotAttributeProfileService.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotAttributeProfileService.swift
@@ -7,7 +7,7 @@ class TrikotAttributeProfileService: NSObject, AttributeProfileService {
 
     var trikotCharacteristics = [CBCharacteristic: TrikotAttributeProfileCharacteristic]()
 
-    let characteristics: Publisher = behaviorSubject()
+    let characteristics: Publisher = Publishers().behaviorSubject(value: nil)
 
     init(service: CBService, peripheral: CBPeripheral) {
         self.service = service

--- a/trikot-bluetooth/swift-extensions/TrikotBluetoothDevice.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotBluetoothDevice.swift
@@ -10,8 +10,8 @@ class TrikotBluetoothDevice: NSObject, BluetoothDevice, CBPeripheralDelegate {
 
     var physicalAddress: String
 
-    var attributeProfileServices: Publisher = behaviorSubject()
-    var isConnected: Publisher = behaviorSubject()
+    var attributeProfileServices: Publisher = Publishers().behaviorSubject(value: nil)
+    var isConnected: Publisher = Publishers().behaviorSubject(value: nil)
 
     var managerIsConnected = false {
         didSet {

--- a/trikot-bluetooth/swift-extensions/TrikotBluetoothManager.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotBluetoothManager.swift
@@ -7,14 +7,14 @@ public class TrikotBluetoothManager: NSObject, BluetoothManager, CBCentralManage
     private let dispatchQueue = DispatchQueue(label: TrikotBluetoothManager.QueueLabel, qos: .background)
     private lazy var centralManager = CBCentralManager(delegate: self, queue: dispatchQueue)
 
-    private let scanResultpublisher = behaviorSubject()
+    private let scanResultpublisher = Publishers().behaviorSubject(value: nil)
     private let numberOfScanRequest = Atomic<Int>(0)
 
     private var scanResults = [CBPeripheral: TrikotBluetoothScanResult]()
     private var connectedDevices = [CBPeripheral: TrikotBluetoothDevice]()
     private var delegates = [CBCentralManagerDelegate]()
 
-    private let bluetoothStatePublisher: Publisher = behaviorSubject()
+    private let bluetoothStatePublisher: Publisher = Publishers().behaviorSubject(value: nil)
 
     public lazy var statePublisher = PublisherExtensionsKt.map(bluetoothStatePublisher) { (value: Any) in
         guard let centralManagerState = value as? CBManagerState else { return nil }

--- a/trikot-bluetooth/swift-extensions/TrikotBluetoothScanResult.swift
+++ b/trikot-bluetooth/swift-extensions/TrikotBluetoothScanResult.swift
@@ -6,7 +6,7 @@ class TrikotBluetoothScanResult: NSObject, BluetoothScanResult {
     private let centralManager: CBCentralManager
     private let peripheral: CBPeripheral
     private var lostHeartbeatTimer: Foundation.Timer?
-    private var manufacturerData = behaviorSubject()
+    private var manufacturerData = Publishers().behaviorSubject(value: nil)
 
     var bluetoothDevice: TrikotBluetoothDevice?
 
@@ -14,7 +14,7 @@ class TrikotBluetoothScanResult: NSObject, BluetoothScanResult {
 
     var physicalAddress: String
 
-    var rssi: Publisher = behaviorSubject()
+    var rssi: Publisher = Publishers().behaviorSubject(value: nil)
 
     var onHeartBeatLost: (() -> Void)? {
         didSet {


### PR DESCRIPTION
Since the switch to the new memory model, the iOS Bluetooth library contained compilation errors:

> - Cannot find 'behaviorSubject' in scope
> - Cannot find 'frozenSubject' in scope

To fix the errors, the way the `subject` and `behaviorSubject` are initialized has been changed.

## How Has This Been Tested?

This change was tested in a project using Bluetooth.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
