### PR TITLE
Fix name clash when using Kotlin 1.9.21

### DIFF
--- a/trikot-viewmodels/swift-extensions/UITextFieldExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UITextFieldExtensions.swift
@@ -53,7 +53,7 @@ extension UITextField {
                 observe(inputTextViewModel.editorAction) { [weak self] (action: InputTextEditorAction) in
                     if action != ViewModelAction.Companion.init().None {
                         self?.addAction(events: .editingDidEndOnExit, { _ in
-                            action.execute()
+                            action.execute(actionContext: nil)
                         })
                     } else {
                         self?.removeAction(events: .editingDidEndOnExit)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using the Kotlin 1.9.21 the Kotlin Native compiler now adds an underscores to the helper function execute.
<!--- Describe your changes in detail -->

## Motivation and Context

We now call the full function `execute(actionContext: Any?)` with the argument `nil` to keep the same behaviour and fix the name clash.
<!--- Why is those changes required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
