### PR TITLE
change init of Strings dictionary in iOS in TrikotHttpResponse

### DIFF
--- a/trikot-http/swift-extensions/TrikotHttpResponse.swift
+++ b/trikot-http/swift-extensions/TrikotHttpResponse.swift
@@ -13,7 +13,7 @@ public class TrikotHttpResponse: NSObject, HttpResponse {
 
     @objc
     public init(data: Data?, response: URLResponse?) {
-        var headers = [String: String]()
+        var headers: [String: String] = [:]
         source = HttpResponseResponseSource.unknown
         if let response = response as? HTTPURLResponse {
             response.allHeaderFields.forEach {(arg) in


### PR DESCRIPTION
## Description

Changed the syntax to build a String dictionary in iOS

## Motivation and Context

For some reason, the syntax used before to init the Strings map in TrikotHttpError causes error in building my iOS app.  

```
ios/Pods/Trikot/trikot-http/swift-extensions/TrikotHttpResponse.swift:16:23: cannot call value of non-function type '[AnyHashable : String.Type]'

var headers = [String: String]()
```

## How Has This Been Tested?
The app is not working locally without this change. So fixing it locally allowed me to build the app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)
