### PR TITLE
Fix VMDTextField parameter not used in the implementation

### DIFF
--- a/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
+++ b/trikot-viewmodels-declarative/compose/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/viewmodel/VMDTextField.kt
@@ -30,7 +30,7 @@ fun VMDTextField(
     textStyle: TextStyle = LocalTextStyle.current,
     placeHolderStyle: TextStyle = LocalTextStyle.current,
     label: @Composable (() -> Unit)? = null,
-    placeholder: @Composable (() -> Unit)? = null,
+    placeholder: @Composable ((String) -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
     keyboardActions: KeyboardActions = KeyboardActions(),
@@ -56,7 +56,7 @@ fun VMDTextField(
         enabled = textFieldViewModel.isEnabled,
         label = label,
         placeholder = {
-            Text(
+            placeholder?.invoke(textFieldViewModel.placeholder) ?: Text(
                 text = textFieldViewModel.placeholder,
                 style = placeHolderStyle
             )


### PR DESCRIPTION

## Description

I added a check if a placeholder is passed to the function, if it is the case we use the placeholder instead of the Text.

## Motivation and Context

In the VMDTextField we have a placeholder parameter, but it was not used in the implementation. 
It was impossible to have a custom placeholder for the VMDText since what we passed to the TextField was a simple Text with a style. I ran in a case where my text input was on a single line, but the placeholder was on multiple lines. Being able to set a placeholder will solve this case and make the VMDTextField more flexible.

## How Has This Been Tested?

I tested this change in a project. I tested the function by passing a placeholder as parameter. 
I also tested without a parameter to make sure everything still work correctly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
