### PR TITLE
[KwordRemoteUpdate] Add supervisorScope to prevent cancellation of parallel http requests

### DIFF
--- a/trikot-kword/kword-remote-update/src/commonMain/kotlin/com/mirego/trikot/kword/remote/update/internal/RemoteTranslationsFetcher.kt
+++ b/trikot-kword/kword-remote-update/src/commonMain/kotlin/com/mirego/trikot/kword/remote/update/internal/RemoteTranslationsFetcher.kt
@@ -39,8 +39,8 @@ internal class RemoteTranslationsFetcher(
                 } ?: HttpClient()
 
                 coroutineScope.launch {
-                    supervisorScope {
-                        languageCodes.map { languageCode ->
+                    languageCodes.map { languageCode ->
+                        supervisorScope {
                             async {
                                 val translationsUrl = buildTranslationsUrl(
                                     baseTranslationsUrlVal,
@@ -50,10 +50,10 @@ internal class RemoteTranslationsFetcher(
                                 )
                                 fetchTranslations(sharedHttpClient, translationsUrl, baseFileName, languageCode)
                             }
-                        }.awaitAll().also { requestsResults ->
-                            applyFetchedTranslations(i18N, baseMap, requestsResults)
-                            sharedHttpClient.close()
                         }
+                    }.awaitAll().also { requestsResults ->
+                        applyFetchedTranslations(i18N, baseMap, requestsResults)
+                        sharedHttpClient.close()
                     }
                 }
             }


### PR DESCRIPTION
In a previous PR https://github.com/mirego/trikot/pull/208, I wrapped parallel HTTP requests inside a CoroutineScope. This means that one HTTP request failure will cause all the other requests to fail, which is not the intended behavior.

## Description

To fix this issue, each async task within the CoroutineScope is wrapped inside a supervisorScope to prevent parent job to be cancelled if the request fails.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
