### PR TITLE
[Kword] Fix ios sample after kotlinx-couroutines signature change

### DIFF
--- a/trikot-kword/sample/ios/Sample/Collector.swift
+++ b/trikot-kword/sample/ios/Sample/Collector.swift
@@ -1,17 +1,15 @@
 import TRIKOT_FRAMEWORK_NAME
 
 class Collector<T>: FlowCollector {
-    
     let callback:(T) -> Void
 
     init(callback: @escaping (T) -> Void) {
         self.callback = callback
     }
-
-
-    func emit(value: Any?, completionHandler: @escaping (KotlinUnit?, Error?) -> Void) {
+    
+    func emit(value: Any?, completionHandler: @escaping (Error?) -> Void) {
         callback(value as! T)
 
-        completionHandler(KotlinUnit(), nil)
+        completionHandler(nil)
     }
 }


### PR DESCRIPTION
## Description
Fix kword sample, FlowCollector signature changed in latest kotlinx.coroutines version.

## Motivation and Context
Sample did not compile

## How Has This Been Tested?
Ran the sample

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
