### PR TITLE
Fix file dependency declaration in viewmodels-declarative-compiler-core

### DIFF
--- a/trikot-viewmodels-declarative-compiler/viewmodels-declarative-compiler-core/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compiler/BaseVMDCodeGenerator.kt
+++ b/trikot-viewmodels-declarative-compiler/viewmodels-declarative-compiler-core/src/main/kotlin/com/mirego/trikot/viewmodels/declarative/compiler/BaseVMDCodeGenerator.kt
@@ -94,10 +94,20 @@ abstract class BaseVMDCodeGenerator(
         logger.logging("Creating file:")
         logger.logging("     packageName: $packageName")
         logger.logging("     className: $className")
-
+        val viewModelFile = viewModelMetaData.viewModelInterface.containingFile
+        val dependencies = if (viewModelFile != null) {
+            Dependencies(
+                false,
+                viewModelFile
+            )
+        } else {
+            Dependencies(
+                false,
+            )
+        }
         OutputStreamWriter(
             codeGenerator.createNewFile(
-                dependencies = Dependencies(false),
+                dependencies = dependencies,
                 packageName = packageName,
                 fileName = className
             ),


### PR DESCRIPTION
Fix file dependency declaration in viewmodels-declarative-compiler-core

## Description

In `BaseVMDCodeGenerator`,` codeGenerator.createNewFile()` is called without declaring any dependency. 
However, any generated ViewModel has at least one dependency to declare to allow KSP incremental build to work properly. 

## Motivation and Context
We had build issue on CI after migrating from Kotlin 2.0 to Kotlin 2.2. 
After investigation, I found that KSP cache was behaving strangely and that almost none of the Impl classes were present in `generated/ksp/metadata`. 
With this fix, classes seems to be generated as expected.


## How Has This Been Tested?

Not enough, just make the build on CI pass. How do you intend to test this KSP plugin? 
AFAIK there is no sample project for it. 

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
