### PR TITLE
Update Kingfisher to 7.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Upcoming
 
+### Updates
+
+- Kingfisher to `7.10.1`
+
 ### Breaking Changes
 
 - [VMD] Change parameters order for some Compose components

--- a/Trikot.podspec
+++ b/Trikot.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |spec|
     subspec.tvos.deployment_target = '12.0'
     subspec.dependency 'Trikot/streams'
     subspec.dependency 'Trikot/viewmodels'
-    subspec.dependency 'Kingfisher', '~> 7.8.1'
+    subspec.dependency 'Kingfisher', '~> 7.10.1'
   end
 
   # View Model Declarative
@@ -68,14 +68,14 @@ Pod::Spec.new do |spec|
     subspec.source_files = 'trikot-viewmodels-declarative/swift/uikit/**/*.swift'
     subspec.dependency 'Trikot/streams'
     subspec.dependency 'Trikot/viewmodels.declarative'
-    subspec.dependency 'Kingfisher', '~> 7.8.1'
+    subspec.dependency 'Kingfisher', '~> 7.10.1'
   end
 
   spec.subspec 'viewmodels.declarative.SwiftUI' do |subspec|
     subspec.source_files = 'trikot-viewmodels-declarative/swift/swiftui/**/*.swift'
     subspec.dependency 'Trikot/viewmodels.declarative'
     subspec.dependency 'Trikot/viewmodels.declarative.Combine'
-    subspec.dependency 'Kingfisher', '~> 7.8.1'
+    subspec.dependency 'Kingfisher', '~> 7.10.1'
     subspec.dependency 'SwiftUIIntrospect', '~> 1.0'
   end
 
@@ -87,7 +87,7 @@ Pod::Spec.new do |spec|
     spec.subspec 'viewmodels.declarative.SwiftUI.flow' do |subspec|
       subspec.source_files = 'trikot-viewmodels-declarative-flow/swift/swiftui/**/*.swift'
       subspec.dependency 'Trikot/viewmodels.declarative.flow'
-      subspec.dependency 'Kingfisher', '~> 7.8.1'
+      subspec.dependency 'Kingfisher', '~> 7.10.1'
       subspec.dependency 'SwiftUIIntrospect', '~> 1.0'
     end
 

--- a/trikot-viewmodels-declarative-flow/sample/ios/Podfile.lock
+++ b/trikot-viewmodels-declarative-flow/sample/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Kingfisher (7.8.1)
+  - Kingfisher (7.10.1)
   - SwiftLint (0.52.3)
   - SwiftUIIntrospect (1.0.0)
   - Trikot/kword (5.4.0):
@@ -7,7 +7,7 @@ PODS:
   - Trikot/viewmodels.declarative.flow (5.4.0):
     - TRIKOT_FRAMEWORK_NAME
   - Trikot/viewmodels.declarative.SwiftUI.flow (5.4.0):
-    - Kingfisher (~> 7.8.1)
+    - Kingfisher (~> 7.10.1)
     - SwiftUIIntrospect (~> 1.0)
     - Trikot/viewmodels.declarative.flow
     - TRIKOT_FRAMEWORK_NAME
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
     :path: "../common"
 
 SPEC CHECKSUMS:
-  Kingfisher: 63f677311d36a3473f6b978584f8a3845d023dc5
+  Kingfisher: bc5abe80a8e0144537ef1dd5a0b2621b04f7f439
   SwiftLint: 76ec9c62ad369cff2937474cb34c9af3fa270b7b
   SwiftUIIntrospect: 9f15bf51d1a7582e168a683debca38649f3e152e
-  Trikot: b1a6d5d25cb2c16bda9bfe4fe69f2588f542f644
+  Trikot: 0192eb1b5555dda955003d6e1f95362b9c7678ec
   TRIKOT_FRAMEWORK_NAME: 677d2ac6978065c7ce493038d0c7701ec43fe363
 
 PODFILE CHECKSUM: 3ea922a40d3e15204de5e4af30076387b6e5f2c9

--- a/trikot-viewmodels-declarative/sample/ios/Podfile.lock
+++ b/trikot-viewmodels-declarative/sample/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Kingfisher (7.8.1)
+  - Kingfisher (7.10.1)
   - ReachabilitySwift (5.0.0)
   - SwiftLint (0.52.3)
   - SwiftUIIntrospect (1.0.0)
@@ -16,13 +16,13 @@ PODS:
   - Trikot/viewmodels.declarative.Combine (5.4.0):
     - TRIKOT_FRAMEWORK_NAME
   - Trikot/viewmodels.declarative.SwiftUI (5.4.0):
-    - Kingfisher (~> 7.8.1)
+    - Kingfisher (~> 7.10.1)
     - SwiftUIIntrospect (~> 1.0)
     - Trikot/viewmodels.declarative
     - Trikot/viewmodels.declarative.Combine
     - TRIKOT_FRAMEWORK_NAME
   - Trikot/viewmodels.declarative.UIKit (5.4.0):
-    - Kingfisher (~> 7.8.1)
+    - Kingfisher (~> 7.10.1)
     - Trikot/streams
     - Trikot/viewmodels.declarative
     - TRIKOT_FRAMEWORK_NAME
@@ -52,12 +52,12 @@ EXTERNAL SOURCES:
     :path: "../common"
 
 SPEC CHECKSUMS:
-  Kingfisher: 63f677311d36a3473f6b978584f8a3845d023dc5
+  Kingfisher: bc5abe80a8e0144537ef1dd5a0b2621b04f7f439
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   SwiftLint: 76ec9c62ad369cff2937474cb34c9af3fa270b7b
   SwiftUIIntrospect: 9f15bf51d1a7582e168a683debca38649f3e152e
-  Trikot: b1a6d5d25cb2c16bda9bfe4fe69f2588f542f644
-  TRIKOT_FRAMEWORK_NAME: 700ed0baa9ff8412686d9187837f7a427c4fe1e3
+  Trikot: 0192eb1b5555dda955003d6e1f95362b9c7678ec
+  TRIKOT_FRAMEWORK_NAME: 78d24f3b4e7e2cd3da313a33db4aa2d375293c36
 
 PODFILE CHECKSUM: 8057f57ba2a2db77f33517422839afd5282c408e
 

--- a/trikot-viewmodels/sample/ios/Podfile.lock
+++ b/trikot-viewmodels/sample/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Kingfisher (7.8.1)
+  - Kingfisher (7.10.1)
   - SwiftLint (0.52.3)
-  - Trikot/streams (5.3.0):
+  - Trikot/streams (5.4.0):
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels (5.3.0):
+  - Trikot/viewmodels (5.4.0):
     - Trikot/streams
     - TRIKOT_FRAMEWORK_NAME
-  - Trikot/viewmodels.Kingfisher (5.3.0):
-    - Kingfisher (~> 7.8.1)
+  - Trikot/viewmodels.Kingfisher (5.4.0):
+    - Kingfisher (~> 7.10.1)
     - Trikot/streams
     - Trikot/viewmodels
     - TRIKOT_FRAMEWORK_NAME
@@ -32,9 +32,9 @@ EXTERNAL SOURCES:
     :path: "../common"
 
 SPEC CHECKSUMS:
-  Kingfisher: 63f677311d36a3473f6b978584f8a3845d023dc5
+  Kingfisher: bc5abe80a8e0144537ef1dd5a0b2621b04f7f439
   SwiftLint: 76ec9c62ad369cff2937474cb34c9af3fa270b7b
-  Trikot: 3f21d54bfbd1000f054a8e3f037d4048a91d1c82
+  Trikot: 0192eb1b5555dda955003d6e1f95362b9c7678ec
   TRIKOT_FRAMEWORK_NAME: 78d24f3b4e7e2cd3da313a33db4aa2d375293c36
 
 PODFILE CHECKSUM: 56a60de7bc0a9826254d4aa86c5368fff73f8ee5


### PR DESCRIPTION
## Description

This updates Kingfisher to 7.10.1.

## Motivation and Context

Kingfisher now includes the new required reason API privacy manifest which will be required by Apple in spring 2024.

## How Has This Been Tested?

Tested in the sample apps.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
