### PR TITLE
Fix possibly huge memory leak caused by long lived CancellableManagerProvider

### DIFF
--- a/trikot-foundation/trikotFoundation/api/android/trikotFoundation.api
+++ b/trikot-foundation/trikotFoundation/api/android/trikotFoundation.api
@@ -203,6 +203,7 @@ public final class com/mirego/trikot/foundation/concurrent/AtomicReference {
 	public fun <init> (Ljava/lang/Object;)V
 	public final fun compareAndSet (Ljava/lang/Object;Ljava/lang/Object;)Z
 	public final fun compareAndSwap (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getAndSet (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getValue ()Ljava/lang/Object;
 	public final fun setOrThrow (Ljava/lang/Object;Ljava/lang/Object;)V
 	public final fun setOrThrow (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V

--- a/trikot-foundation/trikotFoundation/api/jvm/trikotFoundation.api
+++ b/trikot-foundation/trikotFoundation/api/jvm/trikotFoundation.api
@@ -203,6 +203,7 @@ public final class com/mirego/trikot/foundation/concurrent/AtomicReference {
 	public fun <init> (Ljava/lang/Object;)V
 	public final fun compareAndSet (Ljava/lang/Object;Ljava/lang/Object;)Z
 	public final fun compareAndSwap (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public final fun getAndSet (Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getValue ()Ljava/lang/Object;
 	public final fun setOrThrow (Ljava/lang/Object;Ljava/lang/Object;)V
 	public final fun setOrThrow (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)V

--- a/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
+++ b/trikot-foundation/trikotFoundation/src/commonMain/kotlin/com/mirego/trikot/foundation/concurrent/AtomicReference.kt
@@ -23,6 +23,10 @@ class AtomicReference<T>(value: T) {
     fun compareAndSwap(expected: T, new: T): T {
         return if (compareAndSet(expected, new)) new else value
     }
+
+    fun getAndSet(new: T): T {
+        return atomicValue.getAndSet(new)
+    }
 }
 
 fun <T> AtomicReference<T>.setOrThrow(new: T) = setOrThrow(value, new)

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
@@ -3,18 +3,14 @@ package com.mirego.trikot.streams.cancellable
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 
 class CancellableManagerProvider : Cancellable {
-    private val cancellableManager = CancellableManager()
     private val internalCancellableManagerRef = AtomicReference(CancellableManager())
 
-    fun cancelPreviousAndCreate(): CancellableManager {
-        internalCancellableManagerRef.value.cancel()
-        return CancellableManager().also {
-            internalCancellableManagerRef.setOrThrow(internalCancellableManagerRef.value, it)
-            cancellableManager.add(it)
+    fun cancelPreviousAndCreate(): CancellableManager =
+        CancellableManager().also {
+            internalCancellableManagerRef.getAndSet(it).cancel()
         }
-    }
 
     override fun cancel() {
-        cancellableManager.cancel()
+        internalCancellableManagerRef.value.cancel()
     }
 }

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
@@ -13,7 +13,7 @@ class CancellableManagerProvider : Cancellable {
             internalCancellableManagerRef.getAndSet(cancellableManager).cancel()
             serialQueue.dispatch {
                 if (isCancelled.value) {
-                    internalCancellableManagerRef.value.cancel()
+                    cancellableManager.cancel()
                 }
             }
         }

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProvider.kt
@@ -1,16 +1,29 @@
 package com.mirego.trikot.streams.cancellable
 
 import com.mirego.trikot.foundation.concurrent.AtomicReference
+import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
 
 class CancellableManagerProvider : Cancellable {
+    private val serialQueue = SynchronousSerialQueue()
     private val internalCancellableManagerRef = AtomicReference(CancellableManager())
+    private val isCancelled = AtomicReference(false)
 
-    fun cancelPreviousAndCreate(): CancellableManager =
-        CancellableManager().also {
-            internalCancellableManagerRef.getAndSet(it).cancel()
+    fun cancelPreviousAndCreate(): CancellableManager {
+        return CancellableManager().also { cancellableManager ->
+            internalCancellableManagerRef.getAndSet(cancellableManager).cancel()
+            serialQueue.dispatch {
+                if (isCancelled.value) {
+                    internalCancellableManagerRef.value.cancel()
+                }
+            }
         }
+    }
 
     override fun cancel() {
-        internalCancellableManagerRef.value.cancel()
+        serialQueue.dispatch {
+            if (isCancelled.compareAndSet(isCancelled.value, true)) {
+                internalCancellableManagerRef.value.cancel()
+            }
+        }
     }
 }

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProviderTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerProviderTests.kt
@@ -24,4 +24,15 @@ class CancellableManagerProviderTests {
 
         assertTrue { cancelled }
     }
+
+    @Test
+    fun requestingACancellableManagerFromACancelledProviderReturnsACancelledCancellableManager() {
+        val cancellableManagerProvider = CancellableManagerProvider()
+        cancellableManagerProvider.cancel()
+        val cancellableManager = cancellableManagerProvider.cancelPreviousAndCreate()
+        var cancelled = false
+        cancellableManager.add { cancelled = true }
+
+        assertTrue { cancelled }
+    }
 }


### PR DESCRIPTION
## Description

A long lived CancellableManagerProvider could easily end up with very many “cancelled” Cancellable in it’s internal CancellableManager because this is only cleared when the Provider itself is cancelled.

This can cause huge memory leaks in some cases, for example in the DebounceProcessor

Since there is only ever one “not cancelled” CancellableManager provided by the CancellableManagerProvider, there is actually no need to keep the previously provided, now cancelled, CancellableManager.

We now simply use the internalCancellableManagerRef.

Also took the oportunity to make cancelPreviousAndCreate hopefully atomic be exposing and using getAndSet on AtomicReference

## Motivation and Context

In certain realtime application, usage of `debounce()` on long lived, shared publishers could cause immense memory leaks

## How Has This Been Tested?

- Tested in our application
- Ran the unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)