### PR TITLE
Support multiple translation files with kword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Breaking Changes
 
 - [kword] Gradle plugin DSL changed. All properties are now lazy.
+  `translationFile` was replaced with `translationFiles` to support multiple translation files.
+
   Instead of
 
 ```kotlin
@@ -20,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Do this
 
 ```kotlin
-  translationFile.set(file("src/commonMain/resources/translations/translation.en.json"))
+  translationFiles.setFrom(file("src/commonMain/resources/translations/translation.en.json"))
   enumClassName.set("com.mirego.sample.KWordTranslation")
   generatedDir.set(file("src/commonMain/generated"))
 ```

--- a/trikot-kword/kword-plugin/api/kword-plugin.api
+++ b/trikot-kword/kword-plugin/api/kword-plugin.api
@@ -16,7 +16,6 @@ public abstract class com/mirego/kword/KWordExtension {
 	public fun <init> ()V
 	public abstract fun getEnumClassName ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGeneratedDir ()Lorg/gradle/api/file/DirectoryProperty;
-	public abstract fun getTranslationFile ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getTranslationFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 

--- a/trikot-kword/kword-plugin/src/main/kotlin/com.mirego.kword/KWordExtension.kt
+++ b/trikot-kword/kword-plugin/src/main/kotlin/com.mirego.kword/KWordExtension.kt
@@ -2,12 +2,9 @@ package com.mirego.kword
 
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 
 abstract class KWordExtension {
-    abstract val translationFile: RegularFileProperty
-
     abstract val translationFiles: ConfigurableFileCollection
 
     abstract val enumClassName: Property<String>

--- a/trikot-kword/kword-plugin/src/main/kotlin/com.mirego.kword/KWordPlugin.kt
+++ b/trikot-kword/kword-plugin/src/main/kotlin/com.mirego.kword/KWordPlugin.kt
@@ -15,9 +15,7 @@ class KWordPlugin : Plugin<Project> {
             it.group = TASKS_GROUP
             it.description = "Generate keys enum based on json translation file."
             it.enumClassName.set(extension.enumClassName)
-            it.translationFiles.setFrom(
-                extension.translationFiles + extension.translationFile
-            )
+            it.translationFiles.setFrom(extension.translationFiles)
             it.generatedDir.set(extension.generatedDir)
         }
     }


### PR DESCRIPTION
## Description

The property `translationFile` was replaced with `translationFiles` to support multiple translation files.

  Instead of

```kotlin
  translationFile = file("src/commonMain/resources/translations/translation.en.json")
  enumClassName = "com.mirego.sample.KWordTranslation"
  generatedDir = file("src/commonMain/generated")
```
Do this

```kotlin
  translationFiles.setFrom(file("src/commonMain/resources/translations/translation.en.json"))
  enumClassName.set("com.mirego.sample.KWordTranslation")
  generatedDir.set(file("src/commonMain/generated"))
```

## 🗒 Notes
`translationFiles` was already available in `KWordExtension`, but it was not possible to only set `translationFiles` without 
 any `translationFile`. This error was returned on keys generation :
```
Cannot query the value of extension 'kword' property 'translationFile' because it has no value available.
```

This issue highlighted the fact that we should simply have a `ConfigurableFileCollection`, and the list will contains one element if you only have one translation file.

## How Has This Been Tested?

With kword sample app

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
