### PR TITLE
[VMD-Flow] VMDHtmlTextViewModel / VMDHtmlText

### DIFF
--- a/trikot-streams/streams/api/android/streams.api
+++ b/trikot-streams/streams/api/android/streams.api
@@ -220,6 +220,7 @@ public final class com/mirego/trikot/streams/reactive/PublisherExtensionsKt {
 	public static final fun scan (Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function2;)Lorg/reactivestreams/Publisher;
 	public static final fun scanWith (Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lorg/reactivestreams/Publisher;
 	public static final fun shared (Lorg/reactivestreams/Publisher;)Lorg/reactivestreams/Publisher;
+	public static final fun skip (Lorg/reactivestreams/Publisher;J)Lorg/reactivestreams/Publisher;
 	public static final fun startWith (Lorg/reactivestreams/Publisher;Ljava/lang/Object;)Lorg/reactivestreams/Publisher;
 	public static final fun subscribe (Lorg/reactivestreams/Publisher;Lcom/mirego/trikot/streams/cancellable/CancellableManager;Lkotlin/jvm/functions/Function1;)V
 	public static final fun subscribe (Lorg/reactivestreams/Publisher;Lcom/mirego/trikot/streams/cancellable/CancellableManager;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V

--- a/trikot-streams/streams/api/jvm/streams.api
+++ b/trikot-streams/streams/api/jvm/streams.api
@@ -209,6 +209,7 @@ public final class com/mirego/trikot/streams/reactive/PublisherExtensionsKt {
 	public static final fun scan (Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function2;)Lorg/reactivestreams/Publisher;
 	public static final fun scanWith (Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)Lorg/reactivestreams/Publisher;
 	public static final fun shared (Lorg/reactivestreams/Publisher;)Lorg/reactivestreams/Publisher;
+	public static final fun skip (Lorg/reactivestreams/Publisher;J)Lorg/reactivestreams/Publisher;
 	public static final fun startWith (Lorg/reactivestreams/Publisher;Ljava/lang/Object;)Lorg/reactivestreams/Publisher;
 	public static final fun subscribe (Lorg/reactivestreams/Publisher;Lcom/mirego/trikot/streams/cancellable/CancellableManager;Lkotlin/jvm/functions/Function1;)V
 	public static final fun subscribe (Lorg/reactivestreams/Publisher;Lcom/mirego/trikot/streams/cancellable/CancellableManager;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/PublisherExtensions.kt
@@ -283,7 +283,7 @@ fun <T, R> Publisher<T>.scanWith(
 }
 
 /** Suppress the first n items emitted by a Publisher **/
-internal fun <T> Publisher<T>.skip(n: Long) = SkipProcessor(this, n)
+fun <T> Publisher<T>.skip(n: Long): Publisher<T> = SkipProcessor(this, n)
 
 /** Periodically looks at publisher and emits whichever item it has most recently emitted since the previous sampling. **/
 fun <T> Publisher<T>.sample(

--- a/trikot-viewmodels-declarative-flow/compose-flow/api/compose-flow.api
+++ b/trikot-viewmodels-declarative-flow/compose-flow/api/compose-flow.api
@@ -104,6 +104,10 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 	public static final fun VMDDropDownMenuItem (Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerViewModel;Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerItemViewModel;ILandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function5;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDHtmlTextKt {
+	public static final fun VMDHtmlText-VhcvRP8 (Lcom/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/text/TextStyle;ZIILkotlin/jvm/functions/Function1;ILandroidx/compose/ui/text/SpanStyle;Landroidx/compose/runtime/Composer;II)V
+}
+
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDImageKt {
 	public static final fun LocalImage (Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageResource;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
 	public static final fun RemoteImage (Landroidx/compose/ui/Modifier;Ljava/lang/String;Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageResource;Lkotlin/jvm/functions/Function5;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Landroidx/compose/ui/graphics/ColorFilter;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDHtmlText.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDHtmlText.kt
@@ -1,0 +1,48 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.core.text.HtmlCompat
+import com.mirego.trikot.viewmodels.declarative.components.VMDHtmlTextViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.html.HtmlText
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.html.linkTextColor
+
+@Composable
+fun VMDHtmlText(
+    viewModel: VMDHtmlTextViewModel,
+    modifier: Modifier = Modifier,
+    style: TextStyle = TextStyle.Default,
+    softWrap: Boolean = true,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    flags: Int = HtmlCompat.FROM_HTML_MODE_COMPACT,
+    urlSpanStyle: SpanStyle = SpanStyle(
+        color = linkTextColor(),
+        textDecoration = TextDecoration.Underline,
+    ),
+) {
+    val textViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    HtmlText(
+        text = viewModel.html,
+        modifier = modifier.vmdModifier(textViewModel),
+        style = style,
+        softWrap = softWrap,
+        overflow = overflow,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+        linkClicked = viewModel.urlActionBlock,
+        flags = flags,
+        urlSpanStyle = urlSpanStyle,
+    )
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/internal/html/CharacterStyle.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/internal/html/CharacterStyle.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 compose-html
+ * https://github.com/viluahealthcare/compose-html
+ *
+ * Modified for Trikot
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.html
+
+import android.text.style.ForegroundColorSpan
+import android.text.style.StrikethroughSpan
+import android.text.style.UnderlineSpan
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextDecoration
+
+internal fun UnderlineSpan.spanStyle(): SpanStyle =
+    SpanStyle(textDecoration = TextDecoration.Underline)
+
+internal fun ForegroundColorSpan.spanStyle(): SpanStyle =
+    SpanStyle(color = Color(foregroundColor))
+
+internal fun StrikethroughSpan.spanStyle(): SpanStyle =
+    SpanStyle(textDecoration = TextDecoration.LineThrough)

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/internal/html/HtmlText.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/internal/html/HtmlText.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 compose-html
+ * https://github.com/viluahealthcare/compose-html
+ *
+ * Modified for Trikot
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.html
+
+import android.text.style.BulletSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.RelativeSizeSpan
+import android.text.style.StrikethroughSpan
+import android.text.style.StyleSpan
+import android.text.style.SubscriptSpan
+import android.text.style.SuperscriptSpan
+import android.text.style.TypefaceSpan
+import android.text.style.URLSpan
+import android.text.style.UnderlineSpan
+import android.widget.TextView
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.takeOrElse
+import androidx.core.text.HtmlCompat
+
+private const val URL_TAG = "url_tag"
+private val LIST_REGEX = "(<li\\s*[^>]*>)(.*)(</li>)".toRegex()
+
+@Composable
+internal fun HtmlText(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = TextStyle.Default,
+    softWrap: Boolean = true,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    linkClicked: ((String) -> Unit)? = null,
+    flags: Int = HtmlCompat.FROM_HTML_MODE_COMPACT,
+    urlSpanStyle: SpanStyle = SpanStyle(
+        color = linkTextColor(),
+        textDecoration = TextDecoration.Underline,
+    ),
+) {
+    val fontSize = style.fontSize.takeOrElse { 12.sp }
+    val content = text.asHTML(fontSize, flags, urlSpanStyle)
+    if (linkClicked != null) {
+        ClickableText(
+            modifier = modifier,
+            text = content,
+            style = style,
+            softWrap = softWrap,
+            overflow = overflow,
+            maxLines = maxLines,
+            onTextLayout = onTextLayout,
+            onClick = {
+                content
+                    .getStringAnnotations(URL_TAG, it, it)
+                    .firstOrNull()
+                    ?.let { stringAnnotation -> linkClicked(stringAnnotation.item) }
+            },
+        )
+    } else {
+        Text(
+            modifier = modifier,
+            text = content,
+            style = style,
+            softWrap = softWrap,
+            overflow = overflow,
+            maxLines = maxLines,
+            onTextLayout = onTextLayout,
+        )
+    }
+}
+
+@Composable
+internal fun linkTextColor() = Color(
+    TextView(LocalContext.current).linkTextColors.defaultColor,
+)
+
+private fun String.addBullets() =
+    replace(LIST_REGEX) { matchResult ->
+        val (startTag, inside, endTag) = matchResult.destructured
+        "$startTag&nbsp;&nbsp;&nbsp;&nbsp;• $inside$endTag"
+    }
+
+@Composable
+private fun String.asHTML(
+    fontSize: TextUnit,
+    flags: Int,
+    urlSpanStyle: SpanStyle,
+) = buildAnnotatedString {
+    val modifiedHtml = addBullets()
+    val spanned = HtmlCompat.fromHtml(modifiedHtml, flags)
+    val spans = spanned.getSpans(0, spanned.length, Any::class.java)
+
+    append(spanned.toString())
+
+    spans
+        .filter { it !is BulletSpan }
+        .forEach { span ->
+            val start = spanned.getSpanStart(span)
+            val end = spanned.getSpanEnd(span)
+            when (span) {
+                is RelativeSizeSpan -> span.spanStyle(fontSize)
+                is StyleSpan -> span.spanStyle()
+                is UnderlineSpan -> span.spanStyle()
+                is ForegroundColorSpan -> span.spanStyle()
+                is TypefaceSpan -> span.spanStyle()
+                is StrikethroughSpan -> span.spanStyle()
+                is SuperscriptSpan -> span.spanStyle()
+                is SubscriptSpan -> span.spanStyle()
+
+                is URLSpan -> {
+                    addStringAnnotation(
+                        tag = URL_TAG,
+                        annotation = span.url,
+                        start = start,
+                        end = end,
+                    )
+                    urlSpanStyle
+                }
+
+                else -> null
+            }?.let { spanStyle ->
+                addStyle(spanStyle, start, end)
+            }
+        }
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/internal/html/MetricAffectingSpan.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/internal/html/MetricAffectingSpan.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 compose-html
+ * https://github.com/viluahealthcare/compose-html
+ *
+ * Modified for Trikot
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.html
+
+import android.graphics.Typeface
+import android.text.style.RelativeSizeSpan
+import android.text.style.StyleSpan
+import android.text.style.SubscriptSpan
+import android.text.style.SuperscriptSpan
+import android.text.style.TypefaceSpan
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.BaselineShift
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import java.io.File
+
+private const val PATH_SYSTEM_FONTS_FILE = "/system/etc/fonts.xml"
+private const val PATH_SYSTEM_FONTS_DIR = "/system/fonts/"
+
+internal fun RelativeSizeSpan.spanStyle(fontSize: TextUnit): SpanStyle =
+    SpanStyle(fontSize = (fontSize.value * sizeChange).sp)
+
+internal fun StyleSpan.spanStyle(): SpanStyle? = when (style) {
+    Typeface.BOLD -> SpanStyle(fontWeight = FontWeight.Bold)
+    Typeface.ITALIC -> SpanStyle(fontStyle = FontStyle.Italic)
+    Typeface.BOLD_ITALIC -> SpanStyle(
+        fontWeight = FontWeight.Bold,
+        fontStyle = FontStyle.Italic,
+    )
+    else -> null
+}
+
+internal fun SubscriptSpan.spanStyle(): SpanStyle =
+    SpanStyle(baselineShift = BaselineShift.Subscript)
+
+internal fun SuperscriptSpan.spanStyle(): SpanStyle =
+    SpanStyle(baselineShift = BaselineShift.Superscript)
+
+internal fun TypefaceSpan.spanStyle(): SpanStyle? {
+    val xmlContent = File(PATH_SYSTEM_FONTS_FILE).readText()
+    return if (xmlContent.contains("""<family name="$family""")) {
+        val familyChunkXml = xmlContent.substringAfter("""<family name="$family""")
+            .substringBefore("""</family>""")
+        val fontName = familyChunkXml.substringAfter("""<font weight="400" style="normal">""")
+            .substringBefore("</font>")
+        SpanStyle(fontFamily = FontFamily(Typeface.createFromFile("$PATH_SYSTEM_FONTS_DIR$fontName")))
+    } else {
+        null
+    }
+}

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseActivity.kt
@@ -3,6 +3,7 @@ package com.mirego.sample.ui.showcase.components.text
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModel
@@ -20,6 +21,10 @@ class TextShowcaseActivity : ViewModelActivity<TextShowcaseViewModelController, 
         setContent {
             TextShowcaseView(textShowcaseViewModel = viewModel)
         }
+    }
+
+    override fun showMessage(text: String) {
+        Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
     }
 
     override fun close() {

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -9,8 +9,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.mirego.sample.resource.SampleImageProvider
 import com.mirego.sample.resource.SampleTextStyleProvider
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
@@ -20,6 +25,7 @@ import com.mirego.sample.ui.theming.medium
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModelPreview
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDHtmlText
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDText
 import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDeclarative
 
@@ -37,7 +43,8 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
             VMDText(
@@ -117,6 +124,27 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
 
             VMDText(
                 viewModel = viewModel.richText
+            )
+
+            VMDHtmlText(
+                viewModel = viewModel.htmlText,
+                style = TextStyle(
+                    fontSize = 20.sp,
+                    lineHeight = 30.sp,
+                    fontWeight = FontWeight.Light,
+                    color = Color.Red
+                ),
+            )
+
+            VMDHtmlText(
+                viewModel = viewModel.htmlTextWithLinks,
+                style = TextStyle(
+                    fontSize = 12.sp,
+                    color = Color.Black
+                ),
+                urlSpanStyle = SpanStyle(
+                    color = Color.Green
+                ),
             )
         }
     }

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseNavigationDelegate.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseNavigationDelegate.kt
@@ -2,4 +2,6 @@ package com.mirego.sample.viewmodels.showcase.components.text
 
 import com.mirego.sample.viewmodels.showcase.ShowcaseNavigationDelegate
 
-interface TextShowcaseNavigationDelegate : ShowcaseNavigationDelegate
+interface TextShowcaseNavigationDelegate : ShowcaseNavigationDelegate {
+    fun showMessage(text: String)
+}

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModel.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModel.kt
@@ -1,6 +1,7 @@
 package com.mirego.sample.viewmodels.showcase.components.text
 
 import com.mirego.sample.viewmodels.showcase.ShowcaseViewModel
+import com.mirego.trikot.viewmodels.declarative.components.VMDHtmlTextViewModel
 import com.mirego.trikot.viewmodels.declarative.components.VMDTextViewModel
 
 interface TextShowcaseViewModel : ShowcaseViewModel {
@@ -20,4 +21,6 @@ interface TextShowcaseViewModel : ShowcaseViewModel {
     val caption1: VMDTextViewModel
     val caption2: VMDTextViewModel
     val richText: VMDTextViewModel
+    val htmlText: VMDHtmlTextViewModel
+    val htmlTextWithLinks: VMDHtmlTextViewModel
 }

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelController.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelController.kt
@@ -9,5 +9,8 @@ class TextShowcaseViewModelController(i18N: I18N) : VMDViewModelController<TextS
     override fun onCreate() {
         super.onCreate()
         viewModel.closeButton.setAction { navigationDelegate?.close() }
+        viewModel.htmlTextWithLinks.setUrlAction {
+            navigationDelegate?.showMessage(it)
+        }
     }
 }

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelImpl.kt
@@ -8,11 +8,35 @@ import com.mirego.trikot.kword.I18N
 import com.mirego.trikot.viewmodels.declarative.components.VMDTextViewModel
 import com.mirego.trikot.viewmodels.declarative.properties.VMDRichTextSpan
 import com.mirego.trikot.viewmodels.declarative.properties.VMDSpanStyleResourceTransform
+import com.mirego.trikot.viewmodels.declarative.viewmodel.htmlText
 import com.mirego.trikot.viewmodels.declarative.viewmodel.text
 import kotlinx.coroutines.CoroutineScope
 
 class TextShowcaseViewModelImpl(i18N: I18N, coroutineScope: CoroutineScope) :
     ShowcaseViewModelImpl(coroutineScope), TextShowcaseViewModel {
+
+    private companion object {
+        private const val HTML_TEXT = """
+             <h1>Heading 1</h1>
+             <p>Paragraph with <a href="https://mirego.com">Link</a></p>
+             <h2>Heading 2</h2>
+             <p>This is some html. Look, here's an <u>underline</u>.</p>
+             <p>Look, this is <em>emphasized.</em> And here's some <b>bold</b>.</p>
+             <p>Here are UL list items:
+             <ul>
+             <li>One</li>
+             <li>Two</li>
+             <li>Three</li>
+             </ul>
+             <p>Here are OL list items:
+             <ol>
+             <li>One</li>
+             <li>Two</li>
+             <li>Three</li>
+             </ol>
+        """
+    }
+
     override val title = text(i18N[KWordTranslation.TEXT_SHOWCASE_TITLE])
 
     override val largeTitle = text(i18N[KWordTranslation.TEXT_SHOWCASE_TEXT_LARGE_TITLE]) {
@@ -58,4 +82,8 @@ class TextShowcaseViewModelImpl(i18N: I18N, coroutineScope: CoroutineScope) :
             )
         )
     )
+
+    override val htmlText = htmlText(HTML_TEXT)
+
+    override val htmlTextWithLinks = htmlText(HTML_TEXT)
 }

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelPreview.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/text/TextShowcaseViewModelPreview.kt
@@ -3,10 +3,12 @@ package com.mirego.sample.viewmodels.showcase.components.text
 import com.mirego.sample.extensions.rangeOf
 import com.mirego.sample.resources.SampleImageResource
 import com.mirego.sample.resources.SampleTextStyleResource
+import com.mirego.trikot.viewmodels.declarative.components.VMDHtmlTextViewModel
 import com.mirego.trikot.viewmodels.declarative.properties.VMDRichTextSpan
 import com.mirego.trikot.viewmodels.declarative.properties.VMDSpanStyleResourceTransform
 import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.viewmodel.buttonWithImage
+import com.mirego.trikot.viewmodels.declarative.viewmodel.htmlText
 import com.mirego.trikot.viewmodels.declarative.viewmodel.text
 import kotlinx.coroutines.MainScope
 
@@ -57,4 +59,8 @@ class TextShowcaseViewModelPreview : VMDViewModelImpl(MainScope()), TextShowcase
             )
         )
     )
+
+    override val htmlText: VMDHtmlTextViewModel = htmlText("<em>html text</em>")
+
+    override val htmlTextWithLinks: VMDHtmlTextViewModel = htmlText("<a href=\"https://mirego.com\">html link</a>")
 }

--- a/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Showcase/Components/Text/TextShowcaseView.swift
+++ b/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Showcase/Components/Text/TextShowcaseView.swift
@@ -75,6 +75,28 @@ struct TextShowcaseView: RootViewModelView {
                         VMDText(viewModel.richText)
                             .style(.body)
                     }
+                    
+                    Group {
+                        VMDHtmlText(
+                            viewModel.htmlText,
+                            style: VMDHtmlTextStyle(
+                                fontSize: 20,
+                                lineHeight: 30,
+                                fontWeight: .light
+                            ),
+                            color: .red
+                        )
+                        
+                        VMDHtmlText(
+                            viewModel.htmlTextWithLinks,
+                            style: VMDHtmlTextStyle(
+                                fontSize: 12,
+                                lineHeight: 12
+                            ),
+                            color: .black,
+                            linkTextAttributes: [ .foregroundColor: UIColor.green ]
+                        )
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()

--- a/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Showcase/Components/Text/TextShowcaseViewController.swift
+++ b/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Showcase/Components/Text/TextShowcaseViewController.swift
@@ -9,6 +9,12 @@ class TextShowcaseViewController: BaseViewModelViewController<TextShowcaseViewMo
 }
 
 extension TextShowcaseViewController: TextShowcaseNavigationDelegate {
+    func showMessage(text: String) {
+        let alertController = UIAlertController(title: nil, message: text, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel, handler: nil))
+        present(alertController, animated: true, completion: nil)
+    }
+    
     func close() {
         dismiss(animated: true, completion: nil)
     }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+import TRIKOT_FRAMEWORK_NAME
+import UIKit
+
+public struct VMDHtmlText: View {
+    @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDHtmlTextViewModel>
+    
+    private let style: VMDHtmlTextStyle
+    private let color: Color
+    private let numberOfLines: Int
+    private let linkTextAttributes: [NSAttributedString.Key : Any]?
+    
+    public init(
+        _ viewModel: VMDHtmlTextViewModel,
+        style: VMDHtmlTextStyle,
+        color: Color,
+        numberOfLines: Int = 0,
+        linkTextAttributes: [NSAttributedString.Key : Any]? = nil
+    ) {
+        self.observableViewModel = viewModel.asObservable()
+        self.style = style
+        self.color = color
+        self.numberOfLines = numberOfLines
+        self.linkTextAttributes = linkTextAttributes
+    }
+    
+    private var viewModel: VMDHtmlTextViewModel {
+        observableViewModel.viewModel
+    }
+    
+    public var body: some View {
+        HTMLText(
+            html: viewModel.html,
+            style: style,
+            color: color,
+            numberOfLines: numberOfLines,
+            linkTextAttributes: linkTextAttributes,
+            onOpenURL: viewModel.urlActionBlock
+        )
+    }
+}
+
+private struct HTMLText: UIViewRepresentable {
+
+    private let html: String
+    private let style: VMDHtmlTextStyle
+    private let color: Color
+    private let numberOfLines: Int
+    private let linkTextAttributes: [NSAttributedString.Key : Any]?
+    private let onOpenURL: ((String) -> Void)?
+    
+    init(
+        html: String,
+        style: VMDHtmlTextStyle,
+        color: Color,
+        numberOfLines: Int = 0,
+        linkTextAttributes: [NSAttributedString.Key : Any]? = nil,
+        onOpenURL: ((String) -> Void)? = nil
+    ) {
+        self.html = html
+        self.style = style
+        self.color = color
+        self.numberOfLines = numberOfLines
+        self.linkTextAttributes = linkTextAttributes
+        self.onOpenURL = onOpenURL
+    }
+    
+    func makeUIView(context: Context) -> UITextView {
+        let view = ContentTextView()
+        view.isEditable = true
+        view.isScrollEnabled = false
+        view.backgroundColor = .clear
+        view.textContainer.lineFragmentPadding = .zero
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        view.textContainer.lineBreakMode = .byTruncatingTail
+        view.textContainer.maximumNumberOfLines = numberOfLines
+        let isUserInteractionEnabled = onOpenURL != nil
+        view.isUserInteractionEnabled = isUserInteractionEnabled
+        if isUserInteractionEnabled {
+            view.delegate = context.coordinator
+        }
+        return view
+    }
+    
+    func updateUIView(_ textView: UITextView, context: Context) {
+        DispatchQueue.main.async {
+            textView.attributedText = format(string: fullHtml)
+            textView.textColor = UIColor(color)
+            if let linkTextAttributes {
+                textView.linkTextAttributes = linkTextAttributes
+            }
+            textView.textContainer.maximumNumberOfLines = numberOfLines
+            textView.accessibilityTraits = .staticText
+        }
+        textView.invalidateIntrinsicContentSize()
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    private func format(string: String) -> NSAttributedString? {
+        guard let data = string.data(using: .utf8) else { return nil }
+        
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+        return try? NSAttributedString(data: data, options: options, documentAttributes: nil)
+    }
+    
+    private var fullHtml: String {
+        """
+        <html>
+        <head>
+            <style>
+                body {
+                    font-family: '\(style.fontFamily)';
+                    font-size: \(style.fontSize);
+                    font-weight: \(style.fontWeight.rawValue);
+                    -webkit-text-size-adjust: none;
+                    margin: 0;
+                }
+            </style>
+        </head>
+        <body>
+            \(html)
+        </body>
+        </html>
+        """
+    }
+    
+    final class Coordinator: NSObject, UITextViewDelegate {
+        let parent: HTMLText
+        
+        init(_ parent: HTMLText) {
+            self.parent = parent
+        }
+        
+        func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+            parent.onOpenURL?(URL.absoluteString)
+            return false
+        }
+    }
+    
+    private var fontSize: CGFloat {
+        UIFontMetrics(forTextStyle: style.relativeTextStyle.uiFontTextStyle).scaledValue(for: style.fontSize)
+    }
+    
+    private class ContentTextView: UITextView {
+        override var canBecomeFirstResponder: Bool { false }
+        
+        override var intrinsicContentSize: CGSize {
+            let sizeThatFits = sizeThatFits(CGSize(width: frame.width, height: .greatestFiniteMagnitude))
+            return frame.height > 0 ? sizeThatFits : super.intrinsicContentSize
+        }
+    }
+}
+
+public struct VMDHtmlTextStyle {
+    public var fontSize: CGFloat
+    public var lineHeight: CGFloat
+    public var fontFamily: String
+    public var fontWeight: VMDHtmlTextWeight
+    public var relativeTextStyle: Font.TextStyle
+    
+    public init(
+        fontSize: CGFloat,
+        lineHeight: CGFloat,
+        fontFamily: String = "-apple-system",
+        fontWeight: VMDHtmlTextWeight = VMDHtmlTextWeight.normal,
+        relativeTextStyle: Font.TextStyle = .body
+    ) {
+        self.fontSize = fontSize
+        self.lineHeight = lineHeight
+        self.fontFamily = fontFamily
+        self.fontWeight = fontWeight
+        self.relativeTextStyle = relativeTextStyle
+    }
+}
+
+public enum VMDHtmlTextWeight: Int {
+    case thin = 100
+    case extralight = 200
+    case light = 300
+    case normal = 400
+    case medium = 500
+    case semibold = 600
+    case bold = 700
+    case extrabold = 800
+    case black = 900
+
+    public static let w100 = VMDHtmlTextWeight.thin
+    public static let w200 = VMDHtmlTextWeight.extralight
+    public static let w300 = VMDHtmlTextWeight.light
+    public static let w400 = VMDHtmlTextWeight.normal
+    public static let w500 = VMDHtmlTextWeight.medium
+    public static let w600 = VMDHtmlTextWeight.semibold
+    public static let w700 = VMDHtmlTextWeight.bold
+    public static let w800 = VMDHtmlTextWeight.extrabold
+    public static let w900 = VMDHtmlTextWeight.black
+}
+
+private extension Font.TextStyle {
+    var uiFontTextStyle: UIFont.TextStyle {
+        switch self {
+        case .largeTitle: return .largeTitle
+        case .title: return .title1
+        case .title2: return .title2
+        case .title3: return .title3
+        case .headline: return .headline
+        case .subheadline: return .subheadline
+        case .body: return .body
+        case .callout: return .callout
+        case .caption: return .caption1
+        case .caption2: return .caption2
+        case .footnote: return .footnote
+        @unknown default:
+            return .body
+        }
+    }
+}

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/android/viewmodels-declarative-flow.api
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/android/viewmodels-declarative-flow.api
@@ -377,10 +377,11 @@ public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDControl
 	public fun setEnabled (Z)V
 }
 
-public final class com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel {
+public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel {
 	public fun <init> (Lkotlinx/coroutines/CoroutineScope;)V
 	public final fun bindHtml (Lkotlinx/coroutines/flow/Flow;)V
 	public fun getHtml ()Ljava/lang/String;
+	protected fun getPropertyMapping ()Ljava/util/Map;
 	public fun getUrlActionBlock ()Lkotlin/jvm/functions/Function1;
 	public fun setHtml (Ljava/lang/String;)V
 	public final fun setUrlAction (Lkotlin/jvm/functions/Function1;)V

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/android/viewmodels-declarative-flow.api
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/android/viewmodels-declarative-flow.api
@@ -101,6 +101,11 @@ public abstract interface class com/mirego/trikot/viewmodels/declarative/compone
 	public abstract fun isEnabled ()Z
 }
 
+public abstract interface class com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModel {
+	public abstract fun getHtml ()Ljava/lang/String;
+	public abstract fun getUrlActionBlock ()Lkotlin/jvm/functions/Function1;
+}
+
 public abstract interface class com/mirego/trikot/viewmodels/declarative/components/VMDImageViewModel : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModel {
 	public abstract fun getContentDescription ()Ljava/lang/String;
 	public abstract fun getImage ()Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageDescriptor;
@@ -293,6 +298,8 @@ public final class com/mirego/trikot/viewmodels/declarative/components/factory/V
 	public final fun withContent (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public static synthetic fun withContent$default (Lcom/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents$Text$Companion;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public static synthetic fun withContent$default (Lcom/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents$Text$Companion;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
+	public final fun withHtml (Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
+	public final fun withHtml (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
 	public final fun withSpans (Ljava/lang/String;Ljava/util/List;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public final fun withSpans (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public static synthetic fun withSpans$default (Lcom/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents$Text$Companion;Ljava/lang/String;Ljava/util/List;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
@@ -368,6 +375,17 @@ public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDControl
 	protected fun getPropertyMapping ()Ljava/util/Map;
 	public fun isEnabled ()Z
 	public fun setEnabled (Z)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;)V
+	public final fun bindHtml (Lkotlinx/coroutines/flow/Flow;)V
+	public fun getHtml ()Ljava/lang/String;
+	public fun getUrlActionBlock ()Lkotlin/jvm/functions/Function1;
+	public fun setHtml (Ljava/lang/String;)V
+	public final fun setUrlAction (Lkotlin/jvm/functions/Function1;)V
+	public final fun setUrlAction (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)V
+	public fun setUrlActionBlock (Lkotlin/jvm/functions/Function1;)V
 }
 
 public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDImageViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDImageViewModel {
@@ -947,6 +965,8 @@ public final class com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewMod
 	public static synthetic fun buttonWithTextPair$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl;
 	public static final fun determinateProgress (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;FFLkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDProgressViewModelImpl;
 	public static synthetic fun determinateProgress$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;FFLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDProgressViewModelImpl;
+	public static final fun htmlText (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
+	public static synthetic fun htmlText$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
 	public static final fun image (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageDescriptor;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDImageViewModelImpl;
 	public static synthetic fun image$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageDescriptor;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDImageViewModelImpl;
 	public static final fun indeterminateProgress (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDProgressViewModelImpl;

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/jvm/viewmodels-declarative-flow.api
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/jvm/viewmodels-declarative-flow.api
@@ -377,10 +377,11 @@ public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDControl
 	public fun setEnabled (Z)V
 }
 
-public final class com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel {
+public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel {
 	public fun <init> (Lkotlinx/coroutines/CoroutineScope;)V
 	public final fun bindHtml (Lkotlinx/coroutines/flow/Flow;)V
 	public fun getHtml ()Ljava/lang/String;
+	protected fun getPropertyMapping ()Ljava/util/Map;
 	public fun getUrlActionBlock ()Lkotlin/jvm/functions/Function1;
 	public fun setHtml (Ljava/lang/String;)V
 	public final fun setUrlAction (Lkotlin/jvm/functions/Function1;)V

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/jvm/viewmodels-declarative-flow.api
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/api/jvm/viewmodels-declarative-flow.api
@@ -101,6 +101,11 @@ public abstract interface class com/mirego/trikot/viewmodels/declarative/compone
 	public abstract fun isEnabled ()Z
 }
 
+public abstract interface class com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModel {
+	public abstract fun getHtml ()Ljava/lang/String;
+	public abstract fun getUrlActionBlock ()Lkotlin/jvm/functions/Function1;
+}
+
 public abstract interface class com/mirego/trikot/viewmodels/declarative/components/VMDImageViewModel : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModel {
 	public abstract fun getContentDescription ()Ljava/lang/String;
 	public abstract fun getImage ()Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageDescriptor;
@@ -293,6 +298,8 @@ public final class com/mirego/trikot/viewmodels/declarative/components/factory/V
 	public final fun withContent (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public static synthetic fun withContent$default (Lcom/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents$Text$Companion;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public static synthetic fun withContent$default (Lcom/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents$Text$Companion;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
+	public final fun withHtml (Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
+	public final fun withHtml (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
 	public final fun withSpans (Ljava/lang/String;Ljava/util/List;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public final fun withSpans (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
 	public static synthetic fun withSpans$default (Lcom/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents$Text$Companion;Ljava/lang/String;Ljava/util/List;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDTextViewModelImpl;
@@ -368,6 +375,17 @@ public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDControl
 	protected fun getPropertyMapping ()Ljava/util/Map;
 	public fun isEnabled ()Z
 	public fun setEnabled (Z)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;)V
+	public final fun bindHtml (Lkotlinx/coroutines/flow/Flow;)V
+	public fun getHtml ()Ljava/lang/String;
+	public fun getUrlActionBlock ()Lkotlin/jvm/functions/Function1;
+	public fun setHtml (Ljava/lang/String;)V
+	public final fun setUrlAction (Lkotlin/jvm/functions/Function1;)V
+	public final fun setUrlAction (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)V
+	public fun setUrlActionBlock (Lkotlin/jvm/functions/Function1;)V
 }
 
 public class com/mirego/trikot/viewmodels/declarative/components/impl/VMDImageViewModelImpl : com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelImpl, com/mirego/trikot/viewmodels/declarative/components/VMDImageViewModel {
@@ -877,6 +895,8 @@ public final class com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewMod
 	public static synthetic fun buttonWithTextPair$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDButtonViewModelImpl;
 	public static final fun determinateProgress (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;FFLkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDProgressViewModelImpl;
 	public static synthetic fun determinateProgress$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;FFLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDProgressViewModelImpl;
+	public static final fun htmlText (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
+	public static synthetic fun htmlText$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl;
 	public static final fun image (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageDescriptor;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDImageViewModelImpl;
 	public static synthetic fun image$default (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Lcom/mirego/trikot/viewmodels/declarative/properties/VMDImageDescriptor;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDImageViewModelImpl;
 	public static final fun indeterminateProgress (Lcom/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL;Lkotlin/jvm/functions/Function1;)Lcom/mirego/trikot/viewmodels/declarative/components/impl/VMDProgressViewModelImpl;

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/VMDHtmlTextViewModel.kt
@@ -1,0 +1,10 @@
+package com.mirego.trikot.viewmodels.declarative.components
+
+import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModel
+
+typealias VMDUrlActionBlock = (url: String) -> Unit
+
+interface VMDHtmlTextViewModel : VMDViewModel {
+    val html: String
+    val urlActionBlock: VMDUrlActionBlock?
+}

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/factory/VMDComponents.kt
@@ -3,6 +3,7 @@ package com.mirego.trikot.viewmodels.declarative.components.factory
 import com.mirego.trikot.viewmodels.declarative.components.VMDPickerItemViewModel
 import com.mirego.trikot.viewmodels.declarative.components.VMDPickerViewModel
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDButtonViewModelImpl
+import com.mirego.trikot.viewmodels.declarative.components.impl.VMDHtmlTextViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDImageViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDListViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDLoadingViewModelImpl
@@ -87,6 +88,28 @@ object VMDComponents {
                     .apply {
                         bindText(contentFlow)
                         bindSpans(spansFlow)
+                    }
+                    .apply(closure)
+
+            fun withHtml(
+                html: String,
+                coroutineScope: CoroutineScope,
+                closure: VMDHtmlTextViewModelImpl.() -> Unit
+            ) =
+                VMDHtmlTextViewModelImpl(coroutineScope)
+                    .apply {
+                        this.html = html
+                    }
+                    .apply(closure)
+
+            fun withHtml(
+                htmlFlow: Flow<String>,
+                coroutineScope: CoroutineScope,
+                closure: VMDHtmlTextViewModelImpl.() -> Unit
+            ) =
+                VMDHtmlTextViewModelImpl(coroutineScope)
+                    .apply {
+                        bindHtml(htmlFlow)
                     }
                     .apply(closure)
         }

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
-class VMDHtmlTextViewModelImpl(coroutineScope: CoroutineScope) :
+open class VMDHtmlTextViewModelImpl(coroutineScope: CoroutineScope) :
     VMDViewModelImpl(coroutineScope), VMDHtmlTextViewModel {
 
     private val htmlDelegate = emit("", this, coroutineScope)

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/components/impl/VMDHtmlTextViewModelImpl.kt
@@ -1,0 +1,45 @@
+package com.mirego.trikot.viewmodels.declarative.components.impl
+
+import com.mirego.trikot.foundation.concurrent.atomic
+import com.mirego.trikot.viewmodels.declarative.components.VMDHtmlTextViewModel
+import com.mirego.trikot.viewmodels.declarative.components.VMDUrlActionBlock
+import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModelImpl
+import com.mirego.trikot.viewmodels.declarative.viewmodel.internal.VMDFlowProperty
+import com.mirego.trikot.viewmodels.declarative.viewmodel.internal.emit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+
+class VMDHtmlTextViewModelImpl(coroutineScope: CoroutineScope) :
+    VMDViewModelImpl(coroutineScope), VMDHtmlTextViewModel {
+
+    private val htmlDelegate = emit("", this, coroutineScope)
+    override var html: String by htmlDelegate
+
+    override var urlActionBlock: VMDUrlActionBlock? by atomic(null)
+
+    fun bindHtml(flow: Flow<String>) {
+        updateProperty(this::html, flow)
+    }
+
+    fun setUrlAction(urlAction: VMDUrlActionBlock) {
+        urlActionBlock = { url ->
+            urlAction.invoke(url)
+        }
+    }
+
+    fun <T> setUrlAction(flow: Flow<T>, action: VMDUrlActionBlock) {
+        urlActionBlock = { url ->
+            coroutineScope.launch {
+                flow.firstOrNull()?.let { action(url) }
+            }
+        }
+    }
+
+    override val propertyMapping: Map<String, VMDFlowProperty<*>> by lazy {
+        super.propertyMapping.toMutableMap().also {
+            it[this::html.name] = htmlDelegate
+        }
+    }
+}

--- a/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL.kt
+++ b/trikot-viewmodels-declarative-flow/viewmodels-declarative-flow/src/commonMain/kotlin/com/mirego/trikot/viewmodels/declarative/viewmodel/VMDViewModelDSL.kt
@@ -3,6 +3,7 @@ package com.mirego.trikot.viewmodels.declarative.viewmodel
 import com.mirego.trikot.viewmodels.declarative.components.VMDPickerItemViewModel
 import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDButtonViewModelImpl
+import com.mirego.trikot.viewmodels.declarative.components.impl.VMDHtmlTextViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDImageViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDListViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDLoadingViewModelImpl
@@ -31,6 +32,9 @@ interface VMDViewModelDSL {
 
 fun VMDViewModelDSL.text(content: String = "", spans: List<VMDRichTextSpan> = emptyList(), closure: VMDTextViewModelImpl.() -> Unit = {}) =
     VMDComponents.Text.withSpans(content, spans, coroutineScope, closure)
+
+fun VMDViewModelDSL.htmlText(content: String = "", closure: VMDHtmlTextViewModelImpl.() -> Unit = {}) =
+    VMDComponents.Text.withHtml(content, coroutineScope, closure)
 
 fun VMDViewModelDSL.localImage(image: VMDImageResource = VMDImageResource.None, contentDescription: String? = null, closure: VMDImageViewModelImpl.() -> Unit = {}) =
     VMDComponents.Image.local(image, coroutineScope, contentDescription, closure)


### PR DESCRIPTION
## Description
Renders html text (a subset of html tags) in a Text component in switui / compose. Rendering differ slightly on both platforms but is generally more performant than using a full fledged webview.

## Motivation and Context
Needed to render a list of html blocks interlaced with other type of views.

## How Has This Been Tested?
Added sample

![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-16 at 17 54 08](https://github.com/mirego/trikot/assets/618592/2e7a8971-3662-411f-a726-e9e8c7d0ede3)
![Screenshot_20231016_193629](https://github.com/mirego/trikot/assets/618592/bb8362e7-7627-4578-b87e-ff72811c5ba4)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
