### PR TITLE
refactor: Set Compose modifier as first optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Upcoming
 
+### Breaking Changes
+
+- [VMD] Change parameters order for some Compose components
+
 ### Updates
 
 - Gradle to `8.4`

--- a/trikot-viewmodels-declarative/compose/api/compose.api
+++ b/trikot-viewmodels-declarative/compose/api/compose.api
@@ -71,16 +71,16 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/Pl
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButtonKt {
-	public static final fun VMDButton-TC8WvNY (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDButtonViewModel;Landroidx/compose/ui/Alignment;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/foundation/Indication;Landroidx/compose/ui/semantics/Role;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDButton-TC8WvNY (Lcom/mirego/trikot/viewmodels/declarative/components/VMDButtonViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/foundation/Indication;Landroidx/compose/ui/semantics/Role;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckboxKt {
-	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDCheckbox (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDCheckbox (Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/CheckboxColors;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicatorKt {
-	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
+	public static final fun VMDCircularProgressIndicator-DUhRLBM (Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;Landroidx/compose/ui/Modifier;JFJILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDDropDownMenuKt {
@@ -101,40 +101,40 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VM
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponentKt {
-	public static final fun VMDLabeledComponent (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDLabeledComponent (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumnKt {
-	public static final fun VMDLazyColumn (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDLazyColumn (Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDLazyColumnIndexed (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function5;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRowKt {
-	public static final fun VMDLazyRow (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Horizontal;Landroidx/compose/ui/Alignment$Vertical;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDLazyRow (Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Horizontal;Landroidx/compose/ui/Alignment$Vertical;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDLazyRowIndexed (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Horizontal;Landroidx/compose/ui/Alignment$Vertical;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function5;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicatorKt {
-	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
+	public static final fun VMDLinearProgressIndicator-eaDK9VM (Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;Landroidx/compose/ui/Modifier;JJLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDListKt {
-	public static final fun VMDList (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDList (Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDSectionedList (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDListViewModel;Landroidx/compose/foundation/lazy/LazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLandroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitchKt {
-	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/SwitchColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDSwitch (Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextFieldKt {
-	public static final fun VMDTextField (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/text/KeyboardActions;ZZIILandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material/TextFieldColors;Landroidx/compose/runtime/Composer;III)V
+	public static final fun VMDTextField (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/text/KeyboardActions;ZZIILandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material/TextFieldColors;Landroidx/compose/runtime/Composer;III)V
 	public static final fun buildKeyboardActions (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/foundation/text/KeyboardActions;)Landroidx/compose/foundation/text/KeyboardActions;
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextKt {
-	public static final fun VMDText--4IGK_g (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+	public static final fun VMDText--4IGK_g (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;Landroidx/compose/ui/Modifier;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/ComposableSingletons$VMDCheckboxKt {
@@ -165,7 +165,7 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicatorKt {
-	public static final fun VMDCircularProgressIndicator-DUhRLBM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JFJILandroidx/compose/runtime/Composer;II)V
+	public static final fun VMDCircularProgressIndicator-DUhRLBM (Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;Landroidx/compose/ui/Modifier;JFJILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDDropDownMenuKt {
@@ -182,7 +182,7 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicatorKt {
-	public static final fun VMDLinearProgressIndicator-eaDK9VM (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;JJLandroidx/compose/runtime/Composer;II)V
+	public static final fun VMDLinearProgressIndicator-eaDK9VM (Lcom/mirego/trikot/viewmodels/declarative/components/VMDProgressViewModel;Landroidx/compose/ui/Modifier;JJLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDOutlinedButtonKt {
@@ -190,8 +190,8 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitchKt {
-	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun VMDSwitch (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Lkotlin/jvm/functions/Function4;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VMDSwitch (Lcom/mirego/trikot/viewmodels/declarative/components/VMDToggleViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/material3/SwitchColors;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextButtonKt {
@@ -199,11 +199,11 @@ public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/ma
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextFieldKt {
-	public static final fun VMDTextField (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/text/KeyboardActions;ZZIILandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/TextFieldColors;Landroidx/compose/runtime/Composer;III)V
+	public static final fun VMDTextField (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/foundation/text/KeyboardActions;ZZIILandroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/TextFieldColors;Landroidx/compose/runtime/Composer;III)V
 	public static final fun buildKeyboardActions (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextFieldViewModel;Landroidx/compose/foundation/text/KeyboardActions;)Landroidx/compose/foundation/text/KeyboardActions;
 }
 
 public final class com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextKt {
-	public static final fun VMDText--4IGK_g (Landroidx/compose/ui/Modifier;Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+	public static final fun VMDText--4IGK_g (Lcom/mirego/trikot/viewmodels/declarative/components/VMDTextViewModel;Landroidx/compose/ui/Modifier;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZIILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
 }
 

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDButton.kt
@@ -20,8 +20,8 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDContent
 
 @Composable
 fun <C : VMDContent> VMDButton(
-    modifier: Modifier = Modifier,
     viewModel: VMDButtonViewModel<C>,
+    modifier: Modifier = Modifier,
     contentAlignment: Alignment = Alignment.Center,
     propagateMinConstraints: Boolean = false,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCheckbox.kt
@@ -22,9 +22,9 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
 
 @Composable
 fun VMDCheckbox(
+    viewModel: VMDToggleViewModel<VMDNoContent>,
     modifier: Modifier = Modifier,
     componentModifier: Modifier = Modifier,
-    viewModel: VMDToggleViewModel<VMDNoContent>,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     colors: CheckboxColors = CheckboxDefaults.colors()
 ) {

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDCircularProgressIndicator.kt
@@ -20,8 +20,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsStat
 
 @Composable
 fun VMDCircularProgressIndicator(
-    modifier: Modifier = Modifier,
     viewModel: VMDProgressViewModel,
+    modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colors.primary,
     strokeWidth: Dp = ProgressIndicatorDefaults.StrokeWidth,
     backgroundColor: Color = Color.Transparent,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLabeledComponent.kt
@@ -9,9 +9,9 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun VMDLabeledComponent(
-    modifier: Modifier = Modifier,
     label: @Composable RowScope.() -> Unit,
-    content: @Composable RowScope.() -> Unit
+    content: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyColumn.kt
@@ -21,8 +21,8 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 
 @Composable
 fun <C : VMDIdentifiableContent> VMDLazyColumn(
-    modifier: Modifier = Modifier,
     viewModel: VMDListViewModel<C>,
+    modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     reverseLayout: Boolean = false,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLazyRow.kt
@@ -21,8 +21,8 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 
 @Composable
 fun <C : VMDIdentifiableContent> VMDLazyRow(
-    modifier: Modifier = Modifier,
     viewModel: VMDListViewModel<C>,
+    modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     reverseLayout: Boolean = false,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDLinearProgressIndicator.kt
@@ -19,8 +19,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsStat
 
 @Composable
 fun VMDLinearProgressIndicator(
-    modifier: Modifier = Modifier,
     viewModel: VMDProgressViewModel,
+    modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colors.primary,
     backgroundColor: Color = color.copy(alpha = ProgressIndicatorDefaults.IndicatorBackgroundOpacity)
 ) {

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDList.kt
@@ -24,8 +24,8 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDIdentifiableContent
 @Deprecated("Use either VMDLazyColumn instead")
 @Composable
 fun <C : VMDIdentifiableContent> VMDList(
-    modifier: Modifier = Modifier,
     viewModel: VMDListViewModel<C>,
+    modifier: Modifier = Modifier,
     state: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     reverseLayout: Boolean = false,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDSwitch.kt
@@ -22,9 +22,9 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
 
 @Composable
 fun VMDSwitch(
+    viewModel: VMDToggleViewModel<VMDNoContent>,
     modifier: Modifier = Modifier,
     componentModifier: Modifier = Modifier,
-    viewModel: VMDToggleViewModel<VMDNoContent>,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     colors: SwitchColors = SwitchDefaults.colors()
 ) {

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDText.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDText.kt
@@ -22,8 +22,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsStat
 
 @Composable
 fun VMDText(
-    modifier: Modifier = Modifier,
     viewModel: VMDTextViewModel,
+    modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     fontSize: TextUnit = TextUnit.Unspecified,
     fontStyle: FontStyle? = null,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
@@ -25,8 +25,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.Forma
 
 @Composable
 fun VMDTextField(
-    modifier: Modifier = Modifier,
     viewModel: VMDTextFieldViewModel,
+    modifier: Modifier = Modifier,
     textStyle: TextStyle = LocalTextStyle.current,
     placeHolderStyle: TextStyle = LocalTextStyle.current,
     label: @Composable (() -> Unit)? = null,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDCircularProgressIndicator.kt
@@ -20,8 +20,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsStat
 
 @Composable
 fun VMDCircularProgressIndicator(
-    modifier: Modifier = Modifier,
     viewModel: VMDProgressViewModel,
+    modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colorScheme.primary,
     strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
     trackColor: Color = ProgressIndicatorDefaults.circularTrackColor,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDLinearProgressIndicator.kt
@@ -18,8 +18,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsStat
 
 @Composable
 fun VMDLinearProgressIndicator(
-    modifier: Modifier = Modifier,
     viewModel: VMDProgressViewModel,
+    modifier: Modifier = Modifier,
     color: Color = ProgressIndicatorDefaults.linearColor,
     trackColor: Color = ProgressIndicatorDefaults.linearTrackColor
 ) {

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDSwitch.kt
@@ -23,9 +23,9 @@ import com.mirego.trikot.viewmodels.declarative.content.VMDNoContent
 
 @Composable
 fun VMDSwitch(
+    viewModel: VMDToggleViewModel<VMDNoContent>,
     modifier: Modifier = Modifier,
     componentModifier: Modifier = Modifier,
-    viewModel: VMDToggleViewModel<VMDNoContent>,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     colors: SwitchColors = SwitchDefaults.colors()
 ) {

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDText.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDText.kt
@@ -22,8 +22,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsStat
 
 @Composable
 fun VMDText(
-    modifier: Modifier = Modifier,
     viewModel: VMDTextViewModel,
+    modifier: Modifier = Modifier,
     color: Color = Color.Unspecified,
     fontSize: TextUnit = TextUnit.Unspecified,
     fontStyle: FontStyle? = null,

--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextField.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/material3/VMDTextField.kt
@@ -25,8 +25,8 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.internal.Forma
 
 @Composable
 fun VMDTextField(
-    modifier: Modifier = Modifier,
     viewModel: VMDTextFieldViewModel,
+    modifier: Modifier = Modifier,
     textStyle: TextStyle = LocalTextStyle.current,
     placeHolderStyle: TextStyle = LocalTextStyle.current,
     label: @Composable (() -> Unit)? = null,


### PR DESCRIPTION
## Description

For Jetpack Compose components, update parameters order so that mandatory parameters come before `modifier` parameters. 

## Motivation and Context

According to [Jetpack Compose guidelines](
https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-api-guidelines.md#elements-accept-and-respect-a-modifier-parameter):
_Element functions MUST accept a parameter of type Modifier. This parameter MUST be named “modifier” and MUST appear as the first optional parameter in the element function's parameter list._ 

Convention seems to put mandatory parameters before `modifier` parameter.  (See official Compose components such as `Text()`, `Image()`)...
Rational: 
This allows to use the component by passing the `viewModel` parameter without specifying parameter name:
```
VMDButton(viewModel) {
...
}
```
before:
```
VMDButton(viewModel = viewModel) {
...
}
```
## How Has This Been Tested?
It compiles. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Technicaly a breaking change as it may break existing calls which don't specify parameter names.
