### PR TITLE
Fix thread safety problem surfaced when used in heavy multithreaded usage in a flow interop scenario

### DIFF
--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/processors/CombineLatestProcessor.kt
@@ -32,13 +32,17 @@ internal class CombineLatestProcessor<T>(
 
         override fun onSubscribe(s: Subscription) {
             super.onSubscribe(s)
-            subscribeToCombinedPublishersIfNeeded()
+            serialQueue.dispatch {
+                subscribeToCombinedPublishersIfNeeded()
+            }
         }
 
         override fun onCancel(s: Subscription) {
             super.onCancel(s)
-            cancellableManagerProvider.cancel()
-            hasSubscribed.compareAndSet(true, false)
+            serialQueue.dispatch {
+                cancellableManagerProvider.cancel()
+                hasSubscribed.compareAndSet(true, false)
+            }
         }
 
         override fun onNext(t: T, subscriber: Subscriber<in List<T?>>) {

--- a/trikot-viewmodels-declarative-flow/sample/common/build.gradle.kts
+++ b/trikot-viewmodels-declarative-flow/sample/common/build.gradle.kts
@@ -83,7 +83,7 @@ android {
 
 project.afterEvaluate {
     tasks
-        .filter { task -> task.name.startsWith("compile") && task.name.contains("Kotlin") }
+        .filter { task -> (task.name.startsWith("compile") && task.name.contains("Kotlin"))  || task.name.contains("KtlintCheckOver") }
         .forEach { task ->
             task.dependsOn(tasks.withType<com.mirego.kword.KWordEnumGenerate>())
         }

--- a/trikot-viewmodels-declarative-flow/sample/common/build.gradle.kts
+++ b/trikot-viewmodels-declarative-flow/sample/common/build.gradle.kts
@@ -83,7 +83,7 @@ android {
 
 project.afterEvaluate {
     tasks
-        .filter { task -> (task.name.startsWith("compile") && task.name.contains("Kotlin"))  || task.name.contains("KtlintCheckOver") }
+        .filter { task -> (task.name.startsWith("compile") && task.name.contains("Kotlin")) || task.name.contains("KtlintCheckOver") }
         .forEach { task ->
             task.dependsOn(tasks.withType<com.mirego.kword.KWordEnumGenerate>())
         }

--- a/trikot-viewmodels-declarative/sample/common/build.gradle.kts
+++ b/trikot-viewmodels-declarative/sample/common/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+
 plugins {
     id("com.android.library")
     kotlin("multiplatform")
@@ -85,6 +87,7 @@ android {
 }
 
 project.afterEvaluate {
+    tasks.named("runKtlintCheckOverCommonMainSourceSet").dependsOn("kwordGenerateEnum")
     tasks
         .filter { task -> task.name.startsWith("compile") && task.name.contains("Kotlin") }
         .forEach { task ->

--- a/trikot-viewmodels-declarative/sample/common/build.gradle.kts
+++ b/trikot-viewmodels-declarative/sample/common/build.gradle.kts
@@ -87,9 +87,8 @@ android {
 }
 
 project.afterEvaluate {
-    tasks.named("runKtlintCheckOverCommonMainSourceSet").dependsOn("kwordGenerateEnum")
     tasks
-        .filter { task -> task.name.startsWith("compile") && task.name.contains("Kotlin") }
+        .filter { task -> (task.name.startsWith("compile") && task.name.contains("Kotlin")) || task.name.contains("KtlintCheckOver") }
         .forEach { task ->
             task.dependsOn(tasks.withType<com.mirego.kword.KWordEnumGenerate>())
         }


### PR DESCRIPTION
## Description

Make sure cancel and subscribe is also done on the queue. When used in conjunction with `Kotlinx.Flow` where cancellation is way more common, we ended up occasionally crashing in the CombineLatestProcessor with indexOfBounds errors in the publisherValues list

## Motivation and Context
Example callstack:
```
 Caused by java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
       at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
       at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
       at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
       at java.util.Objects.checkIndex(Objects.java:359)
       at java.util.ArrayList.get(ArrayList.java:434)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription.updatePublisherResultValue(CombineLatestProcessor.kt:67)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription.doOnNext(CombineLatestProcessor.kt:52)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription.access$doOnNext(CombineLatestProcessor.kt)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription$onNext$1.invoke(CombineLatestProcessor.kt:46)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription$onNext$1.invoke(CombineLatestProcessor.kt:45)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousDispatchQueue.dispatch(SynchronousDispatchQueue.kt:7)
       at com.mirego.trikot.foundation.concurrent.dispatchQueue.SequentialDispatchQueue.dispatch(SequentialDispatchQueue.kt:20)
       at com.mirego.trikot.streams.reactive.processors.CombineLatestProcessor$CombineProcessorProcessorSubscription.onNext(CombineLatestProcessor.kt:45)
       at com.mirego.trikot.streams.reactive.processors.ProcessorSubscription.onNext(ProcessorSubscription.kt:21)
       at kotlinx.coroutines.reactive.FlowSubscription$consumeFlow$2.emit(ReactiveFlow.kt:235)
       at kotlinx.coroutines.flow.FlowKt__ChannelsKt.emitAllImpl$FlowKt__ChannelsKt(Channels.kt:37)
       at kotlinx.coroutines.flow.FlowKt__ChannelsKt.access$emitAllImpl$FlowKt__ChannelsKt(Channels.kt)
       at kotlinx.coroutines.flow.FlowKt__ChannelsKt$emitAllImpl$1.invokeSuspend(Channels.kt:11)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
```

## How Has This Been Tested?

Validated in our app where we have the complexe Flow and Publisher interaction

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)