### PR TITLE
Compose material 3 bindings

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/api/compose-flow.api
+++ b/trikot-viewmodels-declarative-flow/compose-flow/api/compose-flow.api
@@ -169,6 +169,68 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 	public static final fun VMDText--4IGK_g (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
 }
 
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDCheckboxKt {
+	public static final field INSTANCE Lcom/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDCheckboxKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
+	public static field lambda-2 Lkotlin/jvm/functions/Function4;
+	public fun <init> ()V
+	public final fun getLambda-1$compose_flow_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda-2$compose_flow_release ()Lkotlin/jvm/functions/Function4;
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDSwitchKt {
+	public static final field INSTANCE Lcom/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDSwitchKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
+	public static field lambda-2 Lkotlin/jvm/functions/Function4;
+	public fun <init> ()V
+	public final fun getLambda-1$compose_flow_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda-2$compose_flow_release ()Lkotlin/jvm/functions/Function4;
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDBasicTextFieldKt {
+	public static final fun VMDBasicTextField (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/ui/Modifier;ZLandroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/text/KeyboardActions;ZIIZLkotlin/jvm/functions/Function1;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/TextFieldColors;Landroidx/compose/ui/graphics/Brush;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckboxKt {
+	public static final fun DisabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun EnabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun SimpleTextToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicatorKt {
+	public static final fun DeterminateCircularProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenuKt {
+	public static final fun VMDDropDownMenu-x0xb5LI (Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerViewModel;ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;JLandroidx/compose/ui/window/PopupProperties;Lkotlin/jvm/functions/Function5;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDDropDownMenuItem (Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerViewModel;Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerItemViewModel;ILandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function2;Landroidx/compose/material3/MenuItemColors;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicatorKt {
+	public static final fun DeterminateLinearProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitchKt {
+	public static final fun DisabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun EnabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun SimpleTextSwitchPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextFieldKt {
+	public static final fun VMDTextField (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/text/KeyboardActions;ZZIILandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/TextFieldColors;Landroidx/compose/runtime/Composer;III)V
+	public static final fun buildKeyboardActions (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/foundation/text/KeyboardActions;)Landroidx/compose/foundation/text/KeyboardActions;
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextKt {
+	public static final fun VMDText--4IGK_g (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+}
+
 public final class com/mirego/trikot/viewmodels/declarative/configuration/DefaultImageProvider : com/mirego/trikot/viewmodels/declarative/configuration/VMDImageProvider {
 	public static final field $stable I
 	public fun <init> ()V

--- a/trikot-viewmodels-declarative-flow/compose-flow/api/compose-flow.api
+++ b/trikot-viewmodels-declarative-flow/compose-flow/api/compose-flow.api
@@ -87,15 +87,11 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckboxKt {
-	public static final fun DisabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicatorKt {
-	public static final fun DeterminateCircularProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
 }
 
@@ -139,7 +135,6 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicatorKt {
-	public static final fun DeterminateLinearProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
 }
 
@@ -153,9 +148,6 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitchKt {
-	public static final fun DisabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextSwitchPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 }
@@ -192,15 +184,11 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckboxKt {
-	public static final fun DisabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicatorKt {
-	public static final fun DeterminateCircularProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
 }
 
@@ -210,14 +198,10 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicatorKt {
-	public static final fun DeterminateLinearProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitchKt {
-	public static final fun DisabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextSwitchPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 }

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
@@ -75,21 +75,21 @@ fun <C : VMDContent> VMDCheckbox(
 
 @Preview
 @Composable
-fun EnabledToggleCheckboxPreview() {
+private fun EnabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(true, MainScope())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun DisabledToggleCheckboxPreview() {
+private fun DisabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(false, MainScope())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun SimpleTextToggleCheckboxPreview() {
+private fun SimpleTextToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withText("Label", true, MainScope())
     VMDCheckbox(viewModel = toggleViewModel, label = { Text(it.text) })
 }

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
@@ -54,7 +54,7 @@ fun VMDCircularProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateCircularProgressIndicatorPreview() {
+private fun DeterminateCircularProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, MainScope())
     VMDCircularProgressIndicator(
         viewModel = progressViewModel

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
@@ -47,7 +47,7 @@ fun VMDLinearProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateLinearProgressIndicatorPreview() {
+private fun DeterminateLinearProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, MainScope())
     VMDLinearProgressIndicator(
         modifier = Modifier.fillMaxWidth(),

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
@@ -75,7 +75,7 @@ fun <C : VMDContent> VMDSwitch(
 
 @Preview
 @Composable
-fun EnabledSwitchPreview() {
+private fun EnabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(true, MainScope())
     VMDSwitch(viewModel = toggleViewModel)
@@ -83,7 +83,7 @@ fun EnabledSwitchPreview() {
 
 @Preview
 @Composable
-fun DisabledSwitchPreview() {
+private fun DisabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(false, MainScope())
     VMDSwitch(viewModel = toggleViewModel)
@@ -91,7 +91,7 @@ fun DisabledSwitchPreview() {
 
 @Preview
 @Composable
-fun SimpleTextSwitchPreview() {
+private fun SimpleTextSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withText("Label", true, MainScope())
     VMDSwitch(viewModel = toggleViewModel, label = { Text(it.text) })

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDBasicTextField.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDBasicTextField.kt
@@ -1,0 +1,102 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextFieldViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.composeValue
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.FormattedVisualTransformation
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VMDBasicTextField(
+    viewModel: VMDTextFieldViewModel,
+    modifier: Modifier = Modifier,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    placeHolderStyle: TextStyle = LocalTextStyle.current,
+    keyboardActions: KeyboardActions = KeyboardActions(),
+    singleLine: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    isError: Boolean = false,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: TextFieldColors = TextFieldDefaults.colors(),
+    cursorBrush: Brush = SolidColor(Color.Black),
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    contentPadding: PaddingValues = TextFieldDefaults.contentPaddingWithoutLabel()
+) {
+    val textFieldViewModel: VMDTextFieldViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val keyboardActionsDelegate = buildKeyboardActions(viewModel, keyboardActions)
+
+    val textColor = textStyle.color
+    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+    val visualTransformation = FormattedVisualTransformation(viewModel.formatText)
+
+    BasicTextField(
+        value = viewModel.text,
+        onValueChange = { value: String ->
+            viewModel.onValueChange(value)
+        },
+        modifier = modifier.vmdModifier(viewModel),
+        enabled = textFieldViewModel.isEnabled,
+        readOnly = readOnly,
+        textStyle = mergedTextStyle,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = textFieldViewModel.keyboardType.composeValue,
+            capitalization = textFieldViewModel.autoCapitalization.composeValue,
+            imeAction = textFieldViewModel.keyboardReturnKeyType.composeValue
+        ),
+        keyboardActions = keyboardActionsDelegate,
+        maxLines = maxLines,
+        minLines = minLines,
+        singleLine = singleLine,
+        visualTransformation = visualTransformation,
+        onTextLayout = onTextLayout,
+        interactionSource = interactionSource,
+        cursorBrush = cursorBrush,
+        decorationBox = @Composable { innerTextField ->
+            TextFieldDefaults.DecorationBox(
+                value = viewModel.text,
+                visualTransformation = visualTransformation,
+                innerTextField = innerTextField,
+                placeholder = {
+                    Text(
+                        text = textFieldViewModel.placeholder,
+                        style = placeHolderStyle
+                    )
+                },
+                singleLine = singleLine,
+                enabled = viewModel.isEnabled,
+                isError = isError,
+                interactionSource = interactionSource,
+                colors = colors,
+                contentPadding = contentPadding,
+                leadingIcon = leadingIcon,
+                trailingIcon = trailingIcon
+            )
+        }
+    )
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDBasicTextField.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDBasicTextField.kt
@@ -27,7 +27,7 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsStat
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.FormattedVisualTransformation
 
-@OptIn(ExperimentalMaterial3Api::class)
+@ExperimentalMaterial3Api
 @Composable
 fun VMDBasicTextField(
     viewModel: VMDTextFieldViewModel,

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDBasicTextField.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDBasicTextField.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import com.mirego.trikot.viewmodels.declarative.components.VMDTextFieldViewModel

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
@@ -76,21 +76,21 @@ fun <C : VMDContent> VMDCheckbox(
 
 @Preview
 @Composable
-fun EnabledToggleCheckboxPreview() {
+private fun EnabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(true, MainScope())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun DisabledToggleCheckboxPreview() {
+private fun DisabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(false, MainScope())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun SimpleTextToggleCheckboxPreview() {
+private fun SimpleTextToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withText("Label", true, MainScope())
     VMDCheckbox(viewModel = toggleViewModel, label = { Text(it.text) })
 }

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
@@ -1,0 +1,96 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxColors
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import com.mirego.trikot.viewmodels.declarative.components.VMDToggleViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLabeledComponent
+import com.mirego.trikot.viewmodels.declarative.content.VMDContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
+import kotlinx.coroutines.MainScope
+
+@Composable
+fun VMDCheckbox(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<VMDNoContent>,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: CheckboxColors = CheckboxDefaults.colors()
+) {
+    VMDCheckbox(
+        modifier = modifier,
+        componentModifier = componentModifier,
+        viewModel = viewModel,
+        label = {},
+        interactionSource = interactionSource,
+        colors = colors
+    )
+}
+
+@Composable
+fun <C : VMDContent> VMDCheckbox(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<C>,
+    label: @Composable (RowScope.(field: C) -> Unit),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: CheckboxColors = CheckboxDefaults.colors()
+) {
+    val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDLabeledComponent(
+        modifier = modifier
+            .toggleable(
+                value = toggleViewModel.isOn,
+                role = Role.Checkbox,
+                onValueChange = { checked -> viewModel.onValueChange(checked) },
+            )
+            .vmdModifier(toggleViewModel),
+        label = { label(toggleViewModel.label) },
+        content = {
+            Checkbox(
+                onCheckedChange = null,
+                modifier = componentModifier,
+                enabled = toggleViewModel.isEnabled,
+                checked = toggleViewModel.isOn,
+                interactionSource = interactionSource,
+                colors = colors,
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EnabledToggleCheckboxPreview() {
+    val toggleViewModel = VMDComponents.Toggle.withState(true, MainScope())
+    VMDCheckbox(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun DisabledToggleCheckboxPreview() {
+    val toggleViewModel = VMDComponents.Toggle.withState(false, MainScope())
+    VMDCheckbox(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun SimpleTextToggleCheckboxPreview() {
+    val toggleViewModel = VMDComponents.Toggle.withText("Label", true, MainScope())
+    VMDCheckbox(viewModel = toggleViewModel, label = { Text(it.text) })
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
@@ -1,0 +1,62 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import com.mirego.trikot.viewmodels.declarative.components.VMDProgressViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+import kotlinx.coroutines.MainScope
+
+@Composable
+fun VMDCircularProgressIndicator(
+    modifier: Modifier = Modifier,
+    viewModel: VMDProgressViewModel,
+    color: Color = MaterialTheme.colorScheme.primary,
+    strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
+    trackColor: Color = ProgressIndicatorDefaults.circularTrackColor,
+    strokeCap: StrokeCap = StrokeCap.Square
+) {
+    val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val animatedProgress by animateFloatAsState(targetValue = progressViewModel.determination?.progressRatio ?: 0f, label = "animatedProgress")
+
+    val newModifier = modifier.vmdModifier(progressViewModel)
+
+    if (viewModel.determination == null) {
+        CircularProgressIndicator(
+            modifier = newModifier,
+            color = color,
+            strokeWidth = strokeWidth,
+            trackColor = trackColor,
+            strokeCap = strokeCap
+        )
+    } else {
+        CircularProgressIndicator(
+            modifier = newModifier,
+            progress = animatedProgress,
+            color = color,
+            strokeWidth = strokeWidth,
+            trackColor = trackColor,
+            strokeCap = strokeCap
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DeterminateCircularProgressIndicatorPreview() {
+    val progressViewModel = VMDComponents.Progress.determinate(0.25f, MainScope())
+    VMDCircularProgressIndicator(
+        viewModel = progressViewModel
+    )
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
@@ -54,7 +54,7 @@ fun VMDCircularProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateCircularProgressIndicatorPreview() {
+private fun DeterminateCircularProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, MainScope())
     VMDCircularProgressIndicator(
         viewModel = progressViewModel

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
@@ -71,7 +71,7 @@ fun <E : VMDPickerItemViewModel> VMDDropDownMenuItem(
         enabled = pickerItemViewModel.isEnabled,
         contentPadding = contentPadding,
         colors = colors,
-        leadingIcon =  leadingIcon,
+        leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
         interactionSource = interactionSource
     )

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
@@ -1,0 +1,79 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MenuDefaults
+import androidx.compose.material3.MenuItemColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupProperties
+import com.mirego.trikot.viewmodels.declarative.components.VMDPickerItemViewModel
+import com.mirego.trikot.viewmodels.declarative.components.VMDPickerViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+
+@Composable
+fun <E : VMDPickerItemViewModel> VMDDropDownMenu(
+    viewModel: VMDPickerViewModel<E>,
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    offset: DpOffset = DpOffset(0.dp, 0.dp),
+    properties: PopupProperties = PopupProperties(focusable = true),
+    content: @Composable ColumnScope.(item: E, index: Int) -> Unit
+) {
+    val pickerViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.vmdModifier(pickerViewModel),
+        offset = offset,
+        properties = properties
+    ) {
+        pickerViewModel.elements.forEachIndexed { index, item ->
+            content(item, index)
+        }
+    }
+}
+
+@Composable
+fun <E : VMDPickerItemViewModel> VMDDropDownMenuItem(
+    pickerViewModel: VMDPickerViewModel<E>,
+    viewModel: E,
+    index: Int,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    contentPadding: PaddingValues = MenuDefaults.DropdownMenuItemContentPadding,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    text: @Composable () -> Unit,
+    colors: MenuItemColors = MenuDefaults.itemColors(),
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+) {
+    val pickerItemViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    DropdownMenuItem(
+        onClick = {
+            pickerViewModel.selectedIndex = index
+            onClick()
+        },
+        text = text,
+        modifier = modifier.vmdModifier(pickerItemViewModel),
+        enabled = pickerItemViewModel.isEnabled,
+        contentPadding = contentPadding,
+        colors = colors,
+        leadingIcon =  leadingIcon,
+        trailingIcon = trailingIcon,
+        interactionSource = interactionSource
+    )
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
@@ -1,0 +1,55 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.mirego.trikot.viewmodels.declarative.components.VMDProgressViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+import kotlinx.coroutines.MainScope
+
+@Composable
+fun VMDLinearProgressIndicator(
+    modifier: Modifier = Modifier,
+    viewModel: VMDProgressViewModel,
+    color: Color = ProgressIndicatorDefaults.linearColor,
+    trackColor: Color = ProgressIndicatorDefaults.linearTrackColor
+) {
+    val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val animatedProgress by animateFloatAsState(targetValue = viewModel.determination?.progressRatio ?: 0f)
+
+    val newModifier = modifier.vmdModifier(progressViewModel)
+
+    if (viewModel.determination == null) {
+        LinearProgressIndicator(
+            modifier = newModifier,
+            color = color,
+            trackColor = trackColor
+        )
+    } else {
+        LinearProgressIndicator(
+            modifier = newModifier,
+            progress = animatedProgress,
+            color = color,
+            trackColor = trackColor
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DeterminateLinearProgressIndicatorPreview() {
+    val progressViewModel = VMDComponents.Progress.determinate(0.25f, MainScope())
+    VMDLinearProgressIndicator(
+        modifier = Modifier.fillMaxWidth(),
+        viewModel = progressViewModel
+    )
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
@@ -46,7 +46,7 @@ fun VMDLinearProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateLinearProgressIndicatorPreview() {
+private fun DeterminateLinearProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, MainScope())
     VMDLinearProgressIndicator(
         modifier = Modifier.fillMaxWidth(),

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
@@ -1,0 +1,99 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchColors
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import com.mirego.trikot.viewmodels.declarative.components.VMDToggleViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLabeledComponent
+import com.mirego.trikot.viewmodels.declarative.content.VMDContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
+import kotlinx.coroutines.MainScope
+
+@Composable
+fun VMDSwitch(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<VMDNoContent>,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: SwitchColors = SwitchDefaults.colors()
+) {
+    VMDSwitch(
+        modifier = modifier,
+        componentModifier = componentModifier,
+        viewModel = viewModel,
+        label = {},
+        interactionSource = interactionSource,
+        colors = colors
+    )
+}
+
+@Composable
+fun <C : VMDContent> VMDSwitch(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<C>,
+    label: @Composable (RowScope.(field: C) -> Unit),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: SwitchColors = SwitchDefaults.colors()
+) {
+    val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDLabeledComponent(
+        modifier = modifier
+            .toggleable(
+                value = toggleViewModel.isOn,
+                role = Role.Switch,
+                onValueChange = { checked -> viewModel.onValueChange(checked) },
+            )
+            .vmdModifier(toggleViewModel),
+        label = { label(toggleViewModel.label) },
+        content = {
+            Switch(
+                modifier = componentModifier,
+                enabled = toggleViewModel.isEnabled,
+                checked = toggleViewModel.isOn,
+                colors = colors,
+                interactionSource = interactionSource,
+                onCheckedChange = null
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EnabledSwitchPreview() {
+    val toggleViewModel =
+        VMDComponents.Toggle.withState(true, MainScope())
+    VMDSwitch(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun DisabledSwitchPreview() {
+    val toggleViewModel =
+        VMDComponents.Toggle.withState(false, MainScope())
+    VMDSwitch(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun SimpleTextSwitchPreview() {
+    val toggleViewModel =
+        VMDComponents.Toggle.withText("Label", true, MainScope())
+    VMDSwitch(viewModel = toggleViewModel, label = { Text(it.text) })
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
@@ -76,7 +76,7 @@ fun <C : VMDContent> VMDSwitch(
 
 @Preview
 @Composable
-fun EnabledSwitchPreview() {
+private fun EnabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(true, MainScope())
     VMDSwitch(viewModel = toggleViewModel)
@@ -84,7 +84,7 @@ fun EnabledSwitchPreview() {
 
 @Preview
 @Composable
-fun DisabledSwitchPreview() {
+private fun DisabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(false, MainScope())
     VMDSwitch(viewModel = toggleViewModel)
@@ -92,7 +92,7 @@ fun DisabledSwitchPreview() {
 
 @Preview
 @Composable
-fun SimpleTextSwitchPreview() {
+private fun SimpleTextSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withText("Label", true, MainScope())
     VMDSwitch(viewModel = toggleViewModel, label = { Text(it.text) })

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDText.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDText.kt
@@ -1,0 +1,65 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.toAnnotatedString
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+
+@Composable
+fun VMDText(
+    modifier: Modifier = Modifier,
+    viewModel: VMDTextViewModel,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current
+) {
+    val textViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    Text(
+        text = textViewModel.toAnnotatedString(),
+        modifier = modifier.vmdModifier(textViewModel),
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = style
+    )
+}

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextField.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextField.kt
@@ -1,0 +1,107 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextFieldViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.composeValue
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.FormattedVisualTransformation
+
+@Composable
+fun VMDTextField(
+    modifier: Modifier = Modifier,
+    viewModel: VMDTextFieldViewModel,
+    textStyle: TextStyle = LocalTextStyle.current,
+    placeHolderStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    keyboardActions: KeyboardActions = KeyboardActions(),
+    isError: Boolean = false,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
+    textFieldColors: TextFieldColors = TextFieldDefaults.colors()
+) {
+    val textFieldViewModel: VMDTextFieldViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val keyboardActionsDelegate = buildKeyboardActions(viewModel, keyboardActions)
+
+    TextField(
+        modifier = modifier.vmdModifier(textFieldViewModel),
+        value = textFieldViewModel.text,
+        onValueChange = { value ->
+            viewModel.onValueChange(value)
+        },
+        enabled = textFieldViewModel.isEnabled,
+        label = label,
+        placeholder = {
+            Text(
+                text = textFieldViewModel.placeholder,
+                style = placeHolderStyle
+            )
+        },
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        textStyle = textStyle,
+        isError = isError,
+        visualTransformation = FormattedVisualTransformation(viewModel.formatText),
+        keyboardActions = keyboardActionsDelegate,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = textFieldViewModel.keyboardType.composeValue,
+            capitalization = textFieldViewModel.autoCapitalization.composeValue,
+            imeAction = textFieldViewModel.keyboardReturnKeyType.composeValue
+        ),
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        shape = shape,
+        colors = textFieldColors
+    )
+}
+
+fun buildKeyboardActions(viewModel: VMDTextFieldViewModel, keyboardActions: KeyboardActions) =
+    KeyboardActions(
+        onDone = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onDone?.invoke(this)
+        },
+        onNext = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onNext?.invoke(this)
+        },
+        onGo = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onGo?.invoke(this)
+        },
+        onPrevious = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onPrevious?.invoke(this)
+        },
+        onSearch = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onSearch?.invoke(this)
+        },
+        onSend = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onSend?.invoke(this)
+        }
+    )

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
@@ -126,6 +126,6 @@ private fun AnimationSection(animationTypeViewModel: AnimationTypeShowcaseViewMo
 
 @Preview(showSystemUi = true)
 @Composable
-fun AnimationTypesShowcaseViewPreview() {
+private fun AnimationTypesShowcaseViewPreview() {
     AnimationTypesShowcaseView(animationTypesShowcaseViewModel = AnimationTypesShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
@@ -124,7 +124,7 @@ fun ButtonShowcaseView(buttonShowcaseViewModel: ButtonShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ButtonShowcaseViewPreview() {
+private fun ButtonShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     ButtonShowcaseView(buttonShowcaseViewModel = ButtonShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -209,7 +209,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ImageShowcaseViewPreview() {
+private fun ImageShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     ImageShowcaseView(imageShowcaseViewModel = ImageShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
@@ -13,8 +14,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.mirego.sample.ui.showcase.ComponentShowcaseTitle
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
+import com.mirego.sample.ui.theming.SampleTextStyle
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDDropDownMenu
@@ -23,39 +26,80 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDDropDownMen
 @Composable
 fun PickerShowcaseView(pickerShowcaseViewModel: PickerShowcaseViewModel) {
     var expanded by remember { mutableStateOf(false) }
+    var expanded2 by remember { mutableStateOf(false) }
     val viewModel: PickerShowcaseViewModel by pickerShowcaseViewModel.observeAsState()
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
     ) {
         ComponentShowcaseTopBar(viewModel)
 
-        Row(
-            Modifier
+        Column(
+            modifier = Modifier
                 .fillMaxWidth()
-                .clickable {
-                    expanded = true
-                }
+                .verticalScroll(state = rememberScrollState())
+                .padding(horizontal = 16.dp),
         ) {
-            ComponentShowcaseTitle(viewModel.textPickerTitle)
-        }
-
-        VMDDropDownMenu(
-            viewModel = viewModel.textPicker,
-            expanded = expanded,
-            onDismissRequest = {
-                expanded = false
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        expanded = true
+                    }
+            ) {
+                ComponentShowcaseTitle(viewModel.textPickerTitle)
             }
-        ) { item, index ->
-            VMDDropDownMenuItem(
-                pickerViewModel = viewModel.textPicker,
-                viewModel = item,
-                index = index,
-                onClick = { expanded = false }
-            ) { pickerItem, _ ->
-                Text(text = pickerItem.content.text)
+
+            VMDDropDownMenu(
+                viewModel = viewModel.textPicker,
+                expanded = expanded,
+                onDismissRequest = {
+                    expanded = false
+                }
+            ) { item, index ->
+                VMDDropDownMenuItem(
+                    pickerViewModel = viewModel.textPicker,
+                    viewModel = item,
+                    index = index,
+                    onClick = { expanded = false }
+                ) { pickerItem, _ ->
+                    Text(text = pickerItem.content.text)
+                }
+            }
+
+            androidx.compose.material3.Text(
+                modifier = Modifier.padding(top = 16.dp),
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        expanded2 = true
+                    }
+            ) {
+                ComponentShowcaseTitle(viewModel.textPickerTitle2)
+            }
+
+            VMDDropDownMenu(
+                viewModel = viewModel.textPicker2,
+                expanded = expanded2,
+                onDismissRequest = {
+                    expanded2 = false
+                }
+            ) { item, index ->
+                com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDDropDownMenuItem(
+                    pickerViewModel = viewModel.textPicker2,
+                    viewModel = item,
+                    index = index,
+                    onClick = { expanded2 = false },
+                    text = {
+                        Text(text = item.content.text)
+                    }
+                )
             }
         }
     }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
@@ -101,8 +101,6 @@ fun ProgressShowcaseView(progressShowcaseViewModel: ProgressShowcaseViewModel) {
                 viewModel = viewModel.indeterminateProgress
             )
         }
-
-
     }
 }
 

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
@@ -1,10 +1,12 @@
 package com.mirego.sample.ui.showcase.components.progress
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -12,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mirego.sample.ui.showcase.ComponentShowcaseTitle
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
+import com.mirego.sample.ui.theming.SampleTextStyle
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModelPreview
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
@@ -25,42 +28,81 @@ fun ProgressShowcaseView(progressShowcaseViewModel: ProgressShowcaseViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
     ) {
         ComponentShowcaseTopBar(viewModel)
 
-        ComponentShowcaseTitle(viewModel.linearDeterminateProgressTitle)
-
-        VMDLinearProgressIndicator(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.determinateProgress
-        )
+                .verticalScroll(state = rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            ComponentShowcaseTitle(viewModel.linearDeterminateProgressTitle)
 
-        ComponentShowcaseTitle(viewModel.linearIndeterminateProgressTitle)
+            VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.determinateProgress
+            )
 
-        VMDLinearProgressIndicator(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.indeterminateProgress
-        )
+            ComponentShowcaseTitle(viewModel.linearIndeterminateProgressTitle)
 
-        ComponentShowcaseTitle(viewModel.circularDeterminateProgressTitle)
+            VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.indeterminateProgress
+            )
 
-        VMDCircularProgressIndicator(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.determinateProgress
-        )
+            ComponentShowcaseTitle(viewModel.circularDeterminateProgressTitle)
 
-        ComponentShowcaseTitle(viewModel.circularIndeterminateProgressTitle)
+            VMDCircularProgressIndicator(
+                modifier = Modifier,
+                viewModel = viewModel.determinateProgress
+            )
 
-        VMDCircularProgressIndicator(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.indeterminateProgress
-        )
+            ComponentShowcaseTitle(viewModel.circularIndeterminateProgressTitle)
+
+            VMDCircularProgressIndicator(
+                viewModel = viewModel.indeterminateProgress
+            )
+
+            Text(
+                modifier = Modifier.padding(top = 10.dp),
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.determinateProgress
+            )
+
+            ComponentShowcaseTitle(viewModel.linearIndeterminateProgressTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.indeterminateProgress
+            )
+
+            ComponentShowcaseTitle(viewModel.circularDeterminateProgressTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCircularProgressIndicator(
+                modifier = Modifier,
+                viewModel = viewModel.determinateProgress
+            )
+
+            ComponentShowcaseTitle(viewModel.circularIndeterminateProgressTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCircularProgressIndicator(
+                viewModel = viewModel.indeterminateProgress
+            )
+        }
+
+
     }
 }
 

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
@@ -108,6 +108,6 @@ fun ProgressShowcaseView(progressShowcaseViewModel: ProgressShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ProgressShowcaseViewPreview() {
+private fun ProgressShowcaseViewPreview() {
     ProgressShowcaseView(progressShowcaseViewModel = ProgressShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -36,13 +37,13 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
     ) {
         ComponentShowcaseTopBar(viewModel)
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(state = rememberScrollState())
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
@@ -146,7 +147,93 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
                     color = Color.Green
                 ),
             )
+
+            Text(
+                modifier = Modifier.padding(top = 16.dp),
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.largeTitle,
+                style = SampleTextStyle.largeTitle
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title1,
+                style = SampleTextStyle.title1
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title1Bold,
+                style = SampleTextStyle.title1.bold()
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title2,
+                style = SampleTextStyle.title2
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title2Bold,
+                style = SampleTextStyle.title2.bold()
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title3,
+                style = SampleTextStyle.title3
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.headline,
+                style = SampleTextStyle.headline
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.body,
+                style = SampleTextStyle.body
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.bodyMedium,
+                style = SampleTextStyle.body.medium()
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.button,
+                style = SampleTextStyle.button
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.callout,
+                style = SampleTextStyle.callout
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.subheadline,
+                style = SampleTextStyle.subheadline
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.footnote,
+                style = SampleTextStyle.footnote
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.caption1,
+                style = SampleTextStyle.caption1
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.caption2,
+                style = SampleTextStyle.caption2
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.richText
+            )
         }
+
     }
 }
 

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -233,7 +233,6 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
                 viewModel = viewModel.richText
             )
         }
-
     }
 }
 

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -239,7 +239,7 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun TextShowcaseViewPreview() {
+private fun TextShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider(), SampleTextStyleProvider())
     TextShowcaseView(textShowcaseViewModel = TextShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
@@ -66,6 +66,39 @@ fun TextFieldShowcaseView(textFieldShowcaseViewModel: TextFieldShowcaseViewModel
 
             VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
         }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            androidx.compose.material3.Text(
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDTextField(viewModel = viewModel.textField)
+
+                VMDButton(
+                    modifier = Modifier.padding(start = 16.dp),
+                    viewModel = viewModel.clearButton
+                ) { content ->
+                    Text(
+                        modifier = Modifier
+                            .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                            .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.onPrimary
+                    )
+                }
+            }
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+        }
     }
 }
 

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
@@ -104,7 +104,7 @@ fun TextFieldShowcaseView(textFieldShowcaseViewModel: TextFieldShowcaseViewModel
 
 @Preview(showSystemUi = true)
 @Composable
-fun TextFieldShowcaseViewPreview() {
+private fun TextFieldShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     TextFieldShowcaseView(textFieldShowcaseViewModel = TextFieldShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -42,7 +42,6 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
                 .fillMaxWidth()
                 .verticalScroll(state = rememberScrollState())
         ) {
-
             ComponentShowcaseTitle(viewModel.checkboxTitle)
 
             VMDCheckbox(

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -182,7 +182,7 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
 
             VMDSwitch(
                 modifier = Modifier
-                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .padding(16.dp)
                     .fillMaxWidth(),
                 viewModel = viewModel.textPairToggle,
                 label = { content ->
@@ -345,7 +345,7 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
 
             com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
                 modifier = Modifier
-                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .padding(16.dp)
                     .fillMaxWidth(),
                 viewModel = viewModel.textPairToggle,
                 label = { content ->
@@ -369,7 +369,7 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ToggleShowcaseViewPreview() {
+private fun ToggleShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     ToggleShowcaseView(toggleShowcaseViewModel = ToggleShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -34,167 +34,336 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
     ) {
         ComponentShowcaseTopBar(viewModel)
 
-        ComponentShowcaseTitle(viewModel.checkboxTitle)
-
-        VMDCheckbox(
+        Column(
             modifier = Modifier
-                .padding(start = 2.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.emptyToggle
-        )
+                .fillMaxWidth()
+                .verticalScroll(state = rememberScrollState())
+        ) {
 
-        ComponentShowcaseTitle(viewModel.textCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.checkboxTitle)
 
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textToggle,
-            label = { Text(it.text, style = SampleTextStyle.body) }
-        )
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 2.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.emptyToggle
+            )
 
-        ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.textCheckboxTitle)
 
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.imageToggle,
-            label = { content ->
-                LocalImage(
-                    imageResource = content.image,
-                    colorFilter = ColorFilter.tint(Color.Black)
-                )
-            }
-        )
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
 
-        ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
 
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textImageToggle,
-            label = { content ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
                     LocalImage(
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
-                    Text(
-                        text = content.text,
-                        style = SampleTextStyle.body
-                    )
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
 
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textPairToggle,
-            label = { content ->
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = content.first,
-                        style = SampleTextStyle.body
-                    )
-                    Text(
-                        text = content.second,
-                        style = SampleTextStyle.caption1
-                    )
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.switchTitle)
+            ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
 
-        VMDSwitch(
-            modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.emptyToggle
-        )
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
 
-        ComponentShowcaseTitle(viewModel.textSwitchTitle)
+            ComponentShowcaseTitle(viewModel.switchTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textToggle,
-            label = { Text(it.text, style = SampleTextStyle.body) }
-        )
+            VMDSwitch(
+                modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.emptyToggle
+            )
 
-        ComponentShowcaseTitle(viewModel.imageSwitchTitle)
+            ComponentShowcaseTitle(viewModel.textSwitchTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.imageToggle,
-            label = { content ->
-                LocalImage(
-                    imageResource = content.image,
-                    colorFilter = ColorFilter.tint(Color.Black)
-                )
-            }
-        )
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
 
-        ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
+            ComponentShowcaseTitle(viewModel.imageSwitchTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textImageToggle,
-            label = { content ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
                     LocalImage(
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
-                    Text(
-                        modifier = Modifier.padding(start = 8.dp),
-                        text = content.text,
-                        style = SampleTextStyle.body
+                }
+            )
+
+            ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
+
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            modifier = Modifier.padding(start = 8.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
+                }
+            )
+
+            ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
+
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
+
+            ComponentShowcaseTitle(viewModel.checkboxTitle)
+
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 2.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.emptyToggle
+            )
+
+            androidx.compose.material3.Text(
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            ComponentShowcaseTitle(viewModel.textCheckboxTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
+
+            ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
+                    LocalImage(
+                        imageResource = content.image,
+                        colorFilter = ColorFilter.tint(Color.Black)
                     )
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
+            ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textPairToggle,
-            label = { content ->
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = content.first,
-                        style = SampleTextStyle.body
-                    )
-                    Text(
-                        text = content.second,
-                        style = SampleTextStyle.caption1
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
+                }
+            )
+
+            ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
+
+            ComponentShowcaseTitle(viewModel.switchTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.emptyToggle
+            )
+
+            ComponentShowcaseTitle(viewModel.textSwitchTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
+
+            ComponentShowcaseTitle(viewModel.imageSwitchTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
+                    LocalImage(
+                        imageResource = content.image,
+                        colorFilter = ColorFilter.tint(Color.Black)
                     )
                 }
-            }
-        )
+            )
+
+            ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            modifier = Modifier.padding(start = 8.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
+                }
+            )
+
+            ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
+        }
     }
 }
 

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModel.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModel.kt
@@ -9,4 +9,6 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
 interface PickerShowcaseViewModel : ShowcaseViewModel {
     val textPickerTitle: VMDTextViewModel
     val textPicker: VMDPickerViewModel<VMDContentPickerItemViewModelImpl<VMDTextContent>>
+    val textPickerTitle2: VMDTextViewModel
+    val textPicker2: VMDPickerViewModel<VMDContentPickerItemViewModelImpl<VMDTextContent>>
 }

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelImpl.kt
@@ -3,7 +3,6 @@ package com.mirego.sample.viewmodels.showcase.components.picker
 import com.mirego.sample.KWordTranslation
 import com.mirego.sample.viewmodels.showcase.ShowcaseViewModelImpl
 import com.mirego.trikot.kword.I18N
-import com.mirego.trikot.viewmodels.declarative.components.VMDPickerViewModel
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDContentPickerItemViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
 import com.mirego.trikot.viewmodels.declarative.viewmodel.picker

--- a/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelImpl.kt
+++ b/trikot-viewmodels-declarative-flow/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelImpl.kt
@@ -3,6 +3,7 @@ package com.mirego.sample.viewmodels.showcase.components.picker
 import com.mirego.sample.KWordTranslation
 import com.mirego.sample.viewmodels.showcase.ShowcaseViewModelImpl
 import com.mirego.trikot.kword.I18N
+import com.mirego.trikot.viewmodels.declarative.components.VMDPickerViewModel
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDContentPickerItemViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
 import com.mirego.trikot.viewmodels.declarative.viewmodel.picker
@@ -21,12 +22,28 @@ class PickerShowcaseViewModelImpl(i18N: I18N, coroutineScope: CoroutineScope) :
             VMDContentPickerItemViewModelImpl(coroutineScope, VMDTextContent("Item 3"), "item_3")
         )
     )
+    override val textPicker2 = picker(
+        listOf(
+            VMDContentPickerItemViewModelImpl(coroutineScope, VMDTextContent("Item 1"), "item_1"),
+            VMDContentPickerItemViewModelImpl(coroutineScope, VMDTextContent("Item 2"), "item_2"),
+            VMDContentPickerItemViewModelImpl(coroutineScope, VMDTextContent("Item 3"), "item_3")
+        )
+    )
 
     override val textPickerTitle = text(i18N[KWordTranslation.PICKER_SHOWCASE_TEXT]) {
         val initialValue = text
         bindText(
             textPicker.flowForProperty(textPicker::selectedIndex).map { index ->
                 textPicker.elements.getOrNull(index)?.content?.text ?: initialValue
+            }
+        )
+    }
+
+    override val textPickerTitle2 = text(i18N[KWordTranslation.PICKER_SHOWCASE_TEXT]) {
+        val initialValue = text
+        bindText(
+            textPicker2.flowForProperty(textPicker::selectedIndex).map { index ->
+                textPicker2.elements.getOrNull(index)?.content?.text ?: initialValue
             }
         )
     }

--- a/trikot-viewmodels-declarative/compose/api/compose.api
+++ b/trikot-viewmodels-declarative/compose/api/compose.api
@@ -145,3 +145,61 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 	public static final fun VMDText--4IGK_g (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
 }
 
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDCheckboxKt {
+	public static final field INSTANCE Lcom/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDCheckboxKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
+	public static field lambda-2 Lkotlin/jvm/functions/Function4;
+	public fun <init> ()V
+	public final fun getLambda-1$compose_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda-2$compose_release ()Lkotlin/jvm/functions/Function4;
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDSwitchKt {
+	public static final field INSTANCE Lcom/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDSwitchKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
+	public static field lambda-2 Lkotlin/jvm/functions/Function4;
+	public fun <init> ()V
+	public final fun getLambda-1$compose_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda-2$compose_release ()Lkotlin/jvm/functions/Function4;
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckboxKt {
+	public static final fun DisabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun EnabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun SimpleTextToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicatorKt {
+	public static final fun DeterminateCircularProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenuKt {
+	public static final fun VMDDropDownMenu-x0xb5LI (Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerViewModel;ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;JLandroidx/compose/ui/window/PopupProperties;Lkotlin/jvm/functions/Function5;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDDropDownMenuItem (Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerViewModel;Lcom/mirego/trikot/viewmodels/declarative/components/VMDPickerItemViewModel;ILandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function2;Landroidx/compose/material3/MenuItemColors;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicatorKt {
+	public static final fun DeterminateLinearProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitchKt {
+	public static final fun DisabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun EnabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun SimpleTextSwitchPreview (Landroidx/compose/runtime/Composer;I)V
+	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextFieldKt {
+	public static final fun VMDTextField (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/text/KeyboardActions;ZZIILandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/TextFieldColors;Landroidx/compose/runtime/Composer;III)V
+	public static final fun buildKeyboardActions (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/foundation/text/KeyboardActions;)Landroidx/compose/foundation/text/KeyboardActions;
+}
+
+public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextKt {
+	public static final fun VMDText--4IGK_g (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+}
+

--- a/trikot-viewmodels-declarative/compose/api/compose.api
+++ b/trikot-viewmodels-declarative/compose/api/compose.api
@@ -75,15 +75,11 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckboxKt {
-	public static final fun DisabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicatorKt {
-	public static final fun DeterminateCircularProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
 }
 
@@ -119,7 +115,6 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicatorKt {
-	public static final fun DeterminateLinearProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
 }
 
@@ -129,9 +124,6 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitchKt {
-	public static final fun DisabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextSwitchPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 }
@@ -164,15 +156,11 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckboxKt {
-	public static final fun DisabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextToggleCheckboxPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicatorKt {
-	public static final fun DeterminateCircularProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
 }
 
@@ -182,14 +170,10 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicatorKt {
-	public static final fun DeterminateLinearProgressIndicatorPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitchKt {
-	public static final fun DisabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun EnabledSwitchPreview (Landroidx/compose/runtime/Composer;I)V
-	public static final fun SimpleTextSwitchPreview (Landroidx/compose/runtime/Composer;I)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 }

--- a/trikot-viewmodels-declarative/compose/build.gradle.kts
+++ b/trikot-viewmodels-declarative/compose/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 
     api("androidx.compose.foundation:foundation:${Versions.JETPACK_COMPOSE_RUNTIME}")
     api("androidx.compose.material:material:${Versions.JETPACK_COMPOSE_RUNTIME}")
+    api("androidx.compose.material3:material3:${Versions.JETPACK_COMPOSE_MATERIAL_3}")
     api("androidx.compose.runtime:runtime:${Versions.JETPACK_COMPOSE_RUNTIME}")
     api("androidx.compose.ui:ui-tooling:${Versions.JETPACK_COMPOSE_RUNTIME}")
     api("io.coil-kt:coil-compose:${Versions.COIL}")

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
@@ -69,21 +69,21 @@ fun <C : VMDContent> VMDCheckbox(
 
 @Preview
 @Composable
-fun EnabledToggleCheckboxPreview() {
+private fun EnabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(true, CancellableManager())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun DisabledToggleCheckboxPreview() {
+private fun DisabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(false, CancellableManager())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun SimpleTextToggleCheckboxPreview() {
+private fun SimpleTextToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withText("Label", true, CancellableManager())
     VMDCheckbox(viewModel = toggleViewModel, label = { Text(it.text) })
 }

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
@@ -56,7 +56,7 @@ fun VMDCircularProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateCircularProgressIndicatorPreview() {
+private fun DeterminateCircularProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, CancellableManager())
     VMDCircularProgressIndicator(
         viewModel = progressViewModel

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
@@ -49,7 +49,7 @@ fun VMDLinearProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateLinearProgressIndicatorPreview() {
+private fun DeterminateLinearProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, CancellableManager())
     VMDLinearProgressIndicator(
         modifier = Modifier.fillMaxWidth(),

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
@@ -68,7 +68,7 @@ fun <C : VMDContent> VMDSwitch(
 
 @Preview
 @Composable
-fun EnabledSwitchPreview() {
+private fun EnabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(true, CancellableManager())
     VMDSwitch(viewModel = toggleViewModel)
@@ -76,7 +76,7 @@ fun EnabledSwitchPreview() {
 
 @Preview
 @Composable
-fun DisabledSwitchPreview() {
+private fun DisabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(false, CancellableManager())
     VMDSwitch(viewModel = toggleViewModel)
@@ -84,7 +84,7 @@ fun DisabledSwitchPreview() {
 
 @Preview
 @Composable
-fun SimpleTextSwitchPreview() {
+private fun SimpleTextSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withText("Label", true, CancellableManager())
     VMDSwitch(viewModel = toggleViewModel, label = { Text(it.text) })

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
@@ -1,0 +1,90 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxColors
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.viewmodels.declarative.components.VMDToggleViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLabeledComponent
+import com.mirego.trikot.viewmodels.declarative.content.VMDContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
+
+@Composable
+fun VMDCheckbox(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<VMDNoContent>,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: CheckboxColors = CheckboxDefaults.colors()
+) {
+    VMDCheckbox(
+        modifier = modifier,
+        componentModifier = componentModifier,
+        viewModel = viewModel,
+        label = {},
+        interactionSource = interactionSource,
+        colors = colors
+    )
+}
+
+@Composable
+fun <C : VMDContent> VMDCheckbox(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<C>,
+    label: @Composable (RowScope.(field: C) -> Unit),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: CheckboxColors = CheckboxDefaults.colors()
+) {
+    val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDLabeledComponent(
+        modifier = Modifier
+            .hidden(viewModel.isHidden)
+            .then(modifier),
+        label = { label(toggleViewModel.label) },
+        content = {
+            Checkbox(
+                onCheckedChange = { checked -> viewModel.onValueChange(checked) },
+                modifier = componentModifier,
+                enabled = toggleViewModel.isEnabled,
+                checked = toggleViewModel.isOn,
+                interactionSource = interactionSource,
+                colors = colors
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EnabledToggleCheckboxPreview() {
+    val toggleViewModel = VMDComponents.Toggle.withState(true, CancellableManager())
+    VMDCheckbox(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun DisabledToggleCheckboxPreview() {
+    val toggleViewModel = VMDComponents.Toggle.withState(false, CancellableManager())
+    VMDCheckbox(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun SimpleTextToggleCheckboxPreview() {
+    val toggleViewModel = VMDComponents.Toggle.withText("Label", true, CancellableManager())
+    VMDCheckbox(viewModel = toggleViewModel, label = { Text(it.text) })
+}

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCheckbox.kt
@@ -70,21 +70,21 @@ fun <C : VMDContent> VMDCheckbox(
 
 @Preview
 @Composable
-fun EnabledToggleCheckboxPreview() {
+private fun EnabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(true, CancellableManager())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun DisabledToggleCheckboxPreview() {
+private fun DisabledToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withState(false, CancellableManager())
     VMDCheckbox(viewModel = toggleViewModel)
 }
 
 @Preview
 @Composable
-fun SimpleTextToggleCheckboxPreview() {
+private fun SimpleTextToggleCheckboxPreview() {
     val toggleViewModel = VMDComponents.Toggle.withText("Label", true, CancellableManager())
     VMDCheckbox(viewModel = toggleViewModel, label = { Text(it.text) })
 }

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
@@ -56,7 +56,7 @@ fun VMDCircularProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateCircularProgressIndicatorPreview() {
+private fun DeterminateCircularProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, CancellableManager())
     VMDCircularProgressIndicator(
         viewModel = progressViewModel

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
@@ -1,0 +1,64 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.viewmodels.declarative.components.VMDProgressViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+
+@Composable
+fun VMDCircularProgressIndicator(
+    modifier: Modifier = Modifier,
+    viewModel: VMDProgressViewModel,
+    color: Color = MaterialTheme.colorScheme.primary,
+    strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
+    trackColor: Color = ProgressIndicatorDefaults.circularTrackColor,
+    strokeCap: StrokeCap = StrokeCap.Square
+) {
+    val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val animatedProgress by animateFloatAsState(targetValue = progressViewModel.determination?.progressRatio ?: 0f, label = "animatedProgress")
+
+    val newModifier = Modifier
+        .hidden(progressViewModel.isHidden)
+        .then(modifier)
+
+    if (viewModel.determination == null) {
+        CircularProgressIndicator(
+            modifier = newModifier,
+            color = color,
+            strokeWidth = strokeWidth,
+            trackColor = trackColor,
+            strokeCap = strokeCap
+        )
+    } else {
+        CircularProgressIndicator(
+            modifier = newModifier,
+            progress = animatedProgress,
+            color = color,
+            strokeWidth = strokeWidth,
+            trackColor = trackColor,
+            strokeCap = strokeCap
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DeterminateCircularProgressIndicatorPreview() {
+    val progressViewModel = VMDComponents.Progress.determinate(0.25f, CancellableManager())
+    VMDCircularProgressIndicator(
+        viewModel = progressViewModel
+    )
+}

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
@@ -75,7 +75,7 @@ fun <E : VMDPickerItemViewModel> VMDDropDownMenuItem(
         enabled = pickerItemViewModel.isEnabled,
         contentPadding = contentPadding,
         colors = colors,
-        leadingIcon =  leadingIcon,
+        leadingIcon = leadingIcon,
         trailingIcon = trailingIcon,
         interactionSource = interactionSource
     )

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenu.kt
@@ -16,9 +16,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
 import com.mirego.trikot.viewmodels.declarative.components.VMDPickerItemViewModel
 import com.mirego.trikot.viewmodels.declarative.components.VMDPickerViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
-import com.mirego.trikot.viewmodels.declarative.compose.extensions.vmdModifier
 
 @Composable
 fun <E : VMDPickerItemViewModel> VMDDropDownMenu(
@@ -35,7 +35,9 @@ fun <E : VMDPickerItemViewModel> VMDDropDownMenu(
     DropdownMenu(
         expanded = expanded,
         onDismissRequest = onDismissRequest,
-        modifier = modifier.vmdModifier(pickerViewModel),
+        modifier = Modifier
+            .hidden(pickerViewModel.isHidden)
+            .then(modifier),
         offset = offset,
         properties = properties
     ) {
@@ -67,7 +69,9 @@ fun <E : VMDPickerItemViewModel> VMDDropDownMenuItem(
             onClick()
         },
         text = text,
-        modifier = modifier.vmdModifier(pickerItemViewModel),
+        modifier = Modifier
+            .hidden(pickerItemViewModel.isHidden)
+            .then(modifier),
         enabled = pickerItemViewModel.isEnabled,
         contentPadding = contentPadding,
         colors = colors,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
@@ -48,7 +48,7 @@ fun VMDLinearProgressIndicator(
 
 @Preview
 @Composable
-fun DeterminateLinearProgressIndicatorPreview() {
+private fun DeterminateLinearProgressIndicatorPreview() {
     val progressViewModel = VMDComponents.Progress.determinate(0.25f, CancellableManager())
     VMDLinearProgressIndicator(
         modifier = Modifier.fillMaxWidth(),

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
@@ -1,0 +1,58 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.viewmodels.declarative.components.VMDProgressViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+
+@Composable
+fun VMDLinearProgressIndicator(
+    modifier: Modifier = Modifier,
+    viewModel: VMDProgressViewModel,
+    color: Color = ProgressIndicatorDefaults.linearColor,
+    trackColor: Color = ProgressIndicatorDefaults.linearTrackColor
+) {
+    val progressViewModel: VMDProgressViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val animatedProgress by animateFloatAsState(targetValue = viewModel.determination?.progressRatio ?: 0f, label = "animatedProgress")
+
+    val newModifier = Modifier
+        .hidden(progressViewModel.isHidden)
+        .then(modifier)
+
+    if (viewModel.determination == null) {
+        LinearProgressIndicator(
+            modifier = newModifier,
+            color = color,
+            trackColor = trackColor
+        )
+    } else {
+        LinearProgressIndicator(
+            modifier = newModifier,
+            progress = animatedProgress,
+            color = color,
+            trackColor = trackColor
+        )
+    }
+}
+
+@Preview
+@Composable
+fun DeterminateLinearProgressIndicatorPreview() {
+    val progressViewModel = VMDComponents.Progress.determinate(0.25f, CancellableManager())
+    VMDLinearProgressIndicator(
+        modifier = Modifier.fillMaxWidth(),
+        viewModel = progressViewModel
+    )
+}

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
@@ -3,7 +3,6 @@ package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
@@ -1,0 +1,93 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchColors
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import com.mirego.trikot.viewmodels.declarative.components.VMDToggleViewModel
+import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLabeledComponent
+import com.mirego.trikot.viewmodels.declarative.content.VMDContent
+import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
+
+@Composable
+fun VMDSwitch(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<VMDNoContent>,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: SwitchColors = SwitchDefaults.colors()
+) {
+    VMDSwitch(
+        modifier = modifier,
+        componentModifier = componentModifier,
+        viewModel = viewModel,
+        label = {},
+        interactionSource = interactionSource,
+        colors = colors
+    )
+}
+
+@Composable
+fun <C : VMDContent> VMDSwitch(
+    modifier: Modifier = Modifier,
+    componentModifier: Modifier = Modifier,
+    viewModel: VMDToggleViewModel<C>,
+    label: @Composable (RowScope.(field: C) -> Unit),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    colors: SwitchColors = SwitchDefaults.colors()
+) {
+    val toggleViewModel: VMDToggleViewModel<C> by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    VMDLabeledComponent(
+        modifier = Modifier
+            .hidden(toggleViewModel.isHidden)
+            .then(modifier),
+        label = { label(toggleViewModel.label) },
+        content = {
+            Switch(
+                modifier = componentModifier,
+                enabled = toggleViewModel.isEnabled,
+                checked = toggleViewModel.isOn,
+                colors = colors,
+                interactionSource = interactionSource,
+                onCheckedChange = { checked -> viewModel.onValueChange(checked) }
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun EnabledSwitchPreview() {
+    val toggleViewModel =
+        VMDComponents.Toggle.withState(true, CancellableManager())
+    VMDSwitch(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun DisabledSwitchPreview() {
+    val toggleViewModel =
+        VMDComponents.Toggle.withState(false, CancellableManager())
+    VMDSwitch(viewModel = toggleViewModel)
+}
+
+@Preview
+@Composable
+fun SimpleTextSwitchPreview() {
+    val toggleViewModel =
+        VMDComponents.Toggle.withText("Label", true, CancellableManager())
+    VMDSwitch(viewModel = toggleViewModel, label = { Text(it.text) })
+}

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
@@ -70,7 +70,7 @@ fun <C : VMDContent> VMDSwitch(
 
 @Preview
 @Composable
-fun EnabledSwitchPreview() {
+private fun EnabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(true, CancellableManager())
     VMDSwitch(viewModel = toggleViewModel)
@@ -78,7 +78,7 @@ fun EnabledSwitchPreview() {
 
 @Preview
 @Composable
-fun DisabledSwitchPreview() {
+private fun DisabledSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withState(false, CancellableManager())
     VMDSwitch(viewModel = toggleViewModel)
@@ -86,7 +86,7 @@ fun DisabledSwitchPreview() {
 
 @Preview
 @Composable
-fun SimpleTextSwitchPreview() {
+private fun SimpleTextSwitchPreview() {
     val toggleViewModel =
         VMDComponents.Toggle.withText("Label", true, CancellableManager())
     VMDSwitch(viewModel = toggleViewModel, label = { Text(it.text) })

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDText.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDText.kt
@@ -1,0 +1,66 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+
+@Composable
+fun VMDText(
+    modifier: Modifier = Modifier,
+    viewModel: VMDTextViewModel,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current
+) {
+    val textViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+
+    Text(
+        text = textViewModel.text,
+        modifier = Modifier
+            .hidden(textViewModel.isHidden)
+            .then(modifier),
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = style
+    )
+}

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextField.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextField.kt
@@ -1,0 +1,109 @@
+package com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.shape.ZeroCornerSize
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import com.mirego.trikot.viewmodels.declarative.components.VMDTextFieldViewModel
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.composeValue
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.hidden
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.isOverridingAlpha
+import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.FormattedVisualTransformation
+
+@Composable
+fun VMDTextField(
+    modifier: Modifier = Modifier,
+    viewModel: VMDTextFieldViewModel,
+    textStyle: TextStyle = LocalTextStyle.current,
+    placeHolderStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    keyboardActions: KeyboardActions = KeyboardActions(),
+    isError: Boolean = false,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    shape: Shape = MaterialTheme.shapes.small.copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize),
+    textFieldColors: TextFieldColors = TextFieldDefaults.colors()
+) {
+    val textFieldViewModel: VMDTextFieldViewModel by viewModel.observeAsState(excludedProperties = if (modifier.isOverridingAlpha()) listOf(viewModel::isHidden) else emptyList())
+    val keyboardActionsDelegate = buildKeyboardActions(viewModel, keyboardActions)
+
+    TextField(
+        modifier = Modifier
+            .hidden(textFieldViewModel.isHidden)
+            .then(modifier),
+        value = textFieldViewModel.text,
+        onValueChange = { value ->
+            viewModel.onValueChange(value)
+        },
+        enabled = textFieldViewModel.isEnabled,
+        label = label,
+        placeholder = {
+            Text(
+                text = textFieldViewModel.placeholder,
+                style = placeHolderStyle
+            )
+        },
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        textStyle = textStyle,
+        isError = isError,
+        visualTransformation = FormattedVisualTransformation(viewModel.formatText),
+        keyboardActions = keyboardActionsDelegate,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = textFieldViewModel.keyboardType.composeValue,
+            capitalization = textFieldViewModel.autoCapitalization.composeValue,
+            imeAction = textFieldViewModel.keyboardReturnKeyType.composeValue
+        ),
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+        interactionSource = interactionSource,
+        shape = shape,
+        colors = textFieldColors
+    )
+}
+
+fun buildKeyboardActions(viewModel: VMDTextFieldViewModel, keyboardActions: KeyboardActions) =
+    KeyboardActions(
+        onDone = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onDone?.invoke(this)
+        },
+        onNext = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onNext?.invoke(this)
+        },
+        onGo = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onGo?.invoke(this)
+        },
+        onPrevious = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onPrevious?.invoke(this)
+        },
+        onSearch = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onSearch?.invoke(this)
+        },
+        onSend = {
+            viewModel.onReturnKeyTap.invoke()
+            keyboardActions.onSend?.invoke(this)
+        }
+    )

--- a/trikot-viewmodels-declarative/sample/android/build.gradle.kts
+++ b/trikot-viewmodels-declarative/sample/android/build.gradle.kts
@@ -44,6 +44,13 @@ android {
         kotlinCompilerExtensionVersion = Versions.JETPACK_COMPOSE_COMPILER
     }
 
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs +
+            listOf(
+                "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
+            )
+    }
+
     sourceSets {
         getByName("main") {
             resources.srcDir("../common/src/commonMain/resources/")

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
@@ -116,6 +116,6 @@ private fun AnimationSection(animationTypeViewModel: AnimationTypeShowcaseViewMo
 
 @Preview(showSystemUi = true)
 @Composable
-fun AnimationTypesShowcaseViewPreview() {
+private fun AnimationTypesShowcaseViewPreview() {
     AnimationTypesShowcaseView(animationTypesShowcaseViewModel = AnimationTypesShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
@@ -124,7 +124,7 @@ fun ButtonShowcaseView(buttonShowcaseViewModel: ButtonShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ButtonShowcaseViewPreview() {
+private fun ButtonShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     ButtonShowcaseView(buttonShowcaseViewModel = ButtonShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -139,7 +139,7 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ImageShowcaseViewPreview() {
+private fun ImageShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     ImageShowcaseView(imageShowcaseViewModel = ImageShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
@@ -13,8 +14,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.mirego.sample.ui.showcase.ComponentShowcaseTitle
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
+import com.mirego.sample.ui.theming.SampleTextStyle
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDDropDownMenu
@@ -23,6 +26,7 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDDropDownMen
 @Composable
 fun PickerShowcaseView(pickerShowcaseViewModel: PickerShowcaseViewModel) {
     var expanded by remember { mutableStateOf(false) }
+    var expanded2 by remember { mutableStateOf(false) }
     val viewModel: PickerShowcaseViewModel by pickerShowcaseViewModel.observeAsState()
 
     Column(
@@ -57,6 +61,40 @@ fun PickerShowcaseView(pickerShowcaseViewModel: PickerShowcaseViewModel) {
             ) { pickerItem, _ ->
                 Text(text = pickerItem.content.text)
             }
+        }
+
+        androidx.compose.material3.Text(
+            modifier = Modifier.padding(top = 16.dp, start = 16.dp),
+            text = "Material 3",
+            style = SampleTextStyle.largeTitle
+        )
+
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clickable {
+                    expanded2 = true
+                }
+        ) {
+            ComponentShowcaseTitle(viewModel.textPickerTitle2)
+        }
+
+        VMDDropDownMenu(
+            viewModel = viewModel.textPicker2,
+            expanded = expanded2,
+            onDismissRequest = {
+                expanded2 = false
+            }
+        ) { item, index ->
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDDropDownMenuItem(
+                pickerViewModel = viewModel.textPicker2,
+                viewModel = item,
+                index = index,
+                onClick = { expanded2 = false },
+                text = {
+                    Text(text = item.content.text)
+                }
+            )
         }
     }
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
@@ -1,10 +1,12 @@
 package com.mirego.sample.ui.showcase.components.progress
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -12,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mirego.sample.ui.showcase.ComponentShowcaseTitle
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
+import com.mirego.sample.ui.theming.SampleTextStyle
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModelPreview
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
@@ -25,42 +28,79 @@ fun ProgressShowcaseView(progressShowcaseViewModel: ProgressShowcaseViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
     ) {
         ComponentShowcaseTopBar(viewModel)
 
-        ComponentShowcaseTitle(viewModel.linearDeterminateProgressTitle)
-
-        VMDLinearProgressIndicator(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.determinateProgress
-        )
+                .verticalScroll(state = rememberScrollState())
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
 
-        ComponentShowcaseTitle(viewModel.linearIndeterminateProgressTitle)
+            ComponentShowcaseTitle(viewModel.linearDeterminateProgressTitle)
 
-        VMDLinearProgressIndicator(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.indeterminateProgress
-        )
+            VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.determinateProgress
+            )
 
-        ComponentShowcaseTitle(viewModel.circularDeterminateProgressTitle)
+            ComponentShowcaseTitle(viewModel.linearIndeterminateProgressTitle)
 
-        VMDCircularProgressIndicator(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.determinateProgress
-        )
+            VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.indeterminateProgress
+            )
 
-        ComponentShowcaseTitle(viewModel.circularIndeterminateProgressTitle)
+            ComponentShowcaseTitle(viewModel.circularDeterminateProgressTitle)
 
-        VMDCircularProgressIndicator(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.indeterminateProgress
-        )
+            VMDCircularProgressIndicator(
+                viewModel = viewModel.determinateProgress
+            )
+
+            ComponentShowcaseTitle(viewModel.circularIndeterminateProgressTitle)
+
+            VMDCircularProgressIndicator(
+                viewModel = viewModel.indeterminateProgress
+            )
+
+            Text(
+                modifier = Modifier.padding(top = 10.dp),
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.determinateProgress
+            )
+
+            ComponentShowcaseTitle(viewModel.linearIndeterminateProgressTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDLinearProgressIndicator(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                viewModel = viewModel.indeterminateProgress
+            )
+
+            ComponentShowcaseTitle(viewModel.circularDeterminateProgressTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCircularProgressIndicator(
+                modifier = Modifier,
+                viewModel = viewModel.determinateProgress
+            )
+
+            ComponentShowcaseTitle(viewModel.circularIndeterminateProgressTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCircularProgressIndicator(
+                viewModel = viewModel.indeterminateProgress
+            )
+        }
     }
 }
 

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
@@ -106,6 +106,6 @@ fun ProgressShowcaseView(progressShowcaseViewModel: ProgressShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ProgressShowcaseViewPreview() {
+private fun ProgressShowcaseViewPreview() {
     ProgressShowcaseView(progressShowcaseViewModel = ProgressShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
@@ -39,7 +39,6 @@ fun ProgressShowcaseView(progressShowcaseViewModel: ProgressShowcaseViewModel) {
                 .padding(bottom = 16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-
             ComponentShowcaseTitle(viewModel.linearDeterminateProgressTitle)
 
             VMDLinearProgressIndicator(

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -29,13 +30,13 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
     ) {
         ComponentShowcaseTopBar(viewModel)
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(state = rememberScrollState())
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
@@ -110,6 +111,87 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
             )
 
             VMDText(
+                viewModel = viewModel.caption2,
+                style = SampleTextStyle.caption2
+            )
+
+            Text(
+                modifier = Modifier.padding(top = 16.dp),
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.largeTitle,
+                style = SampleTextStyle.largeTitle
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title1,
+                style = SampleTextStyle.title1
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title1Bold,
+                style = SampleTextStyle.title1.bold()
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title2,
+                style = SampleTextStyle.title2
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title2Bold,
+                style = SampleTextStyle.title2.bold()
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.title3,
+                style = SampleTextStyle.title3
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.headline,
+                style = SampleTextStyle.headline
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.body,
+                style = SampleTextStyle.body
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.bodyMedium,
+                style = SampleTextStyle.body.medium()
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.button,
+                style = SampleTextStyle.button
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.callout,
+                style = SampleTextStyle.callout
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.subheadline,
+                style = SampleTextStyle.subheadline
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.footnote,
+                style = SampleTextStyle.footnote
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
+                viewModel = viewModel.caption1,
+                style = SampleTextStyle.caption1
+            )
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(
                 viewModel = viewModel.caption2,
                 style = SampleTextStyle.caption2
             )

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -37,6 +37,7 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
             modifier = Modifier
                 .fillMaxWidth()
                 .verticalScroll(state = rememberScrollState())
+                .padding(bottom = 16.dp)
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
@@ -201,7 +202,7 @@ fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun TextShowcaseViewPreview() {
+private fun TextShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     TextShowcaseView(textShowcaseViewModel = TextShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
@@ -66,6 +66,39 @@ fun TextFieldShowcaseView(textFieldShowcaseViewModel: TextFieldShowcaseViewModel
 
             VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
         }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            androidx.compose.material3.Text(
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDTextField(viewModel = viewModel.textField)
+
+                VMDButton(
+                    modifier = Modifier.padding(start = 16.dp),
+                    viewModel = viewModel.clearButton
+                ) { content ->
+                    Text(
+                        modifier = Modifier
+                            .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                            .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.onPrimary
+                    )
+                }
+            }
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+        }
     }
 }
 

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
@@ -104,7 +104,7 @@ fun TextFieldShowcaseView(textFieldShowcaseViewModel: TextFieldShowcaseViewModel
 
 @Preview(showSystemUi = true)
 @Composable
-fun TextFieldShowcaseViewPreview() {
+private fun TextFieldShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     TextFieldShowcaseView(textFieldShowcaseViewModel = TextFieldShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -177,7 +177,7 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
 
         VMDSwitch(
             modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                .padding(16.dp)
                 .fillMaxWidth(),
             viewModel = viewModel.textPairToggle,
             label = { content ->
@@ -332,7 +332,7 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
 
         com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
             modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                .padding(16.dp)
                 .fillMaxWidth(),
             viewModel = viewModel.textPairToggle,
             label = { content ->
@@ -355,7 +355,7 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
 
 @Preview(showSystemUi = true)
 @Composable
-fun ToggleShowcaseViewPreview() {
+private fun ToggleShowcaseViewPreview() {
     TrikotViewModelDeclarative.initialize(SampleImageProvider())
     ToggleShowcaseView(toggleShowcaseViewModel = ToggleShowcaseViewModelPreview())
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -195,6 +195,161 @@ fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
                 }
             }
         )
+
+        androidx.compose.material3.Text(
+            text = "Material 3",
+            style = SampleTextStyle.largeTitle
+        )
+
+        ComponentShowcaseTitle(viewModel.textCheckboxTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.textToggle,
+            label = { Text(it.text, style = SampleTextStyle.body) }
+        )
+
+        ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.imageToggle,
+            label = { content ->
+                LocalImage(
+                    imageResource = content.image,
+                    colorFilter = ColorFilter.tint(Color.Black)
+                )
+            }
+        )
+
+        ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.textImageToggle,
+            label = { content ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    LocalImage(
+                        imageResource = content.image,
+                        colorFilter = ColorFilter.tint(Color.Black)
+                    )
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body
+                    )
+                }
+            }
+        )
+
+        ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.textPairToggle,
+            label = { content ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = content.first,
+                        style = SampleTextStyle.body
+                    )
+                    Text(
+                        text = content.second,
+                        style = SampleTextStyle.caption1
+                    )
+                }
+            }
+        )
+
+        ComponentShowcaseTitle(viewModel.switchTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+            modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
+            viewModel = viewModel.emptyToggle
+        )
+
+        ComponentShowcaseTitle(viewModel.textSwitchTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.textToggle,
+            label = { Text(it.text, style = SampleTextStyle.body) }
+        )
+
+        ComponentShowcaseTitle(viewModel.imageSwitchTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.imageToggle,
+            label = { content ->
+                LocalImage(
+                    imageResource = content.image,
+                    colorFilter = ColorFilter.tint(Color.Black)
+                )
+            }
+        )
+
+        ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.textImageToggle,
+            label = { content ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    LocalImage(
+                        imageResource = content.image,
+                        colorFilter = ColorFilter.tint(Color.Black)
+                    )
+                    Text(
+                        modifier = Modifier.padding(start = 8.dp),
+                        text = content.text,
+                        style = SampleTextStyle.body
+                    )
+                }
+            }
+        )
+
+        ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
+
+        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+            modifier = Modifier
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
+                .fillMaxWidth(),
+            viewModel = viewModel.textPairToggle,
+            label = { content ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = content.first,
+                        style = SampleTextStyle.body
+                    )
+                    Text(
+                        text = content.second,
+                        style = SampleTextStyle.caption1
+                    )
+                }
+            }
+        )
     }
 }
 

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModel.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModel.kt
@@ -9,4 +9,6 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
 interface PickerShowcaseViewModel : ShowcaseViewModel {
     val textPickerTitle: VMDTextViewModel
     val textPicker: VMDPickerViewModel<VMDContentPickerItemViewModelImpl<VMDTextContent>>
+    val textPickerTitle2: VMDTextViewModel
+    val textPicker2: VMDPickerViewModel<VMDContentPickerItemViewModelImpl<VMDTextContent>>
 }

--- a/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelImpl.kt
+++ b/trikot-viewmodels-declarative/sample/common/src/commonMain/kotlin/com/mirego/sample/viewmodels/showcase/components/picker/PickerShowcaseViewModelImpl.kt
@@ -8,6 +8,8 @@ import com.mirego.trikot.streams.reactive.map
 import com.mirego.trikot.viewmodels.declarative.components.factory.VMDComponents
 import com.mirego.trikot.viewmodels.declarative.components.impl.VMDContentPickerItemViewModelImpl
 import com.mirego.trikot.viewmodels.declarative.content.VMDTextContent
+import com.mirego.trikot.viewmodels.declarative.viewmodel.picker
+import com.mirego.trikot.viewmodels.declarative.viewmodel.text
 
 class PickerShowcaseViewModelImpl(i18N: I18N, cancellableManager: CancellableManager) :
     ShowcaseViewModelImpl(cancellableManager), PickerShowcaseViewModel {
@@ -24,6 +26,13 @@ class PickerShowcaseViewModelImpl(i18N: I18N, cancellableManager: CancellableMan
             VMDContentPickerItemViewModelImpl(cancellableManager, VMDTextContent("Item 3"), "item_3")
         )
     )
+    override val textPicker2 = picker(
+        listOf(
+            VMDContentPickerItemViewModelImpl(cancellableManager, VMDTextContent("Item 1"), "item_1"),
+            VMDContentPickerItemViewModelImpl(cancellableManager, VMDTextContent("Item 2"), "item_2"),
+            VMDContentPickerItemViewModelImpl(cancellableManager, VMDTextContent("Item 3"), "item_3")
+        )
+    )
 
     override val textPickerTitle = VMDComponents.Text.withContent(
         i18N[KWordTranslation.PICKER_SHOWCASE_TEXT],
@@ -33,6 +42,15 @@ class PickerShowcaseViewModelImpl(i18N: I18N, cancellableManager: CancellableMan
         bindText(
             textPicker.publisherForProperty(textPicker::selectedIndex).map { index ->
                 textPicker.elements.getOrNull(index)?.content?.text ?: initialValue
+            }
+        )
+    }
+
+    override val textPickerTitle2 = text(i18N[KWordTranslation.PICKER_SHOWCASE_TEXT]) {
+        val initialValue = text
+        bindText(
+            textPicker2.publisherForProperty(textPicker::selectedIndex).map { index ->
+                textPicker2.elements.getOrNull(index)?.content?.text ?: initialValue
             }
         )
     }


### PR DESCRIPTION
## Description
On ajoute une version des bindings compose qui utilise [material 3](https://developer.android.com/jetpack/compose/designsystems/material3).

## Motivation and Context
Les bindings compose actuel utilisent tous material 1, on garde ces bindings pour ne pas causer de breaking changes ni de changement UI mais on ajoute un package material3 pour avoir le choix d'utiliser la version material3 des composants qui apporte certaines features (dynamic colors) et modifications au niveau de la gestion du thème de couleurs ainsi qu'un update visuel pour certain composants (switch/checkbox, textfield, progress).

## How Has This Been Tested?
Les bindings ajoutés ont tous été ajouté dans les samples.

## Types of changes
- [ x] New feature (non-breaking change which adds functionality)
