### PR TITLE
Fix memory alloc bug when using trikot-graphql

### DIFF
--- a/trikot-graphql/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/QueryEscaping.kt
+++ b/trikot-graphql/graphql/src/commonMain/kotlin/com/mirego/trikot/graphql/QueryEscaping.kt
@@ -1,9 +1,9 @@
 package com.mirego.trikot.graphql
 
 fun String.escapeForGraphql(): String {
-    return this.fold("") { current, value ->
-        current + value.escapeForGraphql()
-    }
+    return this.fold(StringBuilder()) { builder, value ->
+        builder.append(value.escapeForGraphql())
+    }.toString()
 }
 
 fun Char.escapeForGraphql(): String {


### PR DESCRIPTION
## Description
The `String.escapeForGraphql()` extension function was creating countless String objects inside the "fold" loop.

## Motivation and Context

In my app, the query was huge, which means that many many String objects were allocated and deallocated about 100ms later, triggering many garbage collecting events. In an older device with low RAM and/or processing power, this could noticeably freeze the UI (in my case, for about 8 seconds!)

## How Has This Been Tested?

This fix was tested in my project. We no longer allocate many String objects, instead using a StringBuilder.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
