### PR TITLE
FileSystemDataSource ++

### DIFF
--- a/trikot-datasources/datasources-flow-filesystem/api/android/datasources-flow-filesystem.api
+++ b/trikot-datasources/datasources-flow-filesystem/api/android/datasources-flow-filesystem.api
@@ -1,9 +1,11 @@
-public final class com/mirego/trikot/datasources/flow/generic/FileSystemDataSource : com/mirego/trikot/datasources/flow/BaseExpiringExecutableFlowDataSource {
-	public fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;)V
-	public synthetic fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public class com/mirego/trikot/datasources/flow/generic/FileSystemDataSource : com/mirego/trikot/datasources/flow/BaseExpiringExecutableFlowDataSource {
+	public fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;Lcom/mirego/trikot/datasources/flow/FlowDataSource;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;Lcom/mirego/trikot/datasources/flow/FlowDataSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun internalRead (Lcom/mirego/trikot/datasources/flow/ExpiringFlowDataSourceRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun internalRead (Lcom/mirego/trikot/datasources/flow/FlowDataSourceRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun save (Lcom/mirego/trikot/datasources/flow/ExpiringFlowDataSourceRequest;Lcom/mirego/trikot/datasources/flow/FlowDataSourceExpiringValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun save (Lcom/mirego/trikot/datasources/flow/FlowDataSourceRequest;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun shouldSkipRequest (Lcom/mirego/trikot/datasources/flow/ExpiringFlowDataSourceRequest;)Z
 }
 

--- a/trikot-datasources/datasources-flow-filesystem/api/jvm/datasources-flow-filesystem.api
+++ b/trikot-datasources/datasources-flow-filesystem/api/jvm/datasources-flow-filesystem.api
@@ -1,9 +1,11 @@
-public final class com/mirego/trikot/datasources/flow/generic/FileSystemDataSource : com/mirego/trikot/datasources/flow/BaseExpiringExecutableFlowDataSource {
-	public fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;)V
-	public synthetic fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public class com/mirego/trikot/datasources/flow/generic/FileSystemDataSource : com/mirego/trikot/datasources/flow/BaseExpiringExecutableFlowDataSource {
+	public fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;Lcom/mirego/trikot/datasources/flow/FlowDataSource;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/Json;Lkotlinx/serialization/KSerializer;Ljava/lang/String;Lokio/FileSystem;Lcom/mirego/trikot/datasources/flow/FlowDataSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun delete (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun internalRead (Lcom/mirego/trikot/datasources/flow/ExpiringFlowDataSourceRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun internalRead (Lcom/mirego/trikot/datasources/flow/FlowDataSourceRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun save (Lcom/mirego/trikot/datasources/flow/ExpiringFlowDataSourceRequest;Lcom/mirego/trikot/datasources/flow/FlowDataSourceExpiringValue;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun save (Lcom/mirego/trikot/datasources/flow/FlowDataSourceRequest;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun shouldSkipRequest (Lcom/mirego/trikot/datasources/flow/ExpiringFlowDataSourceRequest;)Z
 }
 

--- a/trikot-datasources/datasources-flow-filesystem/src/commonTest/kotlin/com/mirego/trikot/datasources/flow/generic/FileSystemDataSourceTests.kt
+++ b/trikot-datasources/datasources-flow-filesystem/src/commonTest/kotlin/com/mirego/trikot/datasources/flow/generic/FileSystemDataSourceTests.kt
@@ -3,16 +3,21 @@ package com.mirego.trikot.datasources.flow.generic
 import com.mirego.trikot.datasources.flow.ExpiringFlowDataSourceRequest
 import com.mirego.trikot.datasources.flow.FlowDataSourceExpiringValue
 import com.mirego.trikot.datasources.flow.FlowDataSourceRequest
+import com.mirego.trikot.datasources.flow.filesystem.NativeFileSystem
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okio.FileNotFoundException
+import okio.FileSystem
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FileSystemDataSourceTests {
@@ -22,6 +27,7 @@ class FileSystemDataSourceTests {
 
     private val fileSystem = FakeFileSystem()
     private val fileSystemDataSource = FileSystemDataSource<BasicRequest, TestData>(json, dataSerializer, diskCachePath, fileSystem)
+    private val fileSystemDataSourceSkipAll = SkipAllFileSystemDataSource<BasicRequest, TestData>(json, dataSerializer, diskCachePath, fileSystem)
 
     @Test
     fun test_read_valid_data() = runTest {
@@ -65,6 +71,34 @@ class FileSystemDataSourceTests {
         assertEquals("{\"value\":\"savedValue\"}", savedContent)
     }
 
+    @Test
+    fun test_read_skip() = runTest {
+        val testRequest = BasicRequest("test", 1000L, FlowDataSourceRequest.Type.REFRESH_CACHE)
+        val testDataJson = "{\"value\": \"value\"}"
+        val filePath = "$diskCachePath/${testRequest.cacheableId}.json".toPath()
+
+        val parentDirectory = filePath.parent ?: throw AssertionError("Parent directory should not be null")
+        fileSystem.createDirectories(parentDirectory)
+        fileSystem.write(filePath) {
+            writeUtf8(testDataJson)
+        }
+
+        assertFails {
+            fileSystemDataSourceSkipAll.internalRead(testRequest)
+        }
+    }
+
+    @Test
+    fun test_save_data_skip() = runTest {
+        val testRequest = BasicRequest("saveTest", 1000L, FlowDataSourceRequest.Type.REFRESH_CACHE)
+        val testData = TestData("savedValue")
+        val filePath = "$diskCachePath/${testRequest.cacheableId}.json".toPath()
+
+        fileSystemDataSourceSkipAll.save(testRequest, FlowDataSourceExpiringValue(testData, Clock.System.now().toEpochMilliseconds()))
+
+        assertFalse(fileSystem.exists(filePath))
+    }
+
     @Serializable
     private data class TestData(val value: String)
 
@@ -73,4 +107,15 @@ class FileSystemDataSourceTests {
         override val expiredInMilliseconds: Long = 0,
         override val requestType: FlowDataSourceRequest.Type
     ) : ExpiringFlowDataSourceRequest
+
+    private class SkipAllFileSystemDataSource<R : ExpiringFlowDataSourceRequest, TestData>(
+        json: Json,
+        dataSerializer: KSerializer<TestData>,
+        diskCachePath: String,
+        fileManager: FileSystem = NativeFileSystem.fileSystem,
+    ) : FileSystemDataSource<R, TestData>(json, dataSerializer, diskCachePath, fileManager) {
+        override fun shouldSkipRequest(request: R): Boolean {
+            return true
+        }
+    }
 }


### PR DESCRIPTION
## Description

- Add a way to skip read and save data for a specific request. To do so, you have to subclass FileSystemDataSource and override shouldSkipRequest.
- Implement the delete method.

## How Has This Been Tested?

Tested in my project

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
