### PR TITLE
Fix CD/Release workflow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.model.KotlinAndroidExtension
+val samplesEnabled = !extra.has("disable_samples")
 
 buildscript {
     repositories {
@@ -43,11 +43,17 @@ subprojects {
 }
 
 apiValidation {
+    if (samplesEnabled) {
+        ignoredProjects.addAll(
+            listOf(
+                "sample",
+                "android",
+                "common"
+            )
+        )
+    }
     ignoredProjects.addAll(
         listOf(
-            "sample",
-            "android",
-            "common",
             "viewmodels-declarative-compiler-core",
             "viewmodels-declarative-compiler-flow",
             "viewmodels-declarative-compiler-streams"


### PR DESCRIPTION
## Description
Fix CD workflow.
CD disables samples and since binary compatibility plugin cannot find the ignored projects it fails. This prevents from adding those project while samples are disabled.

## Motivation and Context
CD was broken due to https://github.com/mirego/trikot/pull/190

## How Has This Been Tested?
Ran `./gradlew apiCheck -Pdisable_samples`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
