### PR TITLE
[Kword] Generated dir error

### DIFF
--- a/trikot-kword/kword-plugin/src/main/kotlin/com.mirego.kword/KWordEnumGenerate.kt
+++ b/trikot-kword/kword-plugin/src/main/kotlin/com.mirego.kword/KWordEnumGenerate.kt
@@ -14,8 +14,8 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.util.Locale
@@ -28,7 +28,7 @@ abstract class KWordEnumGenerate : DefaultTask() {
     @get:Input
     abstract val enumClassName: Property<String>
 
-    @get:InputDirectory
+    @get:OutputDirectory
     abstract val generatedDir: DirectoryProperty
 
     @get:OutputFile


### PR DESCRIPTION
## Description
Fix issue with kword directory which should have been marked as output directory instead of input.

## Motivation and Context
Fixes this error when the directory does not exist
```
> Task :app:shared:kwordGenerateEnum FAILED

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':app:shared:kwordGenerateEnum' (type 'KWordEnumGenerate').
  - In plugin 'mirego.kword' type 'com.mirego.kword.KWordEnumGenerate' property 'generatedDir' specifies directory 'generated' which doesn't exist.
    
    Reason: An input file was expected to be present but it doesn't exist.
    
    Possible solutions:
      1. Make sure the directory exists before the task is called.
      2. Make sure that the task which produces the directory is declared as an input.
    
    For more information, please refer to https://docs.gradle.org/8.8/userguide/validation_problems.html#input_file_does_not_exist in the Gradle documentation.

```
## How Has This Been Tested?
Tested in sample, by removing the directory manually.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
