### PR TITLE
[VMD-Flow Android]  Add a VMDImage that allow custom loading and error placeholder composable

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -396,7 +396,7 @@ fun RemoteImage(
         filterQuality = filterQuality
     ) {
         if (hasLoadingFailed || imageUrl == null) {
-            error(placeholderImage)
+            placeholderStateView(placeholderImage, PlaceholderState.ERROR)
         } else {
             when (painter.state) {
                 is AsyncImagePainter.State.Success -> {

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -172,6 +172,10 @@ fun VMDImage(
 }
 
 @Composable
+@Deprecated(
+    message = "Use the constructor with custom error and loading instead of custom placeholder",
+    replaceWith = ReplaceWith("VMDImage with custom error and loading instead of custom placeholder")
+)
 fun VMDImage(
     modifier: Modifier = Modifier,
     imageDescriptor: VMDImageDescriptor,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -54,6 +54,32 @@ private const val MAX_BITMAP_SIZE = 100 * 1024 * 1024 // 100 MB, taken from andr
 
 @Composable
 fun VMDImage(
+    viewModel: VMDImageViewModel,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    allowHardware: Boolean = true
+) {
+    val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDImage(
+        imageDescriptor = imageViewModel.image,
+        modifier = modifier.vmdModifier(imageViewModel),
+        contentDescription = imageViewModel.contentDescription,
+        alignment = alignment,
+        onState = onState,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        allowHardware = allowHardware
+    )
+}
+
+@Composable
+fun VMDImage(
     imageDescriptor: VMDImageDescriptor,
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
@@ -141,8 +167,8 @@ fun VMDImage(
 
 @Composable
 @Deprecated(
-    message = "Use the constructor with custom error and loading instead of custom placeholder",
-    replaceWith = ReplaceWith("VMDImage with custom error and loading instead of custom placeholder")
+    message = "Use the constructor with placeholderStateView instead of custom placeholder",
+    replaceWith = ReplaceWith("VMDImage with placeholderStateView instead of custom placeholder")
 )
 fun VMDImage(
     modifier: Modifier = Modifier,
@@ -201,18 +227,9 @@ fun VMDImage(
     viewModel: VMDImageViewModel,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
-    placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit = { imageResource, state ->
-        RemoteImageDefaultPlaceholder(
-            imageResource = imageResource,
-            modifier = modifier,
-            contentScale = placeholderContentScale,
-            colorFilter = colorFilter,
-            contentDescription = viewModel.contentDescription
-        )
-    }
+    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit
 ) {
     val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
@@ -224,7 +241,6 @@ fun VMDImage(
         contentScale = contentScale,
         colorFilter = colorFilter,
         contentDescription = imageViewModel.contentDescription,
-        placeholderContentScale = placeholderContentScale,
         imageDescriptor = imageViewModel.image,
         placeholderStateView = placeholderStateView
     )
@@ -236,19 +252,10 @@ fun VMDImage(
     imageDescriptor: VMDImageDescriptor,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
-    placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit = { imageResource, state ->
-        RemoteImageDefaultPlaceholder(
-            imageResource = imageResource,
-            modifier = modifier,
-            contentScale = placeholderContentScale,
-            colorFilter = colorFilter,
-            contentDescription = contentDescription
-        )
-    },
+    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
     allowHardware: Boolean = true,
     onState: ((AsyncImagePainter.State) -> Unit)? = null,
 ) {

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -281,7 +281,8 @@ fun VMDImage(
                 contentScale = contentScale,
                 colorFilter = colorFilter,
                 contentDescription = contentDescription,
-                allowHardware = allowHardware
+                allowHardware = allowHardware,
+                onState = onState
             )
         }
     }

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -5,8 +5,6 @@ import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -26,12 +24,8 @@ import androidx.compose.ui.layout.LayoutModifier
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -126,6 +126,10 @@ fun VMDImage(
 }
 
 @Composable
+@Deprecated(
+    message = "Use the constructor with placeholder receiving PlaceholderState instead",
+    replaceWith = ReplaceWith("VMDImage with placeholder PlaceholderState instead")
+)
 fun VMDImage(
     modifier: Modifier = Modifier,
     viewModel: VMDImageViewModel,
@@ -167,8 +171,8 @@ fun VMDImage(
 
 @Composable
 @Deprecated(
-    message = "Use the constructor with placeholderStateView instead of custom placeholder",
-    replaceWith = ReplaceWith("VMDImage with placeholderStateView instead of custom placeholder")
+    message = "Use the constructor with placeholder receiving PlaceholderState instead",
+    replaceWith = ReplaceWith("VMDImage with placeholder PlaceholderState instead")
 )
 fun VMDImage(
     modifier: Modifier = Modifier,
@@ -229,7 +233,7 @@ fun VMDImage(
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit
+    placeholder: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit
 ) {
     val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
@@ -242,7 +246,7 @@ fun VMDImage(
         colorFilter = colorFilter,
         contentDescription = imageViewModel.contentDescription,
         imageDescriptor = imageViewModel.image,
-        placeholderStateView = placeholderStateView
+        placeholder = placeholder
     )
 }
 
@@ -255,7 +259,7 @@ fun VMDImage(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
+    placeholder: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
     allowHardware: Boolean = true,
     onState: ((AsyncImagePainter.State) -> Unit)? = null,
 ) {
@@ -277,7 +281,7 @@ fun VMDImage(
                 modifier = modifier,
                 imageUrl = imageDescriptor.url,
                 placeholderImage = imageDescriptor.placeholderImageResource,
-                placeholderStateView = placeholderStateView,
+                placeholder = placeholder,
                 alignment = alignment,
                 contentScale = contentScale,
                 colorFilter = colorFilter,
@@ -367,7 +371,7 @@ fun RemoteImage(
     modifier: Modifier = Modifier,
     imageUrl: String?,
     placeholderImage: VMDImageResource = VMDImageResource.None,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
+    placeholder: @Composable (imageResource: VMDImageResource, placeholderState: PlaceholderState) -> Unit,
     alignment: Alignment = Alignment.Center,
     transform: (AsyncImagePainter.State) -> AsyncImagePainter.State = AsyncImagePainter.DefaultTransform,
     onState: ((AsyncImagePainter.State) -> Unit)? = null,
@@ -398,7 +402,7 @@ fun RemoteImage(
         filterQuality = filterQuality
     ) {
         if (hasLoadingFailed || imageUrl == null) {
-            placeholderStateView(placeholderImage, PlaceholderState.ERROR)
+            placeholder(placeholderImage, PlaceholderState.ERROR)
         } else {
             when (painter.state) {
                 is AsyncImagePainter.State.Success -> {
@@ -407,11 +411,11 @@ fun RemoteImage(
                 }
 
                 is AsyncImagePainter.State.Loading,
-                is AsyncImagePainter.State.Empty -> placeholderStateView(placeholderImage, PlaceholderState.LOADING)
+                is AsyncImagePainter.State.Empty -> placeholder(placeholderImage, PlaceholderState.LOADING)
 
                 is AsyncImagePainter.State.Error -> {
                     hasLoadingFailed = true
-                    placeholderStateView(placeholderImage, PlaceholderState.ERROR)
+                    placeholder(placeholderImage, PlaceholderState.ERROR)
                 }
             }
         }

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -5,24 +5,37 @@ import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutModifier
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.compose.SubcomposeAsyncImageContent
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.size.Dimension
@@ -211,6 +224,93 @@ fun VMDImage(
 }
 
 @Composable
+fun VMDImage(
+    modifier: Modifier = Modifier,
+    viewModel: VMDImageViewModel,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = contentScale,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    error: @Composable (placeholderImageResource: VMDImageResource) -> Unit = { imageResource ->
+        RemoteImageDefaultPlaceholder(
+            imageResource = imageResource,
+            modifier = modifier,
+            contentScale = placeholderContentScale,
+            colorFilter = colorFilter,
+            contentDescription = viewModel.contentDescription
+        )
+    },
+    loading: @Composable (placeholderImageResource: VMDImageResource) -> Unit = { _ -> }
+) {
+    val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDImage(
+        modifier = modifier
+            .vmdModifier(viewModel),
+        alpha = alpha,
+        alignment = alignment,
+        contentScale = contentScale,
+        colorFilter = colorFilter,
+        contentDescription = imageViewModel.contentDescription,
+        placeholderContentScale = placeholderContentScale,
+        imageDescriptor = imageViewModel.image,
+        error = error,
+        loading = loading
+    )
+}
+
+@Composable
+fun VMDImage(
+    modifier: Modifier = Modifier,
+    imageDescriptor: VMDImageDescriptor,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = contentScale,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    contentDescription: String? = null,
+    error: @Composable (placeholderImageResource: VMDImageResource) -> Unit = { imageResource ->
+        RemoteImageDefaultPlaceholder(
+            imageResource = imageResource,
+            modifier = modifier,
+            contentScale = placeholderContentScale,
+            colorFilter = colorFilter,
+            contentDescription = contentDescription
+        )
+    },
+    loading: @Composable (placeholderImageResource: VMDImageResource) -> Unit = { _ -> }
+) {
+    when (imageDescriptor) {
+        is Local -> {
+            LocalImage(
+                modifier = modifier,
+                imageResource = imageDescriptor.imageResource,
+                alignment = alignment,
+                contentScale = contentScale,
+                alpha = alpha,
+                colorFilter = colorFilter,
+                contentDescription = contentDescription
+            )
+        }
+
+        is Remote -> {
+            RemoteImage(
+                modifier = modifier,
+                imageUrl = imageDescriptor.url,
+                placeholderImage = imageDescriptor.placeholderImageResource,
+                error = error,
+                loading = loading,
+                alignment = alignment,
+                contentScale = contentScale,
+                colorFilter = colorFilter,
+                contentDescription = contentDescription
+            )
+        }
+    }
+}
+
+@Composable
 fun LocalImage(
     imageResource: VMDImageResource,
     modifier: Modifier = Modifier,
@@ -279,6 +379,59 @@ fun RemoteImage(
             }
 
             else -> placeholder(placeholderImage, state)
+        }
+    }
+}
+
+@Composable
+fun RemoteImage(
+    modifier: Modifier = Modifier,
+    imageUrl: String?,
+    placeholderImage: VMDImageResource = VMDImageResource.None,
+    error: @Composable (placeholderImageResource: VMDImageResource) -> Unit,
+    loading: @Composable (placeholderImageResource: VMDImageResource) -> Unit,
+    alignment: Alignment = Alignment.Center,
+    transform: (AsyncImagePainter.State) -> AsyncImagePainter.State = AsyncImagePainter.DefaultTransform,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+    contentDescription: String? = null
+) {
+    var hasLoadingFailed by remember { mutableStateOf(false) }
+    LaunchedEffect(imageUrl) {
+        hasLoadingFailed = false
+    }
+    SubcomposeAsyncImage(
+        modifier = modifier,
+        model = imageUrl,
+        contentDescription = contentDescription,
+        transform = transform,
+        alignment = alignment,
+        onState = onState,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        filterQuality = filterQuality
+    ) {
+        if (hasLoadingFailed || imageUrl == null) {
+            error(placeholderImage)
+        } else {
+            when (painter.state) {
+                is AsyncImagePainter.State.Success -> {
+                    hasLoadingFailed = false
+                    SubcomposeAsyncImageContent()
+                }
+
+                is AsyncImagePainter.State.Loading,
+                is AsyncImagePainter.State.Empty -> loading(placeholderImage)
+
+                is AsyncImagePainter.State.Error -> {
+                    hasLoadingFailed = true
+                    error(placeholderImage)
+                }
+            }
         }
     }
 }

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
@@ -30,7 +30,6 @@ fun VMDTextField(
     textStyle: TextStyle = LocalTextStyle.current,
     placeHolderStyle: TextStyle = LocalTextStyle.current,
     label: @Composable (() -> Unit)? = null,
-    placeholder: @Composable (() -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
     keyboardActions: KeyboardActions = KeyboardActions(),

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -33,7 +33,6 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.LocalImage
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.PlaceholderState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDImage
 import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDeclarative
-import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
 
 @Composable
 fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -33,6 +33,7 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.LocalImage
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.PlaceholderState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDImage
 import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDeclarative
+import com.mirego.trikot.viewmodels.declarative.properties.VMDImageResource
 
 @Composable
 fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
@@ -146,7 +147,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                 .padding(16.dp)
                 .aspectRatio(imageAspectRatio),
             viewModel = viewModel.placeholderInvalidImage,
-            placeholderStateView = { image, state ->
+            placeholder = { _, state: PlaceholderState ->
                 when (state) {
                     PlaceholderState.LOADING -> Box(
                         modifier = Modifier
@@ -180,7 +181,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                 .padding(16.dp),
             viewModel = viewModel.remoteImage,
             contentScale = ContentScale.Crop,
-            placeholderStateView = { image, state ->
+            placeholder = { _, state: PlaceholderState ->
                 when (state) {
                     PlaceholderState.LOADING -> Box(
                         modifier = Modifier

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -154,6 +156,26 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                         style = SampleTextStyle.subheadline,
                         color = Color.Black
                     )
+                }
+            }
+        )
+
+        ComponentShowcaseTitle(viewModel.remoteImageTitle)
+
+        VMDImage(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(imageAspectRatio)
+                .padding(16.dp),
+            viewModel = viewModel.remoteImage,
+            contentScale = ContentScale.Crop,
+            loading = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.LightGray)
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
                 }
             }
         )

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -30,6 +30,7 @@ import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewM
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewModelPreview
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.LocalImage
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.PlaceholderState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDImage
 import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDeclarative
 
@@ -145,17 +146,27 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                 .padding(16.dp)
                 .aspectRatio(imageAspectRatio),
             viewModel = viewModel.placeholderInvalidImage,
-            error = { image ->
-                Box(
-                    modifier = Modifier
-                        .background(Color.LightGray)
-                ) {
-                    Text(
-                        modifier = Modifier.align(Alignment.Center),
-                        text = "Unable to load the remote image",
-                        style = SampleTextStyle.subheadline,
-                        color = Color.Black
-                    )
+            placeholderStateView = { image, state ->
+                when (state) {
+                    PlaceholderState.LOADING -> Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.LightGray)
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    }
+
+                    PlaceholderState.ERROR -> Box(
+                        modifier = Modifier
+                            .background(Color.LightGray)
+                    ) {
+                        Text(
+                            modifier = Modifier.align(Alignment.Center),
+                            text = "Unable to load the remote image",
+                            style = SampleTextStyle.subheadline,
+                            color = Color.Black
+                        )
+                    }
                 }
             }
         )
@@ -169,13 +180,27 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                 .padding(16.dp),
             viewModel = viewModel.remoteImage,
             contentScale = ContentScale.Crop,
-            loading = {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Color.LightGray)
-                ) {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            placeholderStateView = { image, state ->
+                when (state) {
+                    PlaceholderState.LOADING -> Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.LightGray)
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    }
+
+                    PlaceholderState.ERROR -> Box(
+                        modifier = Modifier
+                            .background(Color.LightGray)
+                    ) {
+                        Text(
+                            modifier = Modifier.align(Alignment.Center),
+                            text = "Unable to load the remote image",
+                            style = SampleTextStyle.subheadline,
+                            color = Color.Black
+                        )
+                    }
                 }
             }
         )

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -2,6 +2,7 @@ package com.mirego.sample.ui.showcase.components.image
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -131,6 +132,28 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
                         is AsyncImagePainter.State.Error -> Text("Unable to load the remote image", style = SampleTextStyle.subheadline)
                         else -> {}
                     }
+                }
+            }
+        )
+
+        ComponentShowcaseTitle(viewModel.placeholderInvalidImageTitle)
+
+        VMDImage(
+            modifier = Modifier
+                .padding(16.dp)
+                .aspectRatio(imageAspectRatio),
+            viewModel = viewModel.placeholderInvalidImage,
+            error = { image ->
+                Box(
+                    modifier = Modifier
+                        .background(Color.LightGray)
+                ) {
+                    Text(
+                        modifier = Modifier.align(Alignment.Center),
+                        text = "Unable to load the remote image",
+                        style = SampleTextStyle.subheadline,
+                        color = Color.Black
+                    )
                 }
             }
         )

--- a/trikot-viewmodels-declarative-flow/sample/common/TRIKOT_FRAMEWORK_NAME.podspec
+++ b/trikot-viewmodels-declarative-flow/sample/common/TRIKOT_FRAMEWORK_NAME.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'TRIKOT_FRAMEWORK_NAME'
-    spec.version                  = '5.0.0'
+    spec.version                  = '5.1.0'
     spec.homepage                 = 'www.mirego.com'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -6,13 +6,18 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.LayoutModifier
@@ -23,6 +28,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Constraints
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.compose.SubcomposeAsyncImageContent
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.size.Dimension
@@ -44,34 +51,6 @@ import kotlinx.coroutines.flow.mapNotNull
 
 private const val TAG = "VMDImage"
 private const val MAX_BITMAP_SIZE = 100 * 1024 * 1024 // 100 MB, taken from android.graphics.RecordingCanvas
-
-@Composable
-fun VMDImage(
-    viewModel: VMDImageViewModel,
-    modifier: Modifier = Modifier,
-    alignment: Alignment = Alignment.Center,
-    onState: ((AsyncImagePainter.State) -> Unit)? = null,
-    contentScale: ContentScale = ContentScale.Fit,
-    alpha: Float = DefaultAlpha,
-    colorFilter: ColorFilter? = null,
-    allowHardware: Boolean = true
-) {
-    val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
-
-    VMDImage(
-        imageDescriptor = imageViewModel.image,
-        modifier = Modifier
-            .hidden(imageViewModel.isHidden)
-            .then(modifier),
-        contentDescription = imageViewModel.contentDescription,
-        alignment = alignment,
-        onState = onState,
-        contentScale = contentScale,
-        alpha = alpha,
-        colorFilter = colorFilter,
-        allowHardware = allowHardware
-    )
-}
 
 @Composable
 fun VMDImage(
@@ -162,6 +141,10 @@ fun VMDImage(
 }
 
 @Composable
+@Deprecated(
+    message = "Use the constructor with custom error and loading instead of custom placeholder",
+    replaceWith = ReplaceWith("VMDImage with custom error and loading instead of custom placeholder")
+)
 fun VMDImage(
     modifier: Modifier = Modifier,
     imageDescriptor: VMDImageDescriptor,
@@ -208,6 +191,94 @@ fun VMDImage(
                 allowHardware = allowHardware,
                 placeholder = placeholder,
                 asyncStateCallback = asyncStateCallback
+            )
+        }
+    }
+}
+
+@Composable
+fun VMDImage(
+    modifier: Modifier = Modifier,
+    viewModel: VMDImageViewModel,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = contentScale,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit = { imageResource, state ->
+        RemoteImageDefaultPlaceholder(
+            imageResource = imageResource,
+            modifier = modifier,
+            contentScale = placeholderContentScale,
+            colorFilter = colorFilter,
+            contentDescription = viewModel.contentDescription
+        )
+    }
+) {
+    val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDImage(
+        modifier = modifier
+            .hidden(imageViewModel.isHidden)
+            .then(modifier),
+        alpha = alpha,
+        alignment = alignment,
+        contentScale = contentScale,
+        colorFilter = colorFilter,
+        contentDescription = imageViewModel.contentDescription,
+        placeholderContentScale = placeholderContentScale,
+        imageDescriptor = imageViewModel.image,
+        placeholderStateView = placeholderStateView
+    )
+}
+
+@Composable
+fun VMDImage(
+    modifier: Modifier = Modifier,
+    imageDescriptor: VMDImageDescriptor,
+    alignment: Alignment = Alignment.Center,
+    contentScale: ContentScale = ContentScale.Fit,
+    placeholderContentScale: ContentScale = contentScale,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    contentDescription: String? = null,
+    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit = { imageResource, state ->
+        RemoteImageDefaultPlaceholder(
+            imageResource = imageResource,
+            modifier = modifier,
+            contentScale = placeholderContentScale,
+            colorFilter = colorFilter,
+            contentDescription = contentDescription
+        )
+    },
+    allowHardware: Boolean = true,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+) {
+    when (imageDescriptor) {
+        is Local -> {
+            LocalImage(
+                modifier = modifier,
+                imageResource = imageDescriptor.imageResource,
+                alignment = alignment,
+                contentScale = contentScale,
+                alpha = alpha,
+                colorFilter = colorFilter,
+                contentDescription = contentDescription
+            )
+        }
+
+        is Remote -> {
+            RemoteImage(
+                modifier = modifier,
+                imageUrl = imageDescriptor.url,
+                placeholderImage = imageDescriptor.placeholderImageResource,
+                placeholderStateView = placeholderStateView,
+                alignment = alignment,
+                contentScale = contentScale,
+                colorFilter = colorFilter,
+                contentDescription = contentDescription,
+                allowHardware = allowHardware,
+                onState = onState
             )
         }
     }
@@ -287,6 +358,62 @@ fun RemoteImage(
 }
 
 @Composable
+fun RemoteImage(
+    modifier: Modifier = Modifier,
+    imageUrl: String?,
+    placeholderImage: VMDImageResource = VMDImageResource.None,
+    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
+    alignment: Alignment = Alignment.Center,
+    transform: (AsyncImagePainter.State) -> AsyncImagePainter.State = AsyncImagePainter.DefaultTransform,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    filterQuality: FilterQuality = DrawScope.DefaultFilterQuality,
+    contentDescription: String? = null,
+    allowHardware: Boolean = true
+) {
+    var hasLoadingFailed by remember { mutableStateOf(false) }
+    LaunchedEffect(imageUrl) {
+        hasLoadingFailed = false
+    }
+    SubcomposeAsyncImage(
+        modifier = modifier,
+        model = ImageRequest.Builder(LocalContext.current)
+            .data(imageUrl)
+            .allowHardware(allowHardware)
+            .build(),
+        contentDescription = contentDescription,
+        transform = transform,
+        alignment = alignment,
+        onState = onState,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        filterQuality = filterQuality
+    ) {
+        if (hasLoadingFailed || imageUrl == null) {
+            placeholderStateView(placeholderImage, PlaceholderState.ERROR)
+        } else {
+            when (painter.state) {
+                is AsyncImagePainter.State.Success -> {
+                    hasLoadingFailed = false
+                    SubcomposeAsyncImageContent()
+                }
+
+                is AsyncImagePainter.State.Loading,
+                is AsyncImagePainter.State.Empty -> placeholderStateView(placeholderImage, PlaceholderState.LOADING)
+
+                is AsyncImagePainter.State.Error -> {
+                    hasLoadingFailed = true
+                    placeholderStateView(placeholderImage, PlaceholderState.ERROR)
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun RemoteImageDefaultPlaceholder(
     imageResource: VMDImageResource,
     modifier: Modifier = Modifier,
@@ -347,4 +474,9 @@ private fun transformOf(
         is AsyncImagePainter.State.Error -> state.copy(painter = placeholder)
         else -> state
     }
+}
+
+enum class PlaceholderState {
+    LOADING,
+    ERROR
 }

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -54,6 +54,34 @@ private const val MAX_BITMAP_SIZE = 100 * 1024 * 1024 // 100 MB, taken from andr
 
 @Composable
 fun VMDImage(
+    viewModel: VMDImageViewModel,
+    modifier: Modifier = Modifier,
+    alignment: Alignment = Alignment.Center,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    allowHardware: Boolean = true
+) {
+    val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDImage(
+        imageDescriptor = imageViewModel.image,
+        modifier = modifier
+            .hidden(imageViewModel.isHidden)
+            .then(modifier),
+        contentDescription = imageViewModel.contentDescription,
+        alignment = alignment,
+        onState = onState,
+        contentScale = contentScale,
+        alpha = alpha,
+        colorFilter = colorFilter,
+        allowHardware = allowHardware
+    )
+}
+
+@Composable
+fun VMDImage(
     imageDescriptor: VMDImageDescriptor,
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
@@ -142,8 +170,8 @@ fun VMDImage(
 
 @Composable
 @Deprecated(
-    message = "Use the constructor with custom error and loading instead of custom placeholder",
-    replaceWith = ReplaceWith("VMDImage with custom error and loading instead of custom placeholder")
+    message = "Use the constructor with placeholderStateView instead of custom placeholder",
+    replaceWith = ReplaceWith("VMDImage with placeholderStateView instead of custom placeholder")
 )
 fun VMDImage(
     modifier: Modifier = Modifier,
@@ -202,18 +230,9 @@ fun VMDImage(
     viewModel: VMDImageViewModel,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
-    placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit = { imageResource, state ->
-        RemoteImageDefaultPlaceholder(
-            imageResource = imageResource,
-            modifier = modifier,
-            contentScale = placeholderContentScale,
-            colorFilter = colorFilter,
-            contentDescription = viewModel.contentDescription
-        )
-    }
+    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit
 ) {
     val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
@@ -226,7 +245,6 @@ fun VMDImage(
         contentScale = contentScale,
         colorFilter = colorFilter,
         contentDescription = imageViewModel.contentDescription,
-        placeholderContentScale = placeholderContentScale,
         imageDescriptor = imageViewModel.image,
         placeholderStateView = placeholderStateView
     )
@@ -238,19 +256,10 @@ fun VMDImage(
     imageDescriptor: VMDImageDescriptor,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
-    placeholderContentScale: ContentScale = contentScale,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit = { imageResource, state ->
-        RemoteImageDefaultPlaceholder(
-            imageResource = imageResource,
-            modifier = modifier,
-            contentScale = placeholderContentScale,
-            colorFilter = colorFilter,
-            contentDescription = contentDescription
-        )
-    },
+    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
     allowHardware: Boolean = true,
     onState: ((AsyncImagePainter.State) -> Unit)? = null,
 ) {

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImage.kt
@@ -67,7 +67,7 @@ fun VMDImage(
 
     VMDImage(
         imageDescriptor = imageViewModel.image,
-        modifier = modifier
+        modifier = Modifier
             .hidden(imageViewModel.isHidden)
             .then(modifier),
         contentDescription = imageViewModel.contentDescription,
@@ -128,6 +128,10 @@ fun VMDImage(
 }
 
 @Composable
+@Deprecated(
+    message = "Use the constructor with placeholder receiving PlaceholderState instead",
+    replaceWith = ReplaceWith("VMDImage with placeholder PlaceholderState instead")
+)
 fun VMDImage(
     modifier: Modifier = Modifier,
     viewModel: VMDImageViewModel,
@@ -170,8 +174,8 @@ fun VMDImage(
 
 @Composable
 @Deprecated(
-    message = "Use the constructor with placeholderStateView instead of custom placeholder",
-    replaceWith = ReplaceWith("VMDImage with placeholderStateView instead of custom placeholder")
+    message = "Use the constructor with placeholder receiving PlaceholderState instead",
+    replaceWith = ReplaceWith("VMDImage with placeholder PlaceholderState instead")
 )
 fun VMDImage(
     modifier: Modifier = Modifier,
@@ -232,12 +236,12 @@ fun VMDImage(
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit
+    placeholder: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit
 ) {
     val imageViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
 
     VMDImage(
-        modifier = modifier
+        modifier = Modifier
             .hidden(imageViewModel.isHidden)
             .then(modifier),
         alpha = alpha,
@@ -246,7 +250,7 @@ fun VMDImage(
         colorFilter = colorFilter,
         contentDescription = imageViewModel.contentDescription,
         imageDescriptor = imageViewModel.image,
-        placeholderStateView = placeholderStateView
+        placeholder = placeholder
     )
 }
 
@@ -259,7 +263,7 @@ fun VMDImage(
     alpha: Float = DefaultAlpha,
     colorFilter: ColorFilter? = null,
     contentDescription: String? = null,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
+    placeholder: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
     allowHardware: Boolean = true,
     onState: ((AsyncImagePainter.State) -> Unit)? = null,
 ) {
@@ -281,7 +285,7 @@ fun VMDImage(
                 modifier = modifier,
                 imageUrl = imageDescriptor.url,
                 placeholderImage = imageDescriptor.placeholderImageResource,
-                placeholderStateView = placeholderStateView,
+                placeholder = placeholder,
                 alignment = alignment,
                 contentScale = contentScale,
                 colorFilter = colorFilter,
@@ -371,7 +375,7 @@ fun RemoteImage(
     modifier: Modifier = Modifier,
     imageUrl: String?,
     placeholderImage: VMDImageResource = VMDImageResource.None,
-    placeholderStateView: @Composable (placeholderImageResource: VMDImageResource, state: PlaceholderState) -> Unit,
+    placeholder: @Composable (imageResource: VMDImageResource, placeholderState: PlaceholderState) -> Unit,
     alignment: Alignment = Alignment.Center,
     transform: (AsyncImagePainter.State) -> AsyncImagePainter.State = AsyncImagePainter.DefaultTransform,
     onState: ((AsyncImagePainter.State) -> Unit)? = null,
@@ -402,7 +406,7 @@ fun RemoteImage(
         filterQuality = filterQuality
     ) {
         if (hasLoadingFailed || imageUrl == null) {
-            placeholderStateView(placeholderImage, PlaceholderState.ERROR)
+            placeholder(placeholderImage, PlaceholderState.ERROR)
         } else {
             when (painter.state) {
                 is AsyncImagePainter.State.Success -> {
@@ -411,11 +415,11 @@ fun RemoteImage(
                 }
 
                 is AsyncImagePainter.State.Loading,
-                is AsyncImagePainter.State.Empty -> placeholderStateView(placeholderImage, PlaceholderState.LOADING)
+                is AsyncImagePainter.State.Empty -> placeholder(placeholderImage, PlaceholderState.LOADING)
 
                 is AsyncImagePainter.State.Error -> {
                     hasLoadingFailed = true
-                    placeholderStateView(placeholderImage, PlaceholderState.ERROR)
+                    placeholder(placeholderImage, PlaceholderState.ERROR)
                 }
             }
         }


### PR DESCRIPTION
Add a VMDImage signature that allow to pass custom loading and placeholder composable.


## Motivation and Context
The current implementation of RemoteImage that is used when the placeholder param is passed always load a fullscale Image in memory regardless of the view's size (unless size is hardcoded).

The current implementation also does not allow to have a different loading UI than the placeholder / error UI.


## How Has This Been Tested?
I plugged an image in the sample using this signature and a similar version was used in DavidsTea project.


## Types of changes
I did no remove any prior implementation / signature
- [ x] New feature (non-breaking change which adds functionality)
