### PR TITLE
Add cleanCancelledChildren on CancellableManager

### DIFF
--- a/trikot-streams/streams/api/android/streams.api
+++ b/trikot-streams/streams/api/android/streams.api
@@ -23,17 +23,24 @@ public abstract interface class com/mirego/trikot/streams/cancellable/Cancellabl
 	public abstract fun cancel ()V
 }
 
-public final class com/mirego/trikot/streams/cancellable/CancellableManager : com/mirego/trikot/streams/cancellable/Cancellable {
+public final class com/mirego/trikot/streams/cancellable/CancellableManager : com/mirego/trikot/streams/cancellable/Cancellable, com/mirego/trikot/streams/cancellable/VerifiableCancelledState {
 	public fun <init> ()V
 	public final fun add (Lcom/mirego/trikot/streams/cancellable/Cancellable;)Lcom/mirego/trikot/streams/cancellable/Cancellable;
 	public final fun add (Lkotlin/jvm/functions/Function0;)V
 	public fun cancel ()V
+	public final fun cleanCancelledChildren ()V
+	public fun isCancelled ()Z
 }
 
-public final class com/mirego/trikot/streams/cancellable/CancellableManagerProvider : com/mirego/trikot/streams/cancellable/Cancellable {
+public final class com/mirego/trikot/streams/cancellable/CancellableManagerProvider : com/mirego/trikot/streams/cancellable/Cancellable, com/mirego/trikot/streams/cancellable/VerifiableCancelledState {
 	public fun <init> ()V
 	public fun cancel ()V
 	public final fun cancelPreviousAndCreate ()Lcom/mirego/trikot/streams/cancellable/CancellableManager;
+	public fun isCancelled ()Z
+}
+
+public abstract interface class com/mirego/trikot/streams/cancellable/VerifiableCancelledState {
+	public abstract fun isCancelled ()Z
 }
 
 public final class com/mirego/trikot/streams/reactive/AndroidPublisherExtensionsKt {

--- a/trikot-streams/streams/api/jvm/streams.api
+++ b/trikot-streams/streams/api/jvm/streams.api
@@ -23,17 +23,24 @@ public abstract interface class com/mirego/trikot/streams/cancellable/Cancellabl
 	public abstract fun cancel ()V
 }
 
-public final class com/mirego/trikot/streams/cancellable/CancellableManager : com/mirego/trikot/streams/cancellable/Cancellable {
+public final class com/mirego/trikot/streams/cancellable/CancellableManager : com/mirego/trikot/streams/cancellable/Cancellable, com/mirego/trikot/streams/cancellable/VerifiableCancelledState {
 	public fun <init> ()V
 	public final fun add (Lcom/mirego/trikot/streams/cancellable/Cancellable;)Lcom/mirego/trikot/streams/cancellable/Cancellable;
 	public final fun add (Lkotlin/jvm/functions/Function0;)V
 	public fun cancel ()V
+	public final fun cleanCancelledChildren ()V
+	public fun isCancelled ()Z
 }
 
-public final class com/mirego/trikot/streams/cancellable/CancellableManagerProvider : com/mirego/trikot/streams/cancellable/Cancellable {
+public final class com/mirego/trikot/streams/cancellable/CancellableManagerProvider : com/mirego/trikot/streams/cancellable/Cancellable, com/mirego/trikot/streams/cancellable/VerifiableCancelledState {
 	public fun <init> ()V
 	public fun cancel ()V
 	public final fun cancelPreviousAndCreate ()Lcom/mirego/trikot/streams/cancellable/CancellableManager;
+	public fun isCancelled ()Z
+}
+
+public abstract interface class com/mirego/trikot/streams/cancellable/VerifiableCancelledState {
+	public abstract fun isCancelled ()Z
 }
 
 public abstract interface class com/mirego/trikot/streams/reactive/BehaviorSubject : com/mirego/trikot/streams/reactive/MutablePublisher {

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
@@ -1,18 +1,20 @@
 package com.mirego.trikot.streams.cancellable
 
 import com.mirego.trikot.foundation.concurrent.AtomicListReference
-import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.SynchronousSerialQueue
+import kotlinx.atomicfu.atomic
 
-class CancellableManager : Cancellable {
+class CancellableManager : Cancellable, VerifiableCancelledState {
     private val serialQueue = SynchronousSerialQueue()
     private val queueList = AtomicListReference<Cancellable>()
-    private val isCancelled = AtomicReference(false)
+
+    private var isCancelledDelegate = atomic(false)
+    override var isCancelled: Boolean by isCancelledDelegate
 
     fun <T : Cancellable> add(cancellable: T): T {
         queueList.add(cancellable)
 
-        if (isCancelled.value) {
+        if (isCancelled) {
             doCancelAll()
         }
         return cancellable
@@ -28,8 +30,22 @@ class CancellableManager : Cancellable {
         )
     }
 
+    fun cleanCancelledChildren() {
+        serialQueue.dispatch {
+            val value = queueList.value
+            val alreadyCancelledList = value.filter {
+                when (it) {
+                    is VerifiableCancelledState -> it.isCancelled
+                    else -> false
+                }
+            }
+
+            queueList.removeAll(alreadyCancelledList)
+        }
+    }
+
     override fun cancel() {
-        if (isCancelled.compareAndSet(isCancelled.value, true)) {
+        if (isCancelledDelegate.compareAndSet(isCancelledDelegate.value, true)) {
             doCancelAll()
         }
     }

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/CancellableManager.kt
@@ -9,7 +9,7 @@ class CancellableManager : Cancellable, VerifiableCancelledState {
     private val queueList = AtomicListReference<Cancellable>()
 
     private var isCancelledDelegate = atomic(false)
-    override var isCancelled: Boolean by isCancelledDelegate
+    override val isCancelled: Boolean by isCancelledDelegate
 
     fun <T : Cancellable> add(cancellable: T): T {
         queueList.add(cancellable)

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/VerifiableCancelledState.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/cancellable/VerifiableCancelledState.kt
@@ -1,0 +1,5 @@
+package com.mirego.trikot.streams.cancellable
+
+interface VerifiableCancelledState {
+    val isCancelled: Boolean
+}

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
@@ -39,6 +39,9 @@ class Promise<T> internal constructor(
         }
     }
 
+    private val isParentCancellableCancelled: Boolean
+        get() = onParentCancellation.isCancelled
+
     /**
      * When a result is received, we want to make sure we're considered as "cancelled" by the provided cancellableManager if any.
      * This allows to use `CancellableManager::cleanCancelledChildren` with promises to clean up finished promises
@@ -60,7 +63,7 @@ class Promise<T> internal constructor(
             .subscribe(
                 internalCancellableManager,
                 onNext = { value ->
-                    if (!onParentCancellation.isCancelled) {
+                    if (!isParentCancellableCancelled) {
                         result.value = value
                         result.complete()
 
@@ -68,14 +71,14 @@ class Promise<T> internal constructor(
                     }
                 },
                 onError = { error ->
-                    if (!onParentCancellation.isCancelled) {
+                    if (!isParentCancellableCancelled) {
                         result.error = error
 
                         onResultReceived()
                     }
                 },
                 onCompleted = {
-                    if (!onParentCancellation.isCancelled) {
+                    if (!isParentCancellableCancelled) {
                         if (result.value == null && result.error == null) {
                             result.error = EmptyPromiseException
                         }

--- a/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
+++ b/trikot-streams/streams/src/commonMain/kotlin/com/mirego/trikot/streams/reactive/promise/Promise.kt
@@ -49,7 +49,7 @@ class Promise<T> internal constructor(
      *
      * We don't want the `onParentCancellation::cancel()` to run since the provided cancellableManager was not cancelled,
      * so we don't call `cancel()` directly, but instead modify the `isCancelled` value manually.
-      */
+     */
     private fun onResultReceived() {
         onParentCancellation.isCancelled = true
         internalCancellableManager.cancel()

--- a/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerTests.kt
+++ b/trikot-streams/streams/src/commonTest/kotlin/com/mirego/trikot/streams/cancellable/CancellableManagerTests.kt
@@ -1,6 +1,8 @@
 package com.mirego.trikot.streams.cancellable
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CancellableManagerTests {
@@ -22,5 +24,95 @@ class CancellableManagerTests {
         cancellableManager.add { cancelled = true }
 
         assertTrue { cancelled }
+    }
+
+    @Test
+    fun ifCleanCancelledChildrenIsNotCalled_thenAllChildAreCalledOnParentCancellation() {
+        val parentCancellableManager = CancellableManager()
+        val childList = mutableListOf<TestableCancellable>()
+        var cancelCounter = 0
+
+        for (i in 1..3) {
+            val cancellableManager = TestableCancellable(
+                onCancelCalled = { cancelCounter++ }
+            )
+
+            childList.add(cancellableManager)
+            parentCancellableManager.add(cancellableManager)
+        }
+
+        // We have 3 cancellable children
+        assertEquals(3, childList.size)
+
+        // Cancel first 2 children
+        childList[0].cancel()
+        childList[1].cancel()
+
+        assertEquals(2, cancelCounter)
+
+        parentCancellableManager.cancel()
+
+        // All 3 children are called, so 5 total calls
+        assertEquals(5, cancelCounter)
+    }
+
+    @Test
+    fun ifCleanCancelledChildrenIsCalled_thenOnlyCancelRemainingChildOnParentCancellation() {
+        val parentCancellableManager = CancellableManager()
+        val childList = mutableListOf<TestableCancellable>()
+        var cancelCounter = 0
+
+        for (i in 1..3) {
+            val cancellableManager = TestableCancellable(
+                onCancelCalled = { cancelCounter++ }
+            )
+
+            childList.add(cancellableManager)
+            parentCancellableManager.add(cancellableManager)
+        }
+
+        // We have 3 cancellable children
+        assertEquals(3, childList.size)
+
+        var expectedCancelCalls = 0
+        assertEquals(expectedCancelCalls, cancelCounter)
+
+        // Cancel first 2 children
+        childList[0].cancel()
+        childList[1].cancel()
+
+        expectedCancelCalls += 2
+        assertEquals(2, cancelCounter)
+        assertTrue(childList[0].isCancelled)
+        assertTrue(childList[1].isCancelled)
+        assertFalse(childList[2].isCancelled)
+
+        parentCancellableManager.cleanCancelledChildren()
+
+        // Nothing has changed
+        assertEquals(expectedCancelCalls, cancelCounter)
+        assertTrue(childList[0].isCancelled)
+        assertTrue(childList[1].isCancelled)
+        assertFalse(childList[2].isCancelled)
+
+        parentCancellableManager.cancel()
+
+        // Only 1 child is called on parent cancellation since the other 2 have been cleaned
+        expectedCancelCalls++
+        assertEquals(expectedCancelCalls, cancelCounter)
+        assertTrue(childList[0].isCancelled)
+        assertTrue(childList[1].isCancelled)
+        assertTrue(childList[2].isCancelled)
+    }
+
+    private class TestableCancellable(
+        private val onCancelCalled: (() -> Unit)? = null
+    ) : Cancellable, VerifiableCancelledState {
+        override var isCancelled = false
+
+        override fun cancel() {
+            isCancelled = true
+            onCancelCalled?.invoke()
+        }
     }
 }


### PR DESCRIPTION
## Description

Introduce the possibility to clean `Cancellable`s that have already been cancelled in a `CancellableManager`.

## Motivation and Context

It's possible to have a global `CancellableManager` that accumulates a huge number of child `Cancellable` during the lifecycle of an app. When we cancel the massive list of `Cancellable`, it can be very performance heavy and can freeze on some lower-end devices.

We can now manually clean up the `queueList` of a `CancellableManager` by choosing the right moment to do it.

I also wanted to make sure that it could support Promises. Previously, a finished** Promise was still kept in the `queueList` until the provided `CancellableManager` was cancelled. (I like to call it the parent CancellableManager)
Now, a Promise that has received a result is considered "cancelled" and ready to be cleaned.

> ** a promise is finished after `onNext`, `onError` or `onCompleted`.

For a `Cancellable` to be cleaned in the `queueList`, the new interface 
```
interface VerifiableCancelledState {
    val isCancelled: Boolean
}
```
 must be implemented.

`CancellableManager` and `CancellableManagerProvider` already implement `VerifiableCancelledState`, but the interface is public in order to be implemented with your custom Cancellable classes. 

## How Has This Been Tested?

It has been tested in a client app.

We can see a big difference in execution time by cleaning periodically our big `CancellableManager` ahead of time. 
The difference is particularly noticeable on lower-end devices like old Android TVs.

```
public fun doTest() {
    val parentCancellableManager = CancellableManager()

    val cancellableList = AtomicListReference<CancellableManager>()

    for (i in 1..5000) {
        val cancellableManager = CancellableManager()
        parentCancellableManager.add(cancellableManager)

        cancellableList.add(cancellableManager)
    }

    cancellableList.value.forEach {
        it.cancel()
    }

    // In a real life scenario, cleaning should not be done right before cancelling the parent CancellableManager.
    // It's up to the application to determine the right timing to optimize the performance.
    parentCancellableManager.cleanCancelledChildren()

    val elapsed = measureTime {
        parentCancellableManager.cancel()
    }

    println("Time elapsed: ${elapsed.inWholeMilliseconds} milliseconds")
}
```


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
