### PR TITLE
Update Ktor to 2.3.3 and Atomicfu to 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Updates
 
+- Ktor `2.3.3`
+- AtomicFu `0.22.0`
+
 ### Breaking Changes
 
 ## 5.0.0

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 object Versions {
     const val KOTLIN = "1.9.10"
-    const val ATOMIC_FU = "0.20.0"
+    const val ATOMIC_FU = "0.22.0"
     const val ANDROID_GRADLE_PLUGIN = "8.1.1"
     const val JETPACK_COMPOSE_COMPILER = "1.5.3"
     const val JETPACK_COMPOSE_RUNTIME = "1.5.0"
@@ -9,7 +9,7 @@ object Versions {
     const val KTLINT = "11.3.2"
     const val KOTLINX_SERIALIZATION = "1.5.0"
     const val KOTLINX_COROUTINES = "1.7.3"
-    const val KTOR = "2.0.3"
+    const val KTOR = "2.3.3"
     const val KOTLIN_WRAPPERS_EXTENSIONS = "1.0.1-pre.622"
     const val ANDROIDX_LIFECYCLE = "2.6.1"
     const val OKIO = "3.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Update Ktor to 2.3.3 and Atomicfu to 0.22.0

<!--- Why is those changes required? What problem does it solve? -->

Fix error `e: Old Kotlin/JS compiler is no longer supported. Please migrate to the new JS IR backend` caused by old Ktor version

See [KTOR-5543 KTOR-5544 Update Kotlin to 1.8 #3398](https://github.com/ktorio/ktor/pull/3398)

## How Has This Been Tested?

Demo apps

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
