### PR TITLE
Prevent color name clash between swiftui and trikot.viewmodel

### DIFF
--- a/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Home/HomeView.swift
+++ b/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Home/HomeView.swift
@@ -23,7 +23,7 @@ struct HomeView: RootViewModelView {
                         VMDButton(element.button) { textContent in
                             Text(textContent.text)
                         }
-                        .foregroundColor(.black)
+                        .foregroundColor(.primary)
                     }
                 }
             }

--- a/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Home/HomeViewController.swift
+++ b/trikot-viewmodels-declarative-flow/sample/ios/Sample/UI/Home/HomeViewController.swift
@@ -2,11 +2,7 @@ import UIKit
 import Trikot
 import TRIKOT_FRAMEWORK_NAME
 
-class HomeViewController: BaseViewModelViewController<HomeViewModelController, HomeViewModel, HomeView, HomeNavigationDelegate> {
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        .darkContent
-    }
-}
+class HomeViewController: BaseViewModelViewController<HomeViewModelController, HomeViewModel, HomeView, HomeNavigationDelegate> {}
 
 extension HomeViewController: HomeNavigationDelegate {
     func navigateToTextShowcase() {

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
@@ -6,14 +6,14 @@ public struct VMDHtmlText: View {
     @ObservedObject private var observableViewModel: ObservableViewModelAdapter<VMDHtmlTextViewModel>
     
     private let style: VMDHtmlTextStyle
-    private let color: Color
+    private let color: SwiftUI.Color
     private let numberOfLines: Int
     private let linkTextAttributes: [NSAttributedString.Key : Any]?
     
     public init(
         _ viewModel: VMDHtmlTextViewModel,
         style: VMDHtmlTextStyle,
-        color: Color,
+        color: SwiftUI.Color,
         numberOfLines: Int = 0,
         linkTextAttributes: [NSAttributedString.Key : Any]? = nil
     ) {
@@ -44,7 +44,7 @@ private struct HTMLText: UIViewRepresentable {
 
     private let html: String
     private let style: VMDHtmlTextStyle
-    private let color: Color
+    private let color: SwiftUI.Color
     private let numberOfLines: Int
     private let linkTextAttributes: [NSAttributedString.Key : Any]?
     private let onOpenURL: ((String) -> Void)?
@@ -52,7 +52,7 @@ private struct HTMLText: UIViewRepresentable {
     init(
         html: String,
         style: VMDHtmlTextStyle,
-        color: Color,
+        color: SwiftUI.Color,
         numberOfLines: Int = 0,
         linkTextAttributes: [NSAttributedString.Key : Any]? = nil,
         onOpenURL: ((String) -> Void)? = nil


### PR DESCRIPTION
## Description

In the case where a trikot based project is currently migrating from `trikot.viewmodels` to `trikot.viewmodel-declarative` there is a name clash in `VMDHtmlText.swift` between SwiftUI.Color and TRIKOT_FRAMEWORK_NAME.Color

I also improved the look and feel of the sample in dark mode while at it.

| Before | After |
|--------|--------|
| ![Screenshot 2023-10-25 at 6 19 43 PM](https://github.com/mirego/trikot/assets/87188/abb7d3ea-4e37-461c-aaf4-076464e9aa62) | ![Screenshot 2023-10-25 at 6 21 26 PM](https://github.com/mirego/trikot/assets/87188/27d8ef79-b0ba-4533-b8f0-2e4a2612c800) | 

## Motivation and Context

To fix a blocking problem for projects that use both versions of the viewModel

## How Has This Been Tested?

Ran the sample app 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)