### PR TITLE
[Android] Allow the VMDTextStyleProvider to use Composable functions

### DIFF
--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/TextStyleResourceExtensions.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compose/extensions/TextStyleResourceExtensions.kt
@@ -1,5 +1,6 @@
 package com.mirego.trikot.viewmodels.declarative.compose.extensions
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -10,14 +11,17 @@ import com.mirego.trikot.viewmodels.declarative.properties.VMDRichTextSpan
 import com.mirego.trikot.viewmodels.declarative.properties.VMDSpanStyleResourceTransform
 import com.mirego.trikot.viewmodels.declarative.properties.VMDTextStyleResource
 
+@Composable
 fun VMDTextStyleResource.textStyle(): TextStyle? =
     TrikotViewModelDeclarative.textStyleProvider.textStyleForResource(this)
 
+@Composable
 fun VMDTextViewModel.toAnnotatedString() = buildAnnotatedString {
     append(text)
     spans.forEach { addSpanStyle(it) }
 }
 
+@Composable
 private fun AnnotatedString.Builder.addSpanStyle(spanStyle: VMDRichTextSpan) {
     spanStyle.toComposeSpanStyle()?.let {
         addStyle(
@@ -28,6 +32,7 @@ private fun AnnotatedString.Builder.addSpanStyle(spanStyle: VMDRichTextSpan) {
     }
 }
 
+@Composable
 private fun VMDRichTextSpan.toComposeSpanStyle(): SpanStyle? =
     when (val currentTransform = transform) {
         is VMDSpanStyleResourceTransform -> currentTransform.textStyleResource.textStyle()?.toSpanStyle()

--- a/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDTextStyleProvider.kt
+++ b/trikot-viewmodels-declarative-flow/compose-flow/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/configuration/VMDTextStyleProvider.kt
@@ -1,12 +1,15 @@
 package com.mirego.trikot.viewmodels.declarative.configuration
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.TextStyle
 import com.mirego.trikot.viewmodels.declarative.properties.VMDTextStyleResource
 
 interface VMDTextStyleProvider {
+    @Composable
     fun textStyleForResource(resource: VMDTextStyleResource): TextStyle?
 }
 
 class DefaultTextStyleProvider : VMDTextStyleProvider {
+    @Composable
     override fun textStyleForResource(resource: VMDTextStyleResource): TextStyle? = null
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/resource/SampleTextStyleProvider.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/resource/SampleTextStyleProvider.kt
@@ -1,5 +1,6 @@
 package com.mirego.sample.resource
 
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
@@ -20,6 +21,6 @@ class SampleTextStyleProvider : VMDTextStyleProvider {
     @Composable
     private fun mapSampleStyleResource(resource: SampleTextStyleResource): TextStyle =
         when (resource) {
-            SampleTextStyleResource.HIGHLIGHTED -> TextStyle(background = Color.Yellow)
+            SampleTextStyleResource.HIGHLIGHTED -> TextStyle(background = Color.Yellow, color = LocalContentColor.current)
         }
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/resource/SampleTextStyleProvider.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/resource/SampleTextStyleProvider.kt
@@ -1,5 +1,6 @@
 package com.mirego.sample.resource
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import com.mirego.sample.resources.SampleTextStyleResource
@@ -8,6 +9,7 @@ import com.mirego.trikot.viewmodels.declarative.properties.VMDNoTextStyleResourc
 import com.mirego.trikot.viewmodels.declarative.properties.VMDTextStyleResource
 
 class SampleTextStyleProvider : VMDTextStyleProvider {
+    @Composable
     override fun textStyleForResource(resource: VMDTextStyleResource): TextStyle? =
         when (resource) {
             is VMDNoTextStyleResource -> null
@@ -15,9 +17,9 @@ class SampleTextStyleProvider : VMDTextStyleProvider {
             else -> null
         }
 
-    private fun mapSampleStyleResource(resource: VMDTextStyleResource): TextStyle? =
+    @Composable
+    private fun mapSampleStyleResource(resource: SampleTextStyleResource): TextStyle =
         when (resource) {
             SampleTextStyleResource.HIGHLIGHTED -> TextStyle(background = Color.Yellow)
-            else -> null
         }
 }


### PR DESCRIPTION
Allow the VMDTextStyleProvider to call Composable functions. This will allow the TextStyle to use colours that change depending on the app theme.


## Description
Make VMDTextStyleProvider functions Composable so we're able to call Composable functions.


## Motivation and Context
The current implementation only allows a `TextStyle` to use static colours. In the Sports (TSN/RDS) app, we want the styles to use colours that change depending on the app theme (like use a light font colour if the app is in dark theme or vice-versa)


## How Has This Been Tested?
I made the `SampleTextStyleProvider` in the sample app use `LocalContentColor.current` (which is a Composable) when building the `TextStyle` for  `SampleTextStyleResource.HIGHLIGHTED`.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
