### PR TITLE
Datasource: Add typealias StateData

### DIFF
--- a/trikot-datasources/datasources-core/api/android/datasources-core.api
+++ b/trikot-datasources/datasources-core/api/android/datasources-core.api
@@ -54,6 +54,14 @@ public final class com/mirego/trikot/datasources/DataState$Pending : com/mirego/
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/mirego/trikot/datasources/StateDataKt {
+	public static final fun stateDataData (Ljava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static final fun stateDataError (Ljava/lang/Throwable;Ljava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static synthetic fun stateDataError$default (Ljava/lang/Throwable;Ljava/lang/Object;ILjava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static final fun stateDataPending (Ljava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static synthetic fun stateDataPending$default (Ljava/lang/Object;ILjava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+}
+
 public final class com/mirego/trikot/datasources/extensions/DataStateExtensionsKt {
 	public static final fun data (Lcom/mirego/trikot/datasources/DataState;)Ljava/lang/Object;
 	public static final fun error (Lcom/mirego/trikot/datasources/DataState;)Ljava/lang/Throwable;

--- a/trikot-datasources/datasources-core/api/jvm/datasources-core.api
+++ b/trikot-datasources/datasources-core/api/jvm/datasources-core.api
@@ -54,6 +54,14 @@ public final class com/mirego/trikot/datasources/DataState$Pending : com/mirego/
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/mirego/trikot/datasources/StateDataKt {
+	public static final fun stateDataData (Ljava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static final fun stateDataError (Ljava/lang/Throwable;Ljava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static synthetic fun stateDataError$default (Ljava/lang/Throwable;Ljava/lang/Object;ILjava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static final fun stateDataPending (Ljava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+	public static synthetic fun stateDataPending$default (Ljava/lang/Object;ILjava/lang/Object;)Lcom/mirego/trikot/datasources/DataState;
+}
+
 public final class com/mirego/trikot/datasources/extensions/DataStateExtensionsKt {
 	public static final fun data (Lcom/mirego/trikot/datasources/DataState;)Ljava/lang/Object;
 	public static final fun error (Lcom/mirego/trikot/datasources/DataState;)Ljava/lang/Throwable;

--- a/trikot-datasources/datasources-core/src/commonMain/kotlin/com/mirego/trikot/datasources/StateData.kt
+++ b/trikot-datasources/datasources-core/src/commonMain/kotlin/com/mirego/trikot/datasources/StateData.kt
@@ -1,0 +1,7 @@
+package com.mirego.trikot.datasources
+
+typealias StateData<V> = DataState<V, Throwable>
+
+fun <V> stateDataPending(value: V? = null): StateData<V> = DataState.pending(value)
+fun <V> stateDataData(value: V): StateData<V> = DataState.data(value)
+fun <V> stateDataError(error: Throwable, value: V? = null): StateData<V> = DataState.error(error, value)


### PR DESCRIPTION
## Description

Add a typealias StateData to DataState to avoid having to always specify the error type

## Motivation and Context

Less keystrokes more thinking :wesmart:

## How Has This Been Tested?

In my project

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
