### PR TITLE
Update ReachabilitySwift to 5.2

### DIFF
--- a/Trikot.podspec
+++ b/Trikot.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |spec|
   # Http
   spec.subspec 'http' do |subspec|
     subspec.source_files = 'trikot-http/swift-extensions/*.swift'
-    subspec.dependency 'ReachabilitySwift', '~> 5.0'
+    subspec.dependency 'ReachabilitySwift', '~> 5.2'
   end
 
   # View Model

--- a/trikot-viewmodels-declarative/sample/ios/Podfile.lock
+++ b/trikot-viewmodels-declarative/sample/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - Kingfisher (7.10.1)
-  - ReachabilitySwift (5.0.0)
+  - ReachabilitySwift (5.2.1)
   - SwiftLint (0.52.3)
   - SwiftUIIntrospect (1.0.0)
   - Trikot/http (5.4.0):
-    - ReachabilitySwift (~> 5.0)
+    - ReachabilitySwift (~> 5.2)
     - TRIKOT_FRAMEWORK_NAME
   - Trikot/kword (5.4.0):
     - TRIKOT_FRAMEWORK_NAME
@@ -53,10 +53,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Kingfisher: bc5abe80a8e0144537ef1dd5a0b2621b04f7f439
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  ReachabilitySwift: 5ae15e16814b5f9ef568963fb2c87aeb49158c66
   SwiftLint: 76ec9c62ad369cff2937474cb34c9af3fa270b7b
   SwiftUIIntrospect: 9f15bf51d1a7582e168a683debca38649f3e152e
-  Trikot: 0192eb1b5555dda955003d6e1f95362b9c7678ec
+  Trikot: 05f591b69097bbaeec7a5a0fdff6a2a5842620f9
   TRIKOT_FRAMEWORK_NAME: 78d24f3b4e7e2cd3da313a33db4aa2d375293c36
 
 PODFILE CHECKSUM: 8057f57ba2a2db77f33517422839afd5282c408e

--- a/trikot-viewmodels-declarative/sample/ios/Sample.xcodeproj/project.pbxproj
+++ b/trikot-viewmodels-declarative/sample/ios/Sample.xcodeproj/project.pbxproj
@@ -332,7 +332,6 @@
 				C8D868D6268AA9660054CF44 /* Frameworks */,
 				C8D868D7268AA9660054CF44 /* Resources */,
 				0BAFC9F4511610892588BA65 /* [CP] Embed Pods Frameworks */,
-				05C3DB8424842BF979E358B1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -389,23 +388,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		05C3DB8424842BF979E358B1 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Sample/Pods-Sample-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Sample/Pods-Sample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Sample/Pods-Sample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		0BAFC9F4511610892588BA65 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
## Description

This updates ReachabilitySwift to 5.2, which includes the new required Apple privacy manifests.

## Motivation and Context

Starting May 1st 2024, privacy manifests for required reason APIs are now required for 3rd-party libs.

## How Has This Been Tested?

Tested in my project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)
