### PR TITLE
Fix crashing previews in xcode 15

### DIFF
--- a/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
@@ -1,11 +1,18 @@
+import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
+
 
 public class TrikotViewModelDeclarative {
     public static let shared: TrikotViewModelDeclarative = TrikotViewModelDeclarative()
 
+    var isRunningInPreview: Bool {
+        ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+
     var imageProvider: VMDImageProvider {
         guard let internalImageProvider = internalImageProvider else {
-            fatalError("TrikotViewModelDeclarative must be initialized before use")
+            guard isRunningInPreview else { fatalError("TrikotViewModelDeclarative must be initialized before use") }
+            return FallbackImageProvider()
         }
 
         return internalImageProvider
@@ -13,7 +20,8 @@ public class TrikotViewModelDeclarative {
 
     var spanStyleProvider: VMDSpanStyleProvider {
         guard let internalSpanStyleProvider = internalSpanStyleProvider else {
-            fatalError("TrikotViewModelDeclarative must be initialized before use")
+            guard isRunningInPreview else { fatalError("TrikotViewModelDeclarative must be initialized before use") }
+            return DefaultSpanStyleProvider()
         }
 
         return internalSpanStyleProvider
@@ -32,5 +40,31 @@ public class TrikotViewModelDeclarative {
     ) {
         internalImageProvider = imageProvider
         internalSpanStyleProvider = spanStyleProvider
+    }
+}
+
+private class FallbackImageProvider: VMDImageProvider {
+    func imageForResource(imageResource: VMDImageResource) -> Image? {
+        return Image(uiImage: UIImage(color: .red, size: CGSize(width: 12, height: 12))!)
+    }
+}
+
+private extension UIImage {
+    convenience init?(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) {
+        let rect = CGRect(origin: .zero, size: size)
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
+        if let currentContext = UIGraphicsGetCurrentContext() {
+            color.setFill()
+            currentContext.fillEllipse(in: rect.insetBy(dx: size.width / 4, dy: size.height / 4))
+
+            UIColor.black.setStroke()
+            UIRectFrame(rect)
+            let image = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+            guard let cgImage = image?.cgImage else { return nil }
+            self.init(cgImage: cgImage)
+        } else {
+            return nil
+        }
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
@@ -45,26 +45,26 @@ public class TrikotViewModelDeclarative {
 
 private class FallbackImageProvider: VMDImageProvider {
     func imageForResource(imageResource: VMDImageResource) -> Image? {
-        return Image(uiImage: UIImage(color: .red, size: CGSize(width: 12, height: 12))!)
+        return Image(uiImage: UIImage.from(color: .red, size: CGSize(width: 24, height: 24))!)
     }
 }
 
 private extension UIImage {
-    convenience init?(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) {
+    static func from(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) -> UIImage? {
         let rect = CGRect(origin: .zero, size: size)
         UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
-        if let currentContext = UIGraphicsGetCurrentContext() {
-            color.setFill()
-            currentContext.fillEllipse(in: rect.insetBy(dx: size.width / 4, dy: size.height / 4))
+        
+        let currentContext = UIGraphicsGetCurrentContext()
+        
+        color.setFill()
+        currentContext?.fillEllipse(in: rect.insetBy(dx: size.width / 4, dy: size.height / 4))
 
-            UIColor.black.setStroke()
-            UIRectFrame(rect)
-            let image = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-            guard let cgImage = image?.cgImage else { return nil }
-            self.init(cgImage: cgImage)
-        } else {
-            return nil
-        }
+        UIColor.black.setStroke()
+        UIRectFrame(rect)
+
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return image!
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Trikot
 import TRIKOT_FRAMEWORK_NAME
 
 public class TrikotViewModelDeclarative {
@@ -44,26 +45,6 @@ public class TrikotViewModelDeclarative {
 
 private class FallbackImageProvider: VMDImageProvider {
     func imageForResource(imageResource: VMDImageResource) -> Image? {
-        return Image(uiImage: UIImage.from(color: .red, size: CGSize(width: 24, height: 24))!)
-    }
-}
-
-private extension UIImage {
-    static func from(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) -> UIImage? {
-        let rect = CGRect(origin: .zero, size: size)
-        UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
-        
-        let currentContext = UIGraphicsGetCurrentContext()
-        
-        color.setFill()
-        currentContext?.fillEllipse(in: rect.insetBy(dx: size.width / 4, dy: size.height / 4))
-
-        UIColor.black.setStroke()
-        UIRectFrame(rect)
-
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        return image!
+        return Image(systemName: "exclamationmark.brakesignal")
     }
 }

--- a/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
+++ b/trikot-viewmodels-declarative-flow/swift/swiftui/TrikotViewModelDeclarative.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import TRIKOT_FRAMEWORK_NAME
 
-
 public class TrikotViewModelDeclarative {
     public static let shared: TrikotViewModelDeclarative = TrikotViewModelDeclarative()
 


### PR DESCRIPTION
## Description

Since the release of xcode 15, previews have stopped working as soon as you use a VMDImageResources. This is caused by a weird, undocumented xcode preview behaviour where it seems to change process so the `TrikotViewModelDeclarative.shared` instance gets recreated. 

This was detected by printing the object address at each access.

Using  `EnvironmentValues` to inject the `imageProvider` and the `spanStyleProvider` was explored and it does fix the problem, but requires a lot of boilerplate to get the provider and pass it to each view creating an image. No easy solution was found quickly

While we come up with a better solution (or, IF it is considered a bug in xcode, Apple fixes the problem 🤞🏻) this PR at least stops the preview from crashing and displays an ugly fallback image instead

## Motivation and Context

To make xcode previews work again when using VMD

## How Has This Been Tested?

Tested the sample app, see screenshots:

| Preview | Running App |
|--------|--------|
| <img width="436" alt="Screenshot 2023-11-06 at 5 02 59 PM" src="https://github.com/mirego/trikot/assets/87188/f18493fa-cfba-4aab-8799-2e6a813afbe0"> | <img width="381" alt="Screenshot 2023-11-06 at 4 47 26 PM" src="https://github.com/mirego/trikot/assets/87188/3a829c95-9518-45be-ab16-d09221b4abc5"> |

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
