### PR TITLE
Fix/prevent color name clash between swiftui and trikot.viewmodel font class

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
@@ -163,7 +163,7 @@ public struct VMDHtmlTextStyle {
     public var fontFamily: String
     public var fontWeight: VMDHtmlTextWeight
     public var relativeTextStyle: SwiftUI.Font.TextStyle
-
+    
     public init(
         fontSize: CGFloat,
         lineHeight: CGFloat,

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/Components/VMDHtmlText.swift
@@ -162,14 +162,14 @@ public struct VMDHtmlTextStyle {
     public var lineHeight: CGFloat
     public var fontFamily: String
     public var fontWeight: VMDHtmlTextWeight
-    public var relativeTextStyle: Font.TextStyle
-    
+    public var relativeTextStyle: SwiftUI.Font.TextStyle
+
     public init(
         fontSize: CGFloat,
         lineHeight: CGFloat,
         fontFamily: String = "-apple-system",
         fontWeight: VMDHtmlTextWeight = VMDHtmlTextWeight.normal,
-        relativeTextStyle: Font.TextStyle = .body
+        relativeTextStyle: SwiftUI.Font.TextStyle = .body
     ) {
         self.fontSize = fontSize
         self.lineHeight = lineHeight
@@ -201,7 +201,7 @@ public enum VMDHtmlTextWeight: Int {
     public static let w900 = VMDHtmlTextWeight.black
 }
 
-private extension Font.TextStyle {
+private extension SwiftUI.Font.TextStyle {
     var uiFontTextStyle: UIFont.TextStyle {
         switch self {
         case .largeTitle: return .largeTitle


### PR DESCRIPTION
## Description

In the case where a Trikot based project is currently migrating from trikot.viewmodels to trikot.viewmodel-declarative there is a name clash in VMDHtmlText.swift between SwiftUI.Font and TRIKOT_FRAMEWORK_NAME.Font

## Motivation and Context

To fix a blocking problem for projects that use both versions of the viewModel

## How Has This Been Tested?

Ran the sample app and tested in my projects the changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
