### PR TITLE
Add deployment target for iOS and macOS in podspec

### DIFF
--- a/Trikot.podspec
+++ b/Trikot.podspec
@@ -16,6 +16,9 @@ Pod::Spec.new do |spec|
 
   spec.dependency ENV['TRIKOT_FRAMEWORK_NAME']
 
+  spec.ios.deployment_target = '10.0'
+  spec.osx.deployment_target = '10.9'
+
   # Streams
   spec.subspec 'streams' do |subspec|
     subspec.source_files  = "trikot-streams/swift-extensions/*.swift"

--- a/Trikot.podspec
+++ b/Trikot.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |spec|
   spec.dependency ENV['TRIKOT_FRAMEWORK_NAME']
 
   spec.ios.deployment_target = '10.0'
+  spec.tvos.deployment_target = '10.0'
   spec.osx.deployment_target = '10.9'
 
   # Streams


### PR DESCRIPTION
## Description

Added deployment target for macOS (OS X). I still needed to add a deployment target for iOS in the main spec, not sure if it's the right way to do it since some subspec has one.

## Motivation and Context

Need macOS target support for the Pod.

## How Has This Been Tested?

It has been tested in an Xcode project with an iOS and a macOS target with a Podfile as this:

```ruby
require_relative 'podspec_versions.rb'

ENV['TRIKOT_FRAMEWORK_NAME']='Shared'

target 'AppForiOS' do
  use_frameworks!
  platform :ios, '15.0'
  trikotVersion = properties['versions']['trikot']
  pod 'Trikot/kword', :path => '../../trikot', :inhibit_warnings => true
end

target 'AppForMac' do
  use_frameworks!
  platform :macos, '12.0'
  trikotVersion = properties['versions']['trikot']
  pod 'Trikot/kword', :path => '../../trikot', :inhibit_warnings => true
end
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
