### PR TITLE
Trikot analytics revamp

### DIFF
--- a/trikot-analytics/analytics-viewmodel/api/android/analytics-viewmodel.api
+++ b/trikot-analytics/analytics-viewmodel/api/android/analytics-viewmodel.api
@@ -1,3 +1,10 @@
+public class com/mirego/trikot/analytics/SimpleTrackableViewModelAction : com/mirego/trikot/viewmodels/properties/ViewModelAction {
+	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun execute ()V
+	public fun execute (Ljava/lang/Object;)V
+}
+
 public class com/mirego/trikot/analytics/TrackableViewModelAction : com/mirego/trikot/viewmodels/properties/ViewModelAction {
 	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
 	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function1;)V

--- a/trikot-analytics/analytics-viewmodel/api/jvm/analytics-viewmodel.api
+++ b/trikot-analytics/analytics-viewmodel/api/jvm/analytics-viewmodel.api
@@ -1,3 +1,10 @@
+public class com/mirego/trikot/analytics/SimpleTrackableViewModelAction : com/mirego/trikot/viewmodels/properties/ViewModelAction {
+	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun execute ()V
+	public fun execute (Ljava/lang/Object;)V
+}
+
 public class com/mirego/trikot/analytics/TrackableViewModelAction : com/mirego/trikot/viewmodels/properties/ViewModelAction {
 	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
 	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsEvent;Lorg/reactivestreams/Publisher;Lkotlin/jvm/functions/Function1;)V

--- a/trikot-analytics/analytics-viewmodel/src/commonMain/kotlin/com/mirego/trikot/analytics/SimpleTrackableViewModelAction.kt
+++ b/trikot-analytics/analytics-viewmodel/src/commonMain/kotlin/com/mirego/trikot/analytics/SimpleTrackableViewModelAction.kt
@@ -1,0 +1,18 @@
+package com.mirego.trikot.analytics
+
+import com.mirego.trikot.viewmodels.properties.ViewModelAction
+import com.mirego.trikot.viewmodels.properties.ViewModelActionBlock
+
+open class SimpleTrackableViewModelAction(private val event: AnalyticsEvent, private val properties: AnalyticsPropertiesType = mapOf(), actionBlock: ViewModelActionBlock) :
+    ViewModelAction(actionBlock) {
+
+    override fun execute() {
+        super.execute()
+        AnalyticsConfiguration.analyticsManager.trackEvent(event, properties)
+    }
+
+    override fun execute(actionContext: Any?) {
+        super.execute(actionContext)
+        AnalyticsConfiguration.analyticsManager.trackEvent(event, properties)
+    }
+}

--- a/trikot-analytics/analytics-viewmodel/src/commonMain/kotlin/com/mirego/trikot/analytics/TrackableViewModelAction.kt
+++ b/trikot-analytics/analytics-viewmodel/src/commonMain/kotlin/com/mirego/trikot/analytics/TrackableViewModelAction.kt
@@ -5,6 +5,13 @@ import com.mirego.trikot.viewmodels.properties.ViewModelAction
 import com.mirego.trikot.viewmodels.properties.ViewModelActionBlock
 import org.reactivestreams.Publisher
 
+@Deprecated(
+    message = "Deprecated. Please use AnalyticsEvent",
+    replaceWith = ReplaceWith(
+        expression = "AnalyticsEvent",
+        imports = ["com.mirego.trikot.analytics.AnalyticsEvent"]
+    )
+)
 open class TrackableViewModelAction(private val event: AnalyticsEvent, private val properties: Publisher<AnalyticsPropertiesType> = mapOf<String, Any>().just(), actionBlock: ViewModelActionBlock) :
     ViewModelAction(actionBlock) {
     constructor(event: AnalyticsEvent, properties: AnalyticsPropertiesType, actionBlock: ViewModelActionBlock) : this(event, properties.just(), actionBlock)

--- a/trikot-analytics/analytics/api/android/analytics.api
+++ b/trikot-analytics/analytics/api/android/analytics.api
@@ -11,6 +11,7 @@ public abstract interface class com/mirego/trikot/analytics/AnalyticsEvent {
 public abstract interface class com/mirego/trikot/analytics/AnalyticsService {
 	public static final field Companion Lcom/mirego/trikot/analytics/AnalyticsService$Companion;
 	public abstract fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public abstract fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun incrementUserProperties (Ljava/util/Map;)V
@@ -26,6 +27,7 @@ public abstract interface class com/mirego/trikot/analytics/AnalyticsService {
 
 public final class com/mirego/trikot/analytics/AnalyticsService$Companion : com/mirego/trikot/analytics/AnalyticsService {
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V
@@ -40,15 +42,18 @@ public final class com/mirego/trikot/analytics/AnalyticsService$Companion : com/
 }
 
 public final class com/mirego/trikot/analytics/AnalyticsServiceKt {
+	public static final fun identifyUser (Lcom/mirego/trikot/analytics/AnalyticsService;Ljava/lang/String;Ljava/util/Map;)V
 	public static final fun identifyUser (Lcom/mirego/trikot/analytics/AnalyticsService;Ljava/lang/String;Lorg/reactivestreams/Publisher;)V
 	public static final fun logout (Lcom/mirego/trikot/analytics/AnalyticsService;Z)V
 	public static synthetic fun logout$default (Lcom/mirego/trikot/analytics/AnalyticsService;ZILjava/lang/Object;)V
+	public static final fun trackEvent (Lcom/mirego/trikot/analytics/AnalyticsService;Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;)V
 	public static final fun trackEvent (Lcom/mirego/trikot/analytics/AnalyticsService;Lcom/mirego/trikot/analytics/AnalyticsEvent;Lorg/reactivestreams/Publisher;)V
 }
 
 public final class com/mirego/trikot/analytics/AnalyticsServiceLogger : com/mirego/trikot/analytics/AnalyticsService {
 	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsService;)V
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V
@@ -65,6 +70,7 @@ public final class com/mirego/trikot/analytics/AnalyticsServiceLogger : com/mire
 public final class com/mirego/trikot/analytics/EmptyAnalyticsService : com/mirego/trikot/analytics/AnalyticsService {
 	public fun <init> ()V
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V

--- a/trikot-analytics/analytics/api/jvm/analytics.api
+++ b/trikot-analytics/analytics/api/jvm/analytics.api
@@ -11,6 +11,7 @@ public abstract interface class com/mirego/trikot/analytics/AnalyticsEvent {
 public abstract interface class com/mirego/trikot/analytics/AnalyticsService {
 	public static final field Companion Lcom/mirego/trikot/analytics/AnalyticsService$Companion;
 	public abstract fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public abstract fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun incrementUserProperties (Ljava/util/Map;)V
@@ -26,6 +27,7 @@ public abstract interface class com/mirego/trikot/analytics/AnalyticsService {
 
 public final class com/mirego/trikot/analytics/AnalyticsService$Companion : com/mirego/trikot/analytics/AnalyticsService {
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V
@@ -40,15 +42,18 @@ public final class com/mirego/trikot/analytics/AnalyticsService$Companion : com/
 }
 
 public final class com/mirego/trikot/analytics/AnalyticsServiceKt {
+	public static final fun identifyUser (Lcom/mirego/trikot/analytics/AnalyticsService;Ljava/lang/String;Ljava/util/Map;)V
 	public static final fun identifyUser (Lcom/mirego/trikot/analytics/AnalyticsService;Ljava/lang/String;Lorg/reactivestreams/Publisher;)V
 	public static final fun logout (Lcom/mirego/trikot/analytics/AnalyticsService;Z)V
 	public static synthetic fun logout$default (Lcom/mirego/trikot/analytics/AnalyticsService;ZILjava/lang/Object;)V
+	public static final fun trackEvent (Lcom/mirego/trikot/analytics/AnalyticsService;Lcom/mirego/trikot/analytics/AnalyticsEvent;Ljava/util/Map;)V
 	public static final fun trackEvent (Lcom/mirego/trikot/analytics/AnalyticsService;Lcom/mirego/trikot/analytics/AnalyticsEvent;Lorg/reactivestreams/Publisher;)V
 }
 
 public final class com/mirego/trikot/analytics/AnalyticsServiceLogger : com/mirego/trikot/analytics/AnalyticsService {
 	public fun <init> (Lcom/mirego/trikot/analytics/AnalyticsService;)V
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V
@@ -65,6 +70,7 @@ public final class com/mirego/trikot/analytics/AnalyticsServiceLogger : com/mire
 public final class com/mirego/trikot/analytics/EmptyAnalyticsService : com/mirego/trikot/analytics/AnalyticsService {
 	public fun <init> ()V
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
@@ -20,7 +20,19 @@ interface AnalyticsService {
     /*
     The distinctAppId associated with the current device
      */
+    @Deprecated(
+        message = "Deprecated. Please use distinctDeviceId()",
+        replaceWith = ReplaceWith(
+            expression = "distinctDeviceId()",
+            imports = ["com.mirego.trikot.analytics.distinctDeviceId"]
+        )
+    )
     fun distinctAppId(): Promise<String>
+
+    /*
+    The distinctDeviceId associated with the current device
+     */
+    suspend fun distinctDeviceId(): String
 
     /*
     userId: Id of the logged in user
@@ -76,7 +88,16 @@ interface AnalyticsService {
                 currentAnalyticsService().isEnabled = value
             }
 
+        @Deprecated(
+            message = "Deprecated. Please use distinctDeviceId()",
+            replaceWith = ReplaceWith(
+                expression = "distinctDeviceId()",
+                imports = ["com.mirego.trikot.analytics.distinctDeviceId"]
+            )
+        )
         override fun distinctAppId() = currentAnalyticsService().distinctAppId()
+
+        override suspend fun distinctDeviceId() = currentAnalyticsService().distinctDeviceId()
 
         override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
             currentAnalyticsService().identifyUser(userId, properties)
@@ -116,6 +137,13 @@ interface AnalyticsService {
 event: Event to track, will be store using toString() method
 properties: Publisher of property to store with the event. Publisher MUST return a value.
  */
+@Deprecated(
+    message = "Deprecated. Please use the one without a Publisher",
+    replaceWith = ReplaceWith(
+        expression = "trackEvent(event, propertiesMap)",
+        imports = ["com.mirego.trikot.analytics.trackEvent"]
+    )
+)
 fun AnalyticsService.trackEvent(
     event: AnalyticsEvent,
     properties: Publisher<AnalyticsPropertiesType>
@@ -126,13 +154,39 @@ fun AnalyticsService.trackEvent(
 }
 
 /*
+event: Event to track, will be store using toString() method
+properties: Property to store with the event.
+ */
+fun AnalyticsService.trackEvent(
+    event: AnalyticsEvent,
+    propertiesMap: AnalyticsPropertiesType
+) {
+    trackEvent(event, propertiesMap)
+}
+
+/*
  userId: Id of the logged in user
  properties: Publisher of property to store with the event. Publisher MUST return a value.
  */
+@Deprecated(
+    message = "Deprecated. Please use the one without a Publisher",
+    replaceWith = ReplaceWith(
+        expression = "trackEvent(event, propertiesMap)",
+        imports = ["com.mirego.trikot.analytics.identifyUser"]
+    )
+)
 fun AnalyticsService.identifyUser(userId: String, properties: Publisher<AnalyticsPropertiesType>) {
     properties.first().subscribe(CancellableManager()) {
         identifyUser(userId, it)
     }
+}
+
+/*
+ userId: Id of the logged in user
+ properties: Property to store with the event.
+ */
+fun AnalyticsService.identifyUser(userId: String, propertiesMap: AnalyticsPropertiesType) {
+    identifyUser(userId, propertiesMap)
 }
 
 /*

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
@@ -14,7 +14,16 @@ class AnalyticsServiceLogger(private val analyticsService: AnalyticsService) : A
 
     private val superProperties = AtomicReference<AnalyticsPropertiesType>(mapOf())
 
+    @Deprecated(
+        message = "Deprecated. Please use distinctDeviceId()",
+        replaceWith = ReplaceWith(
+            expression = "distinctDeviceId()",
+            imports = ["com.mirego.trikot.analytics.distinctDeviceId"]
+        )
+    )
     override fun distinctAppId() = analyticsService.distinctAppId()
+
+    override suspend fun distinctDeviceId() = analyticsService.distinctDeviceId()
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
         println(

--- a/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
+++ b/trikot-analytics/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
@@ -7,7 +7,16 @@ class EmptyAnalyticsService : AnalyticsService {
 
     override var isEnabled = false
 
+    @Deprecated(
+        message = "Deprecated. Please use distinctDeviceId()",
+        replaceWith = ReplaceWith(
+            expression = "distinctDeviceId()",
+            imports = ["com.mirego.trikot.analytics.distinctDeviceId"]
+        )
+    )
     override fun distinctAppId() = Promise.resolve("ANALYTICS_SERVICE_NOT_CONFIGURED_DISTINCT_ID")
+
+    override suspend fun distinctDeviceId() = "ANALYTICS_SERVICE_NOT_CONFIGURED_DISTINCT_ID"
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
     }

--- a/trikot-analytics/firebase-ktx/api/firebase-ktx.api
+++ b/trikot-analytics/firebase-ktx/api/firebase-ktx.api
@@ -2,6 +2,7 @@ public final class com/mirego/trikot/analytics/FirebaseAnalyticsService : com/mi
 	public fun <init> (Landroid/content/Context;Z)V
 	public synthetic fun <init> (Landroid/content/Context;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V

--- a/trikot-analytics/mixpanel-ktx/api/mixpanel-ktx.api
+++ b/trikot-analytics/mixpanel-ktx/api/mixpanel-ktx.api
@@ -2,6 +2,7 @@ public final class com/mirego/trikot/analytics/MixpanelAnalyticsService : com/mi
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Z)V
 	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun distinctAppId ()Lcom/mirego/trikot/streams/reactive/promise/Promise;
+	public fun distinctDeviceId (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun identifyUser (Ljava/lang/String;Ljava/util/Map;)V
 	public fun incrementUserProperties (Ljava/util/Map;)V

--- a/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
+++ b/trikot-analytics/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
@@ -25,7 +25,16 @@ class MixpanelAnalyticsService(
 
     override val name: String = "MixpanelAnalytics"
 
+    @Deprecated(
+        message = "Deprecated. Please use distinctDeviceId()",
+        replaceWith = ReplaceWith(
+            expression = "distinctDeviceId()",
+            imports = ["com.mirego.trikot.analytics.distinctDeviceId"]
+        )
+    )
     override fun distinctAppId() = Promise.resolve(mixpanelAnalytics.distinctId)
+
+    override suspend fun distinctDeviceId(): String = mixpanelAnalytics.distinctId
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
         mixpanelAnalytics.identify(userId)

--- a/trikot-analytics/swift-extensions/firebase/FirebaseAnalyticsService.swift
+++ b/trikot-analytics/swift-extensions/firebase/FirebaseAnalyticsService.swift
@@ -20,6 +20,10 @@ public class FirebaseAnalyticsService: AnalyticsService {
         PromiseCompanion().resolve(value: Analytics.appInstanceID) as! Promise<NSString>
     }
 
+    public func distinctDeviceId() -> NSString {
+        Analytics.appInstanceID()
+    }
+
     public func identifyUser(userId: String, properties: [String: Any]) {
         Analytics.setUserID(userId)
         properties.forEach { Analytics.setUserProperty(anyToString($0.value), forName: $0.key) }

--- a/trikot-analytics/swift-extensions/firebase/FirebaseAnalyticsService.swift
+++ b/trikot-analytics/swift-extensions/firebase/FirebaseAnalyticsService.swift
@@ -21,7 +21,7 @@ public class FirebaseAnalyticsService: AnalyticsService {
     }
 
     public func distinctDeviceId() -> NSString {
-        Analytics.appInstanceID()
+        Analytics.appInstanceID() as! NSString
     }
 
     public func identifyUser(userId: String, properties: [String: Any]) {

--- a/trikot-analytics/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
+++ b/trikot-analytics/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
@@ -23,7 +23,7 @@ public class MixpanelAnalyticsService: AnalyticsService {
     }
 
     public func distinctDeviceId() -> NSString {
-        Mixpanel.mainInstance().distinctId
+        Mixpanel.mainInstance().distinctId as NSString
     }
 
     public func identifyUser(userId: String, properties: [String: Any]) {

--- a/trikot-analytics/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
+++ b/trikot-analytics/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
@@ -22,6 +22,10 @@ public class MixpanelAnalyticsService: AnalyticsService {
         PromiseCompanion().resolve(value: Mixpanel.mainInstance().distinctId) as! Promise<NSString>
     }
 
+    public func distinctDeviceId() -> NSString {
+        Mixpanel.mainInstance().distinctId
+    }
+
     public func identifyUser(userId: String, properties: [String: Any]) {
         Mixpanel.mainInstance().identify(distinctId: userId)
         Mixpanel.mainInstance().people.set(properties: properties.asMixpanelProperties)


### PR DESCRIPTION
## Description
We deprecate the dependecy to trikot-streams with the following changes

- Deprecate `fun distinctAppId(): Promise<String>` and add `suspend fun distinctAppId(): String`
- Deprecate `AnalyticsService.trackEvent` and `AnalyticsService. identifyUser`, which uses publishers and replace them with functions that don't use publishers.
- Deprecate `TrackableViewModelAction`, because it uses Publishers in its constructor in favour of `SimpleTrackableViewModelAction`

## Motivation and Context

Newer projects should use Coroutines and flows, not trikot-streams.

## How Has This Been Tested?

By running the trikot-viewmodels sample

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
