### PR TITLE
[VMD] Support edge to edge + switch to m3 in samples

### DIFF
--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/BaseSampleActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/BaseSampleActivity.kt
@@ -1,0 +1,18 @@
+package com.mirego.sample.ui
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import com.mirego.trikot.viewmodels.declarative.controller.VMDNavigationDelegate
+import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
+import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
+import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModel
+
+abstract class BaseSampleActivity<VMC : VMDViewModelController<VM, N>, VM : VMDViewModel, N : VMDNavigationDelegate> :
+    ViewModelActivity<VMC, VM, N>() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
+    }
+}

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/home/HomeActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/home/HomeActivity.kt
@@ -2,6 +2,7 @@ package com.mirego.sample.ui.home
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.ui.showcase.animation.types.AnimationTypesShowcaseActivity
 import com.mirego.sample.ui.showcase.components.button.ButtonShowcaseActivity
 import com.mirego.sample.ui.showcase.components.image.ImageShowcaseActivity
@@ -15,9 +16,8 @@ import com.mirego.sample.ui.showcase.components.toggle.ToggleShowcaseActivity
 import com.mirego.sample.viewmodels.home.HomeNavigationDelegate
 import com.mirego.sample.viewmodels.home.HomeViewModel
 import com.mirego.sample.viewmodels.home.HomeViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class HomeActivity : ViewModelActivity<HomeViewModelController, HomeViewModel, HomeNavigationDelegate>(), HomeNavigationDelegate {
+class HomeActivity : BaseSampleActivity<HomeViewModelController, HomeViewModel, HomeNavigationDelegate>(), HomeNavigationDelegate {
 
     override val viewModelController: HomeViewModelController by lazy {
         getViewModelController(HomeViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/home/HomeView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/home/HomeView.kt
@@ -1,14 +1,15 @@
 package com.mirego.sample.ui.home
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Divider
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.DividerDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -27,10 +28,14 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDText
 fun HomeView(homeViewModel: HomeViewModel) {
     val viewModel: HomeViewModel by homeViewModel.observeAsState()
 
-    Column(modifier = Modifier.fillMaxWidth()) {
-        TopAppBar(title = { Text(text = viewModel.title) })
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            TopAppBar(title = { Text(text = viewModel.title) })
+        }
+    ) { paddingValues ->
 
-        VMDSectionedList(viewModel = viewModel.sections) { sections ->
+        VMDSectionedList(viewModel = viewModel.sections, modifier = Modifier.padding(paddingValues)) { sections ->
             sections.forEach { section ->
                 stickyHeader {
                     VMDText(
@@ -38,7 +43,7 @@ fun HomeView(homeViewModel: HomeViewModel) {
                         viewModel = section.title,
                         fontSize = 22.sp
                     )
-                    Divider(color = Color.LightGray)
+                    HorizontalDivider(Modifier, DividerDefaults.Thickness, color = Color.LightGray)
                 }
 
                 items(section.elements, key = { item -> item.identifier }) { element ->
@@ -57,7 +62,7 @@ fun HomeView(homeViewModel: HomeViewModel) {
                             )
                         }
                     )
-                    Divider(color = Color.LightGray)
+                    HorizontalDivider(color = Color.LightGray)
                 }
             }
         }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/ComponentShowcaseTopBar.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/ComponentShowcaseTopBar.kt
@@ -1,6 +1,6 @@
 package com.mirego.sample.ui.showcase
 
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import com.mirego.sample.viewmodels.showcase.ShowcaseViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.LocalImage

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseActivity.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
 class AnimationTypesShowcaseActivity :
-    ViewModelActivity<AnimationTypesShowcaseViewModelController, AnimationTypesShowcaseViewModel, AnimationTypesShowcaseNavigationDelegate>(), AnimationTypesShowcaseNavigationDelegate {
+    BaseSampleActivity<AnimationTypesShowcaseViewModelController, AnimationTypesShowcaseViewModel, AnimationTypesShowcaseNavigationDelegate>(), AnimationTypesShowcaseNavigationDelegate {
 
     override val viewModelController: AnimationTypesShowcaseViewModelController by lazy {
         getViewModelController(AnimationTypesShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
@@ -13,8 +13,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
@@ -58,19 +59,26 @@ private fun animateHorizontalAlignmentAsState(
 fun AnimationTypesShowcaseView(animationTypesShowcaseViewModel: AnimationTypesShowcaseViewModel) {
     val viewModel: AnimationTypesShowcaseViewModel by animationTypesShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
-        AnimationSection(viewModel.linear)
-        AnimationSection(viewModel.easeIn)
-        AnimationSection(viewModel.easeOut)
-        AnimationSection(viewModel.easeInEaseOut)
-        AnimationSection(viewModel.cubicBezier)
-        AnimationSection(viewModel.spring)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
+        ) {
+            AnimationSection(viewModel.linear)
+            AnimationSection(viewModel.easeIn)
+            AnimationSection(viewModel.easeOut)
+            AnimationSection(viewModel.easeInEaseOut)
+            AnimationSection(viewModel.cubicBezier)
+            AnimationSection(viewModel.spring)
+        }
     }
 }
 
@@ -104,11 +112,11 @@ private fun AnimationSection(animationTypeViewModel: AnimationTypeShowcaseViewMo
             ) { content ->
                 Text(
                     modifier = Modifier
-                        .background(MaterialTheme.colors.background, shape = RoundedCornerShape(6.dp))
+                        .background(MaterialTheme.colorScheme.background, shape = RoundedCornerShape(6.dp))
                         .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                     text = content.text,
                     style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
+                    color = MaterialTheme.colorScheme.primary
                 )
             }
         }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseActivity.kt
@@ -5,12 +5,12 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ButtonShowcaseActivity : ViewModelActivity<ButtonShowcaseViewModelController, ButtonShowcaseViewModel, ButtonShowcaseNavigationDelegate>(), ButtonShowcaseNavigationDelegate {
+class ButtonShowcaseActivity : BaseSampleActivity<ButtonShowcaseViewModelController, ButtonShowcaseViewModel, ButtonShowcaseNavigationDelegate>(), ButtonShowcaseNavigationDelegate {
 
     override val viewModelController: ButtonShowcaseViewModelController by lazy {
         getViewModelController(ButtonShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
@@ -12,8 +12,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -42,163 +43,170 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDB
 fun ButtonShowcaseView(buttonShowcaseViewModel: ButtonShowcaseViewModel) {
     val viewModel: ButtonShowcaseViewModel by buttonShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
-
-        ComponentShowcaseTitle(viewModel.textButtonTitle)
-
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textButton
-        ) { content ->
-            Text(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                text = content.text,
-                style = SampleTextStyle.body.medium(),
-                color = MaterialTheme.colors.onPrimary
-            )
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
         }
-
-        ComponentShowcaseTitle(viewModel.imageButtonTitle)
-
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.imageButton
-        ) { content ->
-            LocalImage(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(4.dp),
-                imageResource = content.image,
-                contentDescription = content.contentDescription,
-            )
-        }
-
-        ComponentShowcaseTitle(viewModel.textImageButtonTitle)
-
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textImageButton
-        ) { content ->
-            Row(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                LocalImage(
-                    modifier = Modifier.padding(end = 8.dp),
-                    imageResource = content.image,
-                    contentDescription = content.contentDescription,
-                )
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.onPrimary
-                )
-            }
-        }
-
-        ComponentShowcaseTitle(viewModel.textPairButtonTitle)
-
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textPairButton
-        ) { content ->
-            Column(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = content.first,
-                    style = SampleTextStyle.title2,
-                    color = MaterialTheme.colors.onPrimary
-                )
-                Text(
-                    text = content.second,
-                    style = SampleTextStyle.body,
-                    color = MaterialTheme.colors.onPrimary
-                )
-            }
-        }
+    ) { paddingValues ->
 
         Column(
-            Modifier
-                .padding(horizontal = 16.dp)
-                .padding(top = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
         ) {
-            ComponentShowcaseTitle("Material 3 Elevated Button")
+            ComponentShowcaseTitle(viewModel.textButtonTitle)
 
-            VMDElevatedButton(viewModel.textButton) { content ->
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.textButton
+            ) { content ->
                 Text(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                     text = content.text,
                     style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
+                    color = MaterialTheme.colorScheme.onPrimary
                 )
             }
 
-            VMDElevatedButton(viewModel.textImageButton) { content ->
+            ComponentShowcaseTitle(viewModel.imageButtonTitle)
+
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.imageButton
+            ) { content ->
                 LocalImage(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(4.dp),
                     imageResource = content.image,
                     contentDescription = content.contentDescription,
-                    modifier = Modifier.size(18.dp),
-                    colorFilter = ColorFilter.tint(MaterialTheme.colors.primary)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
                 )
             }
 
-            ComponentShowcaseTitle("Material 3 Filled Button")
+            ComponentShowcaseTitle(viewModel.textImageButtonTitle)
 
-            VMDMaterial3Button(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.onPrimary
-                )
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.textImageButton
+            ) { content ->
+                Row(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    LocalImage(
+                        modifier = Modifier.padding(end = 8.dp),
+                        imageResource = content.image,
+                        contentDescription = content.contentDescription,
+                    )
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
             }
 
-            ComponentShowcaseTitle("Material 3 Filled Tonal Button")
+            ComponentShowcaseTitle(viewModel.textPairButtonTitle)
 
-            VMDFilledTonalButton(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.onSecondary
-                )
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.textPairButton
+            ) { content ->
+                Column(
+                    modifier = Modifier
+                        .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = content.first,
+                        style = SampleTextStyle.title2,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                    Text(
+                        text = content.second,
+                        style = SampleTextStyle.body,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
             }
 
-            ComponentShowcaseTitle("Material 3 Filled Outlined Button")
+            Column(
+                Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                ComponentShowcaseTitle("Material 3 Elevated Button")
 
-            VMDOutlinedButton(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
-                )
-            }
+                VMDElevatedButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
 
-            ComponentShowcaseTitle("Material 3 Filled Text Button")
+                VMDElevatedButton(viewModel.textImageButton) { content ->
+                    LocalImage(
+                        imageResource = content.image,
+                        contentDescription = content.contentDescription,
+                        modifier = Modifier.size(18.dp),
+                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
 
-            VMDTextButton(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
-                )
+                ComponentShowcaseTitle("Material 3 Filled Button")
+
+                VMDMaterial3Button(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+
+                ComponentShowcaseTitle("Material 3 Filled Tonal Button")
+
+                VMDFilledTonalButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colorScheme.onSecondary
+                    )
+                }
+
+                ComponentShowcaseTitle("Material 3 Filled Outlined Button")
+
+                VMDOutlinedButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                ComponentShowcaseTitle("Material 3 Filled Text Button")
+
+                VMDTextButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
             }
         }
     }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ImageShowcaseActivity : ViewModelActivity<ImageShowcaseViewModelController, ImageShowcaseViewModel, ImageShowcaseNavigationDelegate>(), ImageShowcaseNavigationDelegate {
+class ImageShowcaseActivity : BaseSampleActivity<ImageShowcaseViewModelController, ImageShowcaseViewModel, ImageShowcaseNavigationDelegate>(), ImageShowcaseNavigationDelegate {
 
     override val viewModelController: ImageShowcaseViewModelController by lazy {
         getViewModelController(ImageShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -11,8 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Text
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -39,171 +40,178 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
     val viewModel: ImageShowcaseViewModel by imageShowcaseViewModel.observeAsState()
     val imageAspectRatio = 1.5f
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
-        ComponentShowcaseTitle(viewModel.localImageTitle)
-
-        VMDImage(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.localImage,
-            contentScale = ContentScale.Crop
-        )
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
+        ) {
+            ComponentShowcaseTitle(viewModel.localImageTitle)
 
-        ComponentShowcaseTitle(viewModel.remoteImageTitle)
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.localImage,
+                contentScale = ContentScale.Crop
+            )
 
-        VMDImage(
-            modifier = Modifier
+            ComponentShowcaseTitle(viewModel.remoteImageTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.remoteImage,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.localImageDescriptorTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp),
+                imageDescriptor = viewModel.localImageDescriptor,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.remoteImageDescriptorTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+                imageDescriptor = viewModel.remoteImageDescriptor,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.placeholderImageTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+                viewModel = viewModel.placeholderImage,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.placeholderNoImageTitle)
+
+            val imageModifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.remoteImage,
-            contentScale = ContentScale.Crop
-        )
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
 
-        ComponentShowcaseTitle(viewModel.localImageDescriptorTitle)
-
-        VMDImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            imageDescriptor = viewModel.localImageDescriptor,
-            contentScale = ContentScale.Crop
-        )
-
-        ComponentShowcaseTitle(viewModel.remoteImageDescriptorTitle)
-
-        VMDImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
-            imageDescriptor = viewModel.remoteImageDescriptor,
-            contentScale = ContentScale.Crop
-        )
-
-        ComponentShowcaseTitle(viewModel.placeholderImageTitle)
-
-        VMDImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
-            viewModel = viewModel.placeholderImage,
-            contentScale = ContentScale.Crop
-        )
-
-        ComponentShowcaseTitle(viewModel.placeholderNoImageTitle)
-
-        val imageModifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(imageAspectRatio)
-            .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
-
-        VMDImage(
-            modifier = imageModifier,
-            viewModel = viewModel.placeholderNoImage,
-            contentScale = ContentScale.Crop,
-            placeholderContentScale = ContentScale.Crop,
-            placeholder = { placeholderImageResource, state ->
-                Column(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .background(Color.LightGray.copy(alpha = 0.5f)),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    LocalImage(
-                        imageResource = placeholderImageResource,
+            VMDImage(
+                modifier = imageModifier,
+                viewModel = viewModel.placeholderNoImage,
+                contentScale = ContentScale.Crop,
+                placeholderContentScale = ContentScale.Crop,
+                placeholder = { placeholderImageResource, state ->
+                    Column(
                         modifier = Modifier
-                            .size(width = (50 * imageAspectRatio).dp, height = 50.dp)
-                            .padding(bottom = 10.dp),
-                        contentScale = ContentScale.Crop
-                    )
+                            .matchParentSize()
+                            .background(Color.LightGray.copy(alpha = 0.5f)),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        LocalImage(
+                            imageResource = placeholderImageResource,
+                            modifier = Modifier
+                                .size(width = (50 * imageAspectRatio).dp, height = 50.dp)
+                                .padding(bottom = 10.dp),
+                            contentScale = ContentScale.Crop
+                        )
 
+                        when (state) {
+                            is AsyncImagePainter.State.Empty -> Text("There is no image to display", style = SampleTextStyle.subheadline)
+                            is AsyncImagePainter.State.Loading -> Text("Loading", style = SampleTextStyle.subheadline)
+                            is AsyncImagePainter.State.Error -> Text("Unable to load the remote image", style = SampleTextStyle.subheadline)
+                            else -> {}
+                        }
+                    }
+                }
+            )
+
+            ComponentShowcaseTitle(viewModel.placeholderInvalidImageTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .aspectRatio(imageAspectRatio),
+                viewModel = viewModel.placeholderInvalidImage,
+                placeholder = { _, state: PlaceholderState ->
                     when (state) {
-                        is AsyncImagePainter.State.Empty -> Text("There is no image to display", style = SampleTextStyle.subheadline)
-                        is AsyncImagePainter.State.Loading -> Text("Loading", style = SampleTextStyle.subheadline)
-                        is AsyncImagePainter.State.Error -> Text("Unable to load the remote image", style = SampleTextStyle.subheadline)
-                        else -> {}
+                        PlaceholderState.LOADING -> Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Color.LightGray)
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                        }
+
+                        PlaceholderState.ERROR -> Box(
+                            modifier = Modifier
+                                .background(Color.LightGray)
+                        ) {
+                            Text(
+                                modifier = Modifier.align(Alignment.Center),
+                                text = "Unable to load the remote image",
+                                style = SampleTextStyle.subheadline,
+                                color = Color.Black
+                            )
+                        }
                     }
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.placeholderInvalidImageTitle)
+            ComponentShowcaseTitle(viewModel.remoteImageTitle)
 
-        VMDImage(
-            modifier = Modifier
-                .padding(16.dp)
-                .aspectRatio(imageAspectRatio),
-            viewModel = viewModel.placeholderInvalidImage,
-            placeholder = { _, state: PlaceholderState ->
-                when (state) {
-                    PlaceholderState.LOADING -> Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(Color.LightGray)
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                    }
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(16.dp),
+                viewModel = viewModel.remoteImage,
+                contentScale = ContentScale.Crop,
+                placeholder = { _, state: PlaceholderState ->
+                    when (state) {
+                        PlaceholderState.LOADING -> Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Color.LightGray)
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                        }
 
-                    PlaceholderState.ERROR -> Box(
-                        modifier = Modifier
-                            .background(Color.LightGray)
-                    ) {
-                        Text(
-                            modifier = Modifier.align(Alignment.Center),
-                            text = "Unable to load the remote image",
-                            style = SampleTextStyle.subheadline,
-                            color = Color.Black
-                        )
-                    }
-                }
-            }
-        )
-
-        ComponentShowcaseTitle(viewModel.remoteImageTitle)
-
-        VMDImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(16.dp),
-            viewModel = viewModel.remoteImage,
-            contentScale = ContentScale.Crop,
-            placeholder = { _, state: PlaceholderState ->
-                when (state) {
-                    PlaceholderState.LOADING -> Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(Color.LightGray)
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                    }
-
-                    PlaceholderState.ERROR -> Box(
-                        modifier = Modifier
-                            .background(Color.LightGray)
-                    ) {
-                        Text(
-                            modifier = Modifier.align(Alignment.Center),
-                            text = "Unable to load the remote image",
-                            style = SampleTextStyle.subheadline,
-                            color = Color.Black
-                        )
+                        PlaceholderState.ERROR -> Box(
+                            modifier = Modifier
+                                .background(Color.LightGray)
+                        ) {
+                            Text(
+                                modifier = Modifier.align(Alignment.Center),
+                                text = "Unable to load the remote image",
+                                style = SampleTextStyle.subheadline,
+                                color = Color.Black
+                            )
+                        }
                     }
                 }
-            }
-        )
+            )
+        }
     }
 }
 

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ListShowcaseActivity : ViewModelActivity<ListShowcaseViewModelController, ListShowcaseViewModel, ListShowcaseNavigationDelegate>(), ListShowcaseNavigationDelegate {
+class ListShowcaseActivity : BaseSampleActivity<ListShowcaseViewModelController, ListShowcaseViewModel, ListShowcaseNavigationDelegate>(), ListShowcaseNavigationDelegate {
 
     override val viewModelController: ListShowcaseViewModelController by lazy {
         getViewModelController(ListShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Divider
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModel
@@ -23,33 +25,41 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDText
 fun ListShowcaseView(listShowcaseViewModel: ListShowcaseViewModel) {
     val viewModel: ListShowcaseViewModel by listShowcaseViewModel.observeAsState()
 
-    Box(
-        Modifier.fillMaxSize()
-    ) {
-        ComponentShowcaseTopBar(viewModel)
-
-        VMDLazyRow(
-            modifier = Modifier.padding(top = 80.dp),
-            viewModel = viewModel.listViewModel,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(16.dp)
-        ) { element ->
-            VMDText(viewModel = element.content)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
         }
+    ) { paddingValues ->
 
-        VMDLazyColumnIndexed(
-            modifier = Modifier
-                .padding(top = 150.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.listViewModel,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(16.dp)
-        ) { index, element ->
-            Column {
-                if (index != 0) {
-                    Divider(modifier = Modifier.padding(bottom = 16.dp))
-                }
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            VMDLazyRow(
+                modifier = Modifier.padding(top = 0.dp),
+                viewModel = viewModel.listViewModel,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(16.dp)
+            ) { element ->
                 VMDText(viewModel = element.content)
+            }
+
+            VMDLazyColumnIndexed(
+                modifier = Modifier
+                    .padding(top = 70.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.listViewModel,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(16.dp)
+            ) { index, element ->
+                Column {
+                    if (index != 0) {
+                        HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp), color = Color.LightGray)
+                    }
+                    VMDText(viewModel = element.content)
+                }
             }
         }
     }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class PickerShowcaseActivity : ViewModelActivity<PickerShowcaseViewModelController, PickerShowcaseViewModel, PickerShowcaseNavigationDelegate>(), PickerShowcaseNavigationDelegate {
+class PickerShowcaseActivity : BaseSampleActivity<PickerShowcaseViewModelController, PickerShowcaseViewModel, PickerShowcaseNavigationDelegate>(), PickerShowcaseNavigationDelegate {
 
     override val viewModelController: PickerShowcaseViewModelController by lazy {
         getViewModelController(PickerShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
@@ -7,7 +7,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,17 +30,19 @@ fun PickerShowcaseView(pickerShowcaseViewModel: PickerShowcaseViewModel) {
     var expanded2 by remember { mutableStateOf(false) }
     val viewModel: PickerShowcaseViewModel by pickerShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(paddingValues)
                 .verticalScroll(state = rememberScrollState())
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
         ) {
             Row(
                 Modifier

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ProgressShowcaseActivity : ViewModelActivity<ProgressShowcaseViewModelController, ProgressShowcaseViewModel, ProgressShowcaseNavigationDelegate>(), ProgressShowcaseNavigationDelegate {
+class ProgressShowcaseActivity : BaseSampleActivity<ProgressShowcaseViewModelController, ProgressShowcaseViewModel, ProgressShowcaseNavigationDelegate>(), ProgressShowcaseNavigationDelegate {
 
     override val viewModelController: ProgressShowcaseViewModelController by lazy {
         getViewModelController(ProgressShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -25,15 +26,17 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDLinearProgr
 fun ProgressShowcaseView(progressShowcaseViewModel: ProgressShowcaseViewModel) {
     val viewModel: ProgressShowcaseViewModel by progressShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(paddingValues)
                 .verticalScroll(state = rememberScrollState())
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/snackbar/SnackbarShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/snackbar/SnackbarShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.snackbar.SnackbarShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.snackbar.SnackbarShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.snackbar.SnackbarShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class SnackbarShowcaseActivity : ViewModelActivity<SnackbarShowcaseViewModelController, SnackbarShowcaseViewModel, SnackbarShowcaseNavigationDelegate>(), SnackbarShowcaseNavigationDelegate {
+class SnackbarShowcaseActivity : BaseSampleActivity<SnackbarShowcaseViewModelController, SnackbarShowcaseViewModel, SnackbarShowcaseNavigationDelegate>(), SnackbarShowcaseNavigationDelegate {
     override val viewModelController: SnackbarShowcaseViewModelController by lazy {
         getViewModelController(SnackbarShowcaseViewModelController::class)
     }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/snackbar/SnackbarShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/snackbar/SnackbarShowcaseView.kt
@@ -8,11 +8,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -61,11 +61,11 @@ fun SnackbarShowcaseView(snackbarShowcaseViewModel: SnackbarShowcaseViewModel) {
                 ) { content ->
                     Text(
                         modifier = Modifier
-                            .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                            .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(6.dp))
                             .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
                         text = content.text,
                         style = SampleTextStyle.body.medium(),
-                        color = MaterialTheme.colors.onPrimary
+                        color = MaterialTheme.colorScheme.onPrimary
                     )
                 }
             }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseActivity.kt
@@ -5,12 +5,12 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class TextShowcaseActivity : ViewModelActivity<TextShowcaseViewModelController, TextShowcaseViewModel, TextShowcaseNavigationDelegate>(), TextShowcaseNavigationDelegate {
+class TextShowcaseActivity : BaseSampleActivity<TextShowcaseViewModelController, TextShowcaseViewModel, TextShowcaseNavigationDelegate>(), TextShowcaseNavigationDelegate {
 
     override val viewModelController: TextShowcaseViewModelController by lazy {
         getViewModelController(TextShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,15 +37,17 @@ import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDec
 fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
     val viewModel: TextShowcaseViewModel by textShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(paddingValues)
                 .verticalScroll(state = rememberScrollState())
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp),

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class TextFieldShowcaseActivity : ViewModelActivity<TextFieldShowcaseViewModelController, TextFieldShowcaseViewModel, TextFieldShowcaseNavigationDelegate>(), TextFieldShowcaseNavigationDelegate {
+class TextFieldShowcaseActivity : BaseSampleActivity<TextFieldShowcaseViewModelController, TextFieldShowcaseViewModel, TextFieldShowcaseNavigationDelegate>(), TextFieldShowcaseNavigationDelegate {
 
     override val viewModelController: TextFieldShowcaseViewModelController by lazy {
         getViewModelController(TextFieldShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
@@ -9,8 +9,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -33,71 +34,78 @@ import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDec
 fun TextFieldShowcaseView(textFieldShowcaseViewModel: TextFieldShowcaseViewModel) {
     val viewModel: TextFieldShowcaseViewModel by textFieldShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            Row(Modifier.padding(top = 16.dp), verticalAlignment = Alignment.CenterVertically) {
-                VMDTextField(viewModel = viewModel.textField)
-
-                VMDButton(
-                    modifier = Modifier.padding(start = 16.dp),
-                    viewModel = viewModel.clearButton
-                ) { content ->
-                    Text(
-                        modifier = Modifier
-                            .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                            .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                        text = content.text,
-                        style = SampleTextStyle.body.medium(),
-                        color = MaterialTheme.colors.onPrimary
-                    )
-                }
-            }
-
-            VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
         }
+    ) { paddingValues ->
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 10.dp)
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
         ) {
-            androidx.compose.material3.Text(
-                text = "Material 3",
-                style = SampleTextStyle.largeTitle
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Row(Modifier.padding(top = 16.dp), verticalAlignment = Alignment.CenterVertically) {
+                    VMDTextField(viewModel = viewModel.textField)
 
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDTextField(viewModel = viewModel.textField)
-
-                VMDButton(
-                    modifier = Modifier.padding(start = 16.dp),
-                    viewModel = viewModel.clearButton
-                ) { content ->
-                    Text(
-                        modifier = Modifier
-                            .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                            .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                        text = content.text,
-                        style = SampleTextStyle.body.medium(),
-                        color = MaterialTheme.colors.onPrimary
-                    )
+                    VMDButton(
+                        modifier = Modifier.padding(start = 16.dp),
+                        viewModel = viewModel.clearButton
+                    ) { content ->
+                        Text(
+                            modifier = Modifier
+                                .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(6.dp))
+                                .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body.medium(),
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                    }
                 }
+
+                VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
             }
 
-            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp)
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                androidx.compose.material3.Text(
+                    text = "Material 3",
+                    style = SampleTextStyle.largeTitle
+                )
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDTextField(viewModel = viewModel.textField)
+
+                    VMDButton(
+                        modifier = Modifier.padding(start = 16.dp),
+                        viewModel = viewModel.clearButton
+                    ) { content ->
+                        Text(
+                            modifier = Modifier
+                                .background(MaterialTheme.colorScheme.primary, shape = RoundedCornerShape(6.dp))
+                                .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body.medium(),
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                    }
+                }
+
+                com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+            }
         }
     }
 }

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.toggle.ToggleShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.toggle.ToggleShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.toggle.ToggleShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ToggleShowcaseActivity : ViewModelActivity<ToggleShowcaseViewModelController, ToggleShowcaseViewModel, ToggleShowcaseNavigationDelegate>(), ToggleShowcaseNavigationDelegate {
+class ToggleShowcaseActivity : BaseSampleActivity<ToggleShowcaseViewModelController, ToggleShowcaseViewModel, ToggleShowcaseNavigationDelegate>(), ToggleShowcaseNavigationDelegate {
 
     override val viewModelController: ToggleShowcaseViewModelController by lazy {
         getViewModelController(ToggleShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative-flow/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -6,7 +6,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -31,15 +32,17 @@ import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDec
 fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
     val viewModel: ToggleShowcaseViewModel by toggleShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(paddingValues)
                 .verticalScroll(state = rememberScrollState())
         ) {
             ComponentShowcaseTitle(viewModel.checkboxTitle)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/BaseSampleActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/BaseSampleActivity.kt
@@ -1,0 +1,18 @@
+package com.mirego.sample.ui
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import com.mirego.trikot.viewmodels.declarative.controller.VMDNavigationDelegate
+import com.mirego.trikot.viewmodels.declarative.controller.VMDViewModelController
+import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
+import com.mirego.trikot.viewmodels.declarative.viewmodel.VMDViewModel
+
+abstract class BaseSampleActivity<VMC : VMDViewModelController<VM, N>, VM : VMDViewModel, N : VMDNavigationDelegate> :
+    ViewModelActivity<VMC, VM, N>() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge()
+    }
+}

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/home/HomeActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/home/HomeActivity.kt
@@ -2,6 +2,7 @@ package com.mirego.sample.ui.home
 
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.ui.showcase.animation.types.AnimationTypesShowcaseActivity
 import com.mirego.sample.ui.showcase.components.button.ButtonShowcaseActivity
 import com.mirego.sample.ui.showcase.components.image.ImageShowcaseActivity
@@ -14,9 +15,8 @@ import com.mirego.sample.ui.showcase.components.toggle.ToggleShowcaseActivity
 import com.mirego.sample.viewmodels.home.HomeNavigationDelegate
 import com.mirego.sample.viewmodels.home.HomeViewModel
 import com.mirego.sample.viewmodels.home.HomeViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class HomeActivity : ViewModelActivity<HomeViewModelController, HomeViewModel, HomeNavigationDelegate>(), HomeNavigationDelegate {
+class HomeActivity : BaseSampleActivity<HomeViewModelController, HomeViewModel, HomeNavigationDelegate>(), HomeNavigationDelegate {
 
     override val viewModelController: HomeViewModelController by lazy {
         getViewModelController(HomeViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/home/HomeView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/home/HomeView.kt
@@ -1,14 +1,14 @@
 package com.mirego.sample.ui.home
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Divider
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -27,10 +27,14 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDText
 fun HomeView(homeViewModel: HomeViewModel) {
     val viewModel: HomeViewModel by homeViewModel.observeAsState()
 
-    Column(modifier = Modifier.fillMaxWidth()) {
-        TopAppBar(title = { Text(text = viewModel.title) })
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            TopAppBar(title = { Text(text = viewModel.title) })
+        }
+    ) { paddingValues ->
 
-        VMDSectionedList(viewModel = viewModel.sections) { sections ->
+        VMDSectionedList(viewModel = viewModel.sections, modifier = Modifier.padding(paddingValues)) { sections ->
             sections.forEach { section ->
                 stickyHeader {
                     VMDText(
@@ -38,7 +42,7 @@ fun HomeView(homeViewModel: HomeViewModel) {
                         viewModel = section.title,
                         fontSize = 22.sp
                     )
-                    Divider(color = Color.LightGray)
+                    HorizontalDivider(color = Color.LightGray)
                 }
 
                 items(section.elements, key = { item -> item.identifier }) { element ->
@@ -57,7 +61,7 @@ fun HomeView(homeViewModel: HomeViewModel) {
                             )
                         }
                     )
-                    Divider(color = Color.LightGray)
+                    HorizontalDivider(color = Color.LightGray)
                 }
             }
         }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/ComponentShowcaseTopBar.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/ComponentShowcaseTopBar.kt
@@ -1,6 +1,6 @@
 package com.mirego.sample.ui.showcase
 
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import com.mirego.sample.viewmodels.showcase.ShowcaseViewModel
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.LocalImage

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseActivity.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.animation.types.AnimationTypesShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
 class AnimationTypesShowcaseActivity :
-    ViewModelActivity<AnimationTypesShowcaseViewModelController, AnimationTypesShowcaseViewModel, AnimationTypesShowcaseNavigationDelegate>(), AnimationTypesShowcaseNavigationDelegate {
+    BaseSampleActivity<AnimationTypesShowcaseViewModelController, AnimationTypesShowcaseViewModel, AnimationTypesShowcaseNavigationDelegate>(), AnimationTypesShowcaseNavigationDelegate {
 
     override val viewModelController: AnimationTypesShowcaseViewModelController by lazy {
         getViewModelController(AnimationTypesShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/animation/types/AnimationTypesShowcaseView.kt
@@ -14,7 +14,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
@@ -58,19 +59,26 @@ private fun animateHorizontalAlignmentAsState(
 fun AnimationTypesShowcaseView(animationTypesShowcaseViewModel: AnimationTypesShowcaseViewModel) {
     val viewModel: AnimationTypesShowcaseViewModel by animationTypesShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
-        AnimationSection(viewModel.linear)
-        AnimationSection(viewModel.easeIn)
-        AnimationSection(viewModel.easeOut)
-        AnimationSection(viewModel.easeInEaseOut)
-        AnimationSection(viewModel.cubicBezier)
-        AnimationSection(viewModel.spring)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
+        ) {
+            AnimationSection(viewModel.linear)
+            AnimationSection(viewModel.easeIn)
+            AnimationSection(viewModel.easeOut)
+            AnimationSection(viewModel.easeInEaseOut)
+            AnimationSection(viewModel.cubicBezier)
+            AnimationSection(viewModel.spring)
+        }
     }
 }
 
@@ -87,7 +95,12 @@ private fun AnimationSection(animationTypeViewModel: AnimationTypeShowcaseViewMo
         animationSpec = linearAnimatedProperty.animationSpec()
     )
 
-    Column(modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 16.dp), horizontalAlignment = horizontalAlignment) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp),
+        horizontalAlignment = horizontalAlignment
+    ) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
             VMDText(
                 viewModel = viewModel.title,
@@ -108,9 +121,14 @@ private fun AnimationSection(animationTypeViewModel: AnimationTypeShowcaseViewMo
             }
         }
 
-        Canvas(modifier = Modifier.size(30.dp).padding(top = 10.dp), onDraw = {
-            drawCircle(Color.Red)
-        })
+        Canvas(
+            modifier = Modifier
+                .size(30.dp)
+                .padding(top = 10.dp),
+            onDraw = {
+                drawCircle(Color.Red)
+            }
+        )
     }
 }
 

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseActivity.kt
@@ -5,12 +5,12 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.button.ButtonShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ButtonShowcaseActivity : ViewModelActivity<ButtonShowcaseViewModelController, ButtonShowcaseViewModel, ButtonShowcaseNavigationDelegate>(), ButtonShowcaseNavigationDelegate {
+class ButtonShowcaseActivity : BaseSampleActivity<ButtonShowcaseViewModelController, ButtonShowcaseViewModel, ButtonShowcaseNavigationDelegate>(), ButtonShowcaseNavigationDelegate {
 
     override val viewModelController: ButtonShowcaseViewModelController by lazy {
         getViewModelController(ButtonShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/button/ButtonShowcaseView.kt
@@ -13,7 +13,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -42,163 +43,170 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDB
 fun ButtonShowcaseView(buttonShowcaseViewModel: ButtonShowcaseViewModel) {
     val viewModel: ButtonShowcaseViewModel by buttonShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
-
-        ComponentShowcaseTitle(viewModel.textButtonTitle)
-
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textButton
-        ) { content ->
-            Text(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                text = content.text,
-                style = SampleTextStyle.body.medium(),
-                color = MaterialTheme.colors.onPrimary
-            )
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
         }
+    ) { paddingValues ->
 
-        ComponentShowcaseTitle(viewModel.imageButtonTitle)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
+        ) {
+            ComponentShowcaseTitle(viewModel.textButtonTitle)
 
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.imageButton
-        ) { content ->
-            LocalImage(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(4.dp),
-                imageResource = content.image,
-                contentDescription = content.contentDescription
-            )
-        }
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.textButton
+            ) { content ->
+                Text(
+                    modifier = Modifier
+                        .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                    text = content.text,
+                    style = SampleTextStyle.body.medium(),
+                    color = MaterialTheme.colors.onPrimary
+                )
+            }
 
-        ComponentShowcaseTitle(viewModel.textImageButtonTitle)
+            ComponentShowcaseTitle(viewModel.imageButtonTitle)
 
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textImageButton
-        ) { content ->
-            Row(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.imageButton
+            ) { content ->
                 LocalImage(
-                    modifier = Modifier.padding(end = 8.dp),
+                    modifier = Modifier
+                        .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(4.dp),
                     imageResource = content.image,
                     contentDescription = content.contentDescription
                 )
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.onPrimary
-                )
             }
-        }
 
-        ComponentShowcaseTitle(viewModel.textPairButtonTitle)
+            ComponentShowcaseTitle(viewModel.textImageButtonTitle)
 
-        VMDButton(
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
-            viewModel = viewModel.textPairButton
-        ) { content ->
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.textImageButton
+            ) { content ->
+                Row(
+                    modifier = Modifier
+                        .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    LocalImage(
+                        modifier = Modifier.padding(end = 8.dp),
+                        imageResource = content.image,
+                        contentDescription = content.contentDescription
+                    )
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.onPrimary
+                    )
+                }
+            }
+
+            ComponentShowcaseTitle(viewModel.textPairButtonTitle)
+
+            VMDButton(
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+                viewModel = viewModel.textPairButton
+            ) { content ->
+                Column(
+                    modifier = Modifier
+                        .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                        .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = content.first,
+                        style = SampleTextStyle.title2,
+                        color = MaterialTheme.colors.onPrimary
+                    )
+                    Text(
+                        text = content.second,
+                        style = SampleTextStyle.body,
+                        color = MaterialTheme.colors.onPrimary
+                    )
+                }
+            }
+
             Column(
-                modifier = Modifier
-                    .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                    .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Text(
-                    text = content.first,
-                    style = SampleTextStyle.title2,
-                    color = MaterialTheme.colors.onPrimary
-                )
-                Text(
-                    text = content.second,
-                    style = SampleTextStyle.body,
-                    color = MaterialTheme.colors.onPrimary
-                )
-            }
-        }
+                ComponentShowcaseTitle("Material 3 Elevated Button")
 
-        Column(
-            Modifier
-                .padding(horizontal = 16.dp)
-                .padding(top = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            ComponentShowcaseTitle("Material 3 Elevated Button")
+                VMDElevatedButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.primary
+                    )
+                }
 
-            VMDElevatedButton(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
-                )
-            }
+                VMDElevatedButton(viewModel.textImageButton) { content ->
+                    LocalImage(
+                        imageResource = content.image,
+                        contentDescription = content.contentDescription,
+                        modifier = Modifier.size(18.dp),
+                        colorFilter = ColorFilter.tint(MaterialTheme.colors.primary)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.primary
+                    )
+                }
 
-            VMDElevatedButton(viewModel.textImageButton) { content ->
-                LocalImage(
-                    imageResource = content.image,
-                    contentDescription = content.contentDescription,
-                    modifier = Modifier.size(18.dp),
-                    colorFilter = ColorFilter.tint(MaterialTheme.colors.primary)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
-                )
-            }
+                ComponentShowcaseTitle("Material 3 Filled Button")
 
-            ComponentShowcaseTitle("Material 3 Filled Button")
+                VMDMaterial3Button(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.onPrimary
+                    )
+                }
 
-            VMDMaterial3Button(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.onPrimary
-                )
-            }
+                ComponentShowcaseTitle("Material 3 Filled Tonal Button")
 
-            ComponentShowcaseTitle("Material 3 Filled Tonal Button")
+                VMDFilledTonalButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.onSecondary
+                    )
+                }
 
-            VMDFilledTonalButton(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.onSecondary
-                )
-            }
+                ComponentShowcaseTitle("Material 3 Filled Outlined Button")
 
-            ComponentShowcaseTitle("Material 3 Filled Outlined Button")
+                VMDOutlinedButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.primary
+                    )
+                }
 
-            VMDOutlinedButton(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
-                )
-            }
+                ComponentShowcaseTitle("Material 3 Filled Text Button")
 
-            ComponentShowcaseTitle("Material 3 Filled Text Button")
-
-            VMDTextButton(viewModel.textButton) { content ->
-                Text(
-                    text = content.text,
-                    style = SampleTextStyle.body.medium(),
-                    color = MaterialTheme.colors.primary
-                )
+                VMDTextButton(viewModel.textButton) { content ->
+                    Text(
+                        text = content.text,
+                        style = SampleTextStyle.body.medium(),
+                        color = MaterialTheme.colors.primary
+                    )
+                }
             }
         }
     }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.image.ImageShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ImageShowcaseActivity : ViewModelActivity<ImageShowcaseViewModelController, ImageShowcaseViewModel, ImageShowcaseNavigationDelegate>(), ImageShowcaseNavigationDelegate {
+class ImageShowcaseActivity : BaseSampleActivity<ImageShowcaseViewModelController, ImageShowcaseViewModel, ImageShowcaseNavigationDelegate>(), ImageShowcaseNavigationDelegate {
 
     override val viewModelController: ImageShowcaseViewModelController by lazy {
         getViewModelController(ImageShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/image/ImageShowcaseView.kt
@@ -9,7 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,105 +36,112 @@ fun ImageShowcaseView(imageShowcaseViewModel: ImageShowcaseViewModel) {
     val viewModel: ImageShowcaseViewModel by imageShowcaseViewModel.observeAsState()
     val imageAspectRatio = 1.5f
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
-        ComponentShowcaseTitle(viewModel.localImageTitle)
-
-        VMDImage(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.localImage,
-            contentScale = ContentScale.Crop
-        )
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
+        ) {
+            ComponentShowcaseTitle(viewModel.localImageTitle)
 
-        ComponentShowcaseTitle(viewModel.remoteImageTitle)
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.localImage,
+                contentScale = ContentScale.Crop
+            )
 
-        VMDImage(
-            modifier = Modifier
+            ComponentShowcaseTitle(viewModel.remoteImageTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.remoteImage,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.localImageDescriptorTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp),
+                imageDescriptor = viewModel.localImageDescriptor,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.remoteImageDescriptorTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+                imageDescriptor = viewModel.remoteImageDescriptor,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.placeholderImageTitle)
+
+            VMDImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(imageAspectRatio)
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
+                viewModel = viewModel.placeholderImage,
+                contentScale = ContentScale.Crop
+            )
+
+            ComponentShowcaseTitle(viewModel.complexPlaceholderImageTitle)
+
+            val imageModifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.remoteImage,
-            contentScale = ContentScale.Crop
-        )
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
 
-        ComponentShowcaseTitle(viewModel.localImageDescriptorTitle)
-
-        VMDImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
-            imageDescriptor = viewModel.localImageDescriptor,
-            contentScale = ContentScale.Crop
-        )
-
-        ComponentShowcaseTitle(viewModel.remoteImageDescriptorTitle)
-
-        VMDImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
-            imageDescriptor = viewModel.remoteImageDescriptor,
-            contentScale = ContentScale.Crop
-        )
-
-        ComponentShowcaseTitle(viewModel.placeholderImageTitle)
-
-        VMDImage(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(imageAspectRatio)
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp),
-            viewModel = viewModel.placeholderImage,
-            contentScale = ContentScale.Crop
-        )
-
-        ComponentShowcaseTitle(viewModel.complexPlaceholderImageTitle)
-
-        val imageModifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(imageAspectRatio)
-            .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp)
-
-        VMDImage(
-            modifier = imageModifier,
-            viewModel = viewModel.complexPlaceholderImage,
-            contentScale = ContentScale.Crop,
-            placeholderContentScale = ContentScale.Crop,
-            placeholder = { placeholderImageResource, state ->
-                Column(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .background(Color.LightGray.copy(alpha = 0.5f)),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    LocalImage(
-                        imageResource = placeholderImageResource,
+            VMDImage(
+                modifier = imageModifier,
+                viewModel = viewModel.complexPlaceholderImage,
+                contentScale = ContentScale.Crop,
+                placeholderContentScale = ContentScale.Crop,
+                placeholder = { placeholderImageResource, state ->
+                    Column(
                         modifier = Modifier
-                            .size(width = (50 * imageAspectRatio).dp, height = 50.dp)
-                            .padding(bottom = 10.dp),
-                        contentScale = ContentScale.Crop
-                    )
+                            .matchParentSize()
+                            .background(Color.LightGray.copy(alpha = 0.5f)),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        LocalImage(
+                            imageResource = placeholderImageResource,
+                            modifier = Modifier
+                                .size(width = (50 * imageAspectRatio).dp, height = 50.dp)
+                                .padding(bottom = 10.dp),
+                            contentScale = ContentScale.Crop
+                        )
 
-                    when (state) {
-                        is AsyncImagePainter.State.Empty -> Text("There is no image to display", style = SampleTextStyle.subheadline)
-                        is AsyncImagePainter.State.Loading -> Text("Loading", style = SampleTextStyle.subheadline)
-                        is AsyncImagePainter.State.Error -> Text("Unable to load the remote image", style = SampleTextStyle.subheadline)
-                        else -> {}
+                        when (state) {
+                            is AsyncImagePainter.State.Empty -> Text("There is no image to display", style = SampleTextStyle.subheadline)
+                            is AsyncImagePainter.State.Loading -> Text("Loading", style = SampleTextStyle.subheadline)
+                            is AsyncImagePainter.State.Error -> Text("Unable to load the remote image", style = SampleTextStyle.subheadline)
+                            else -> {}
+                        }
                     }
                 }
-            }
-        )
+            )
+        }
     }
 }
 

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ListShowcaseActivity : ViewModelActivity<ListShowcaseViewModelController, ListShowcaseViewModel, ListShowcaseNavigationDelegate>(), ListShowcaseNavigationDelegate {
+class ListShowcaseActivity : BaseSampleActivity<ListShowcaseViewModelController, ListShowcaseViewModel, ListShowcaseNavigationDelegate>(), ListShowcaseNavigationDelegate {
 
     override val viewModelController: ListShowcaseViewModelController by lazy {
         getViewModelController(ListShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/list/ListShowcaseView.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Divider
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.mirego.sample.ui.showcase.ComponentShowcaseTopBar
 import com.mirego.sample.viewmodels.showcase.components.list.ListShowcaseViewModel
@@ -23,33 +25,39 @@ import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDText
 fun ListShowcaseView(listShowcaseViewModel: ListShowcaseViewModel) {
     val viewModel: ListShowcaseViewModel by listShowcaseViewModel.observeAsState()
 
-    Box(
-        Modifier.fillMaxSize()
-    ) {
-        ComponentShowcaseTopBar(viewModel)
-
-        VMDLazyRow(
-            modifier = Modifier.padding(top = 80.dp),
-            viewModel = viewModel.listViewModel,
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(16.dp)
-        ) { element ->
-            VMDText(viewModel = element.content)
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
         }
+    ) { paddingValues ->
 
-        VMDLazyColumnIndexed(
-            modifier = Modifier
-                .padding(top = 150.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.listViewModel,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            contentPadding = PaddingValues(16.dp)
-        ) { index, element ->
-            Column {
-                if (index != 0) {
-                    Divider(modifier = Modifier.padding(bottom = 16.dp))
-                }
+        Box(
+            Modifier.fillMaxSize().padding(paddingValues)
+        ) {
+            VMDLazyRow(
+                modifier = Modifier.padding(top = 80.dp),
+                viewModel = viewModel.listViewModel,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(16.dp)
+            ) { element ->
                 VMDText(viewModel = element.content)
+            }
+
+            VMDLazyColumnIndexed(
+                modifier = Modifier
+                    .padding(top = 150.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.listViewModel,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(16.dp)
+            ) { index, element ->
+                Column {
+                    if (index != 0) {
+                        HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp), color = Color.LightGray)
+                    }
+                    VMDText(viewModel = element.content)
+                }
             }
         }
     }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class PickerShowcaseActivity : ViewModelActivity<PickerShowcaseViewModelController, PickerShowcaseViewModel, PickerShowcaseNavigationDelegate>(), PickerShowcaseNavigationDelegate {
+class PickerShowcaseActivity : BaseSampleActivity<PickerShowcaseViewModelController, PickerShowcaseViewModel, PickerShowcaseNavigationDelegate>(), PickerShowcaseNavigationDelegate {
 
     override val viewModelController: PickerShowcaseViewModelController by lazy {
         getViewModelController(PickerShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/picker/PickerShowcaseView.kt
@@ -7,7 +7,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,6 +23,7 @@ import com.mirego.sample.viewmodels.showcase.components.picker.PickerShowcaseVie
 import com.mirego.trikot.viewmodels.declarative.compose.extensions.observeAsState
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDDropDownMenu
 import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.VMDDropDownMenuItem
+import com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDDropDownMenuItem
 
 @Composable
 fun PickerShowcaseView(pickerShowcaseViewModel: PickerShowcaseViewModel) {
@@ -29,72 +31,79 @@ fun PickerShowcaseView(pickerShowcaseViewModel: PickerShowcaseViewModel) {
     var expanded2 by remember { mutableStateOf(false) }
     val viewModel: PickerShowcaseViewModel by pickerShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
-        Row(
-            Modifier
+        Column(
+            modifier = Modifier
                 .fillMaxWidth()
-                .clickable {
-                    expanded = true
-                }
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
         ) {
-            ComponentShowcaseTitle(viewModel.textPickerTitle)
-        }
-
-        VMDDropDownMenu(
-            viewModel = viewModel.textPicker,
-            expanded = expanded,
-            onDismissRequest = {
-                expanded = false
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        expanded = true
+                    }
+            ) {
+                ComponentShowcaseTitle(viewModel.textPickerTitle)
             }
-        ) { item, index ->
-            VMDDropDownMenuItem(
-                pickerViewModel = viewModel.textPicker,
-                viewModel = item,
-                index = index,
-                onClick = { expanded = false }
-            ) { pickerItem, _ ->
-                Text(text = pickerItem.content.text)
-            }
-        }
 
-        androidx.compose.material3.Text(
-            modifier = Modifier.padding(top = 16.dp, start = 16.dp),
-            text = "Material 3",
-            style = SampleTextStyle.largeTitle
-        )
-
-        Row(
-            Modifier
-                .fillMaxWidth()
-                .clickable {
-                    expanded2 = true
+            VMDDropDownMenu(
+                viewModel = viewModel.textPicker,
+                expanded = expanded,
+                onDismissRequest = {
+                    expanded = false
                 }
-        ) {
-            ComponentShowcaseTitle(viewModel.textPickerTitle2)
-        }
-
-        VMDDropDownMenu(
-            viewModel = viewModel.textPicker2,
-            expanded = expanded2,
-            onDismissRequest = {
-                expanded2 = false
-            }
-        ) { item, index ->
-            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDDropDownMenuItem(
-                pickerViewModel = viewModel.textPicker2,
-                viewModel = item,
-                index = index,
-                onClick = { expanded2 = false },
-                text = {
-                    Text(text = item.content.text)
+            ) { item, index ->
+                VMDDropDownMenuItem(
+                    pickerViewModel = viewModel.textPicker,
+                    viewModel = item,
+                    index = index,
+                    onClick = { expanded = false }
+                ) { pickerItem, _ ->
+                    Text(text = pickerItem.content.text)
                 }
+            }
+
+            androidx.compose.material3.Text(
+                modifier = Modifier.padding(top = 16.dp, start = 16.dp),
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
             )
+
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable {
+                        expanded2 = true
+                    }
+            ) {
+                ComponentShowcaseTitle(viewModel.textPickerTitle2)
+            }
+
+            VMDDropDownMenu(
+                viewModel = viewModel.textPicker2,
+                expanded = expanded2,
+                onDismissRequest = {
+                    expanded2 = false
+                }
+            ) { item, index ->
+                VMDDropDownMenuItem(
+                    pickerViewModel = viewModel.textPicker2,
+                    viewModel = item,
+                    index = index,
+                    onClick = { expanded2 = false },
+                    text = {
+                        Text(text = item.content.text)
+                    }
+                )
+            }
         }
     }
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/progress/ProgressShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.progress.ProgressShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ProgressShowcaseActivity : ViewModelActivity<ProgressShowcaseViewModelController, ProgressShowcaseViewModel, ProgressShowcaseNavigationDelegate>(), ProgressShowcaseNavigationDelegate {
+class ProgressShowcaseActivity : BaseSampleActivity<ProgressShowcaseViewModelController, ProgressShowcaseViewModel, ProgressShowcaseNavigationDelegate>(), ProgressShowcaseNavigationDelegate {
 
     override val viewModelController: ProgressShowcaseViewModelController by lazy {
         getViewModelController(ProgressShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.text.TextShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class TextShowcaseActivity : ViewModelActivity<TextShowcaseViewModelController, TextShowcaseViewModel, TextShowcaseNavigationDelegate>(), TextShowcaseNavigationDelegate {
+class TextShowcaseActivity : BaseSampleActivity<TextShowcaseViewModelController, TextShowcaseViewModel, TextShowcaseNavigationDelegate>(), TextShowcaseNavigationDelegate {
 
     override val viewModelController: TextShowcaseViewModelController by lazy {
         getViewModelController(TextShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/text/TextShowcaseView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,15 +28,17 @@ import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDec
 fun TextShowcaseView(textShowcaseViewModel: TextShowcaseViewModel) {
     val viewModel: TextShowcaseViewModel by textShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(paddingValues)
                 .verticalScroll(state = rememberScrollState())
                 .padding(bottom = 16.dp)
                 .padding(horizontal = 16.dp),

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.textfield.TextFieldShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class TextFieldShowcaseActivity : ViewModelActivity<TextFieldShowcaseViewModelController, TextFieldShowcaseViewModel, TextFieldShowcaseNavigationDelegate>(), TextFieldShowcaseNavigationDelegate {
+class TextFieldShowcaseActivity : BaseSampleActivity<TextFieldShowcaseViewModelController, TextFieldShowcaseViewModel, TextFieldShowcaseNavigationDelegate>(), TextFieldShowcaseNavigationDelegate {
 
     override val viewModelController: TextFieldShowcaseViewModelController by lazy {
         getViewModelController(TextFieldShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/textfield/TextFieldShowcaseView.kt
@@ -10,7 +10,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -33,71 +34,78 @@ import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDec
 fun TextFieldShowcaseView(textFieldShowcaseViewModel: TextFieldShowcaseViewModel) {
     val viewModel: TextFieldShowcaseViewModel by textFieldShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
-        ) {
-            Row(Modifier.padding(top = 16.dp), verticalAlignment = Alignment.CenterVertically) {
-                VMDTextField(viewModel = viewModel.textField)
-
-                VMDButton(
-                    modifier = Modifier.padding(start = 16.dp),
-                    viewModel = viewModel.clearButton
-                ) { content ->
-                    Text(
-                        modifier = Modifier
-                            .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                            .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                        text = content.text,
-                        style = SampleTextStyle.body.medium(),
-                        color = MaterialTheme.colors.onPrimary
-                    )
-                }
-            }
-
-            VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
         }
+    ) { paddingValues ->
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 10.dp)
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
         ) {
-            androidx.compose.material3.Text(
-                text = "Material 3",
-                style = SampleTextStyle.largeTitle
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Row(Modifier.padding(top = 16.dp), verticalAlignment = Alignment.CenterVertically) {
+                    VMDTextField(viewModel = viewModel.textField)
 
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDTextField(viewModel = viewModel.textField)
-
-                VMDButton(
-                    modifier = Modifier.padding(start = 16.dp),
-                    viewModel = viewModel.clearButton
-                ) { content ->
-                    Text(
-                        modifier = Modifier
-                            .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
-                            .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                        text = content.text,
-                        style = SampleTextStyle.body.medium(),
-                        color = MaterialTheme.colors.onPrimary
-                    )
+                    VMDButton(
+                        modifier = Modifier.padding(start = 16.dp),
+                        viewModel = viewModel.clearButton
+                    ) { content ->
+                        Text(
+                            modifier = Modifier
+                                .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                                .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body.medium(),
+                            color = MaterialTheme.colors.onPrimary
+                        )
+                    }
                 }
+
+                VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
             }
 
-            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp)
+                    .padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                androidx.compose.material3.Text(
+                    text = "Material 3",
+                    style = SampleTextStyle.largeTitle
+                )
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDTextField(viewModel = viewModel.textField)
+
+                    VMDButton(
+                        modifier = Modifier.padding(start = 16.dp),
+                        viewModel = viewModel.clearButton
+                    ) { content ->
+                        Text(
+                            modifier = Modifier
+                                .background(MaterialTheme.colors.primary, shape = RoundedCornerShape(6.dp))
+                                .padding(start = 8.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body.medium(),
+                            color = MaterialTheme.colors.onPrimary
+                        )
+                    }
+                }
+
+                com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDText(viewModel = viewModel.characterCountText, style = SampleTextStyle.caption1)
+            }
         }
     }
 }

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseActivity.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import com.mirego.sample.ui.BaseSampleActivity
 import com.mirego.sample.viewmodels.showcase.components.toggle.ToggleShowcaseNavigationDelegate
 import com.mirego.sample.viewmodels.showcase.components.toggle.ToggleShowcaseViewModel
 import com.mirego.sample.viewmodels.showcase.components.toggle.ToggleShowcaseViewModelController
-import com.mirego.trikot.viewmodels.declarative.controller.ViewModelActivity
 
-class ToggleShowcaseActivity : ViewModelActivity<ToggleShowcaseViewModelController, ToggleShowcaseViewModel, ToggleShowcaseNavigationDelegate>(), ToggleShowcaseNavigationDelegate {
+class ToggleShowcaseActivity : BaseSampleActivity<ToggleShowcaseViewModelController, ToggleShowcaseViewModel, ToggleShowcaseNavigationDelegate>(), ToggleShowcaseNavigationDelegate {
 
     override val viewModelController: ToggleShowcaseViewModelController by lazy {
         getViewModelController(ToggleShowcaseViewModelController::class)

--- a/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
+++ b/trikot-viewmodels-declarative/sample/android/src/main/java/com/mirego/sample/ui/showcase/components/toggle/ToggleShowcaseView.kt
@@ -6,7 +6,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -31,325 +32,332 @@ import com.mirego.trikot.viewmodels.declarative.configuration.TrikotViewModelDec
 fun ToggleShowcaseView(toggleShowcaseViewModel: ToggleShowcaseViewModel) {
     val viewModel: ToggleShowcaseViewModel by toggleShowcaseViewModel.observeAsState()
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .verticalScroll(state = rememberScrollState())
-    ) {
-        ComponentShowcaseTopBar(viewModel)
+    Scaffold(
+        modifier = Modifier.fillMaxWidth(),
+        topBar = {
+            ComponentShowcaseTopBar(viewModel)
+        }
+    ) { paddingValues ->
 
-        ComponentShowcaseTitle(viewModel.checkboxTitle)
-
-        VMDCheckbox(
+        Column(
             modifier = Modifier
-                .padding(start = 2.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.emptyToggle
-        )
+                .fillMaxWidth()
+                .padding(paddingValues)
+                .verticalScroll(state = rememberScrollState())
+        ) {
+            ComponentShowcaseTitle(viewModel.checkboxTitle)
 
-        ComponentShowcaseTitle(viewModel.textCheckboxTitle)
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 2.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.emptyToggle
+            )
 
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textToggle,
-            label = { Text(it.text, style = SampleTextStyle.body) }
-        )
+            ComponentShowcaseTitle(viewModel.textCheckboxTitle)
 
-        ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
 
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.imageToggle,
-            label = { content ->
-                LocalImage(
-                    imageResource = content.image,
-                    colorFilter = ColorFilter.tint(Color.Black)
-                )
-            }
-        )
+            ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
 
-        ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
-
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textImageToggle,
-            label = { content ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
                     LocalImage(
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
-                    Text(
-                        text = content.text,
-                        style = SampleTextStyle.body
-                    )
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
 
-        VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textPairToggle,
-            label = { content ->
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = content.first,
-                        style = SampleTextStyle.body
-                    )
-                    Text(
-                        text = content.second,
-                        style = SampleTextStyle.caption1
-                    )
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.switchTitle)
+            ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
 
-        VMDSwitch(
-            modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.emptyToggle
-        )
+            VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
 
-        ComponentShowcaseTitle(viewModel.textSwitchTitle)
+            ComponentShowcaseTitle(viewModel.switchTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textToggle,
-            label = { Text(it.text, style = SampleTextStyle.body) }
-        )
+            VMDSwitch(
+                modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.emptyToggle
+            )
 
-        ComponentShowcaseTitle(viewModel.imageSwitchTitle)
+            ComponentShowcaseTitle(viewModel.textSwitchTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.imageToggle,
-            label = { content ->
-                LocalImage(
-                    imageResource = content.image,
-                    colorFilter = ColorFilter.tint(Color.Black)
-                )
-            }
-        )
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
 
-        ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
+            ComponentShowcaseTitle(viewModel.imageSwitchTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textImageToggle,
-            label = { content ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
                     LocalImage(
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
-                    Text(
-                        modifier = Modifier.padding(start = 8.dp),
-                        text = content.text,
-                        style = SampleTextStyle.body
-                    )
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
+            ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
 
-        VMDSwitch(
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textPairToggle,
-            label = { content ->
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = content.first,
-                        style = SampleTextStyle.body
-                    )
-                    Text(
-                        text = content.second,
-                        style = SampleTextStyle.caption1
-                    )
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            modifier = Modifier.padding(start = 8.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
                 }
-            }
-        )
+            )
 
-        androidx.compose.material3.Text(
-            text = "Material 3",
-            style = SampleTextStyle.largeTitle
-        )
+            ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
 
-        ComponentShowcaseTitle(viewModel.textCheckboxTitle)
+            VMDSwitch(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textToggle,
-            label = { Text(it.text, style = SampleTextStyle.body) }
-        )
+            androidx.compose.material3.Text(
+                text = "Material 3",
+                style = SampleTextStyle.largeTitle
+            )
 
-        ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.textCheckboxTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.imageToggle,
-            label = { content ->
-                LocalImage(
-                    imageResource = content.image,
-                    colorFilter = ColorFilter.tint(Color.Black)
-                )
-            }
-        )
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
 
-        ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.imageCheckboxTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textImageToggle,
-            label = { content ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
                     LocalImage(
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
-                    Text(
-                        text = content.text,
-                        style = SampleTextStyle.body
-                    )
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
+            ComponentShowcaseTitle(viewModel.textImageCheckboxTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textPairToggle,
-            label = { content ->
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = content.first,
-                        style = SampleTextStyle.body
-                    )
-                    Text(
-                        text = content.second,
-                        style = SampleTextStyle.caption1
-                    )
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.switchTitle)
+            ComponentShowcaseTitle(viewModel.textPairCheckboxTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
-            modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
-            viewModel = viewModel.emptyToggle
-        )
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDCheckbox(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
 
-        ComponentShowcaseTitle(viewModel.textSwitchTitle)
+            ComponentShowcaseTitle(viewModel.switchTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textToggle,
-            label = { Text(it.text, style = SampleTextStyle.body) }
-        )
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier.padding(start = 10.dp, top = 16.dp, end = 16.dp),
+                viewModel = viewModel.emptyToggle
+            )
 
-        ComponentShowcaseTitle(viewModel.imageSwitchTitle)
+            ComponentShowcaseTitle(viewModel.textSwitchTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.imageToggle,
-            label = { content ->
-                LocalImage(
-                    imageResource = content.image,
-                    colorFilter = ColorFilter.tint(Color.Black)
-                )
-            }
-        )
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textToggle,
+                label = { Text(it.text, style = SampleTextStyle.body) }
+            )
 
-        ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
+            ComponentShowcaseTitle(viewModel.imageSwitchTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
-            modifier = Modifier
-                .padding(start = 16.dp, top = 16.dp, end = 16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textImageToggle,
-            label = { content ->
-                Row(
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.imageToggle,
+                label = { content ->
                     LocalImage(
                         imageResource = content.image,
                         colorFilter = ColorFilter.tint(Color.Black)
                     )
-                    Text(
-                        modifier = Modifier.padding(start = 8.dp),
-                        text = content.text,
-                        style = SampleTextStyle.body
-                    )
                 }
-            }
-        )
+            )
 
-        ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
+            ComponentShowcaseTitle(viewModel.textImageSwitchTitle)
 
-        com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
-            modifier = Modifier
-                .padding(16.dp)
-                .fillMaxWidth(),
-            viewModel = viewModel.textPairToggle,
-            label = { content ->
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = content.first,
-                        style = SampleTextStyle.body
-                    )
-                    Text(
-                        text = content.second,
-                        style = SampleTextStyle.caption1
-                    )
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(start = 16.dp, top = 16.dp, end = 16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textImageToggle,
+                label = { content ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LocalImage(
+                            imageResource = content.image,
+                            colorFilter = ColorFilter.tint(Color.Black)
+                        )
+                        Text(
+                            modifier = Modifier.padding(start = 8.dp),
+                            text = content.text,
+                            style = SampleTextStyle.body
+                        )
+                    }
                 }
-            }
-        )
+            )
+
+            ComponentShowcaseTitle(viewModel.textPairSwitchTitle)
+
+            com.mirego.trikot.viewmodels.declarative.compose.viewmodel.material3.VMDSwitch(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                viewModel = viewModel.textPairToggle,
+                label = { content ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = content.first,
+                            style = SampleTextStyle.body
+                        )
+                        Text(
+                            text = content.second,
+                            style = SampleTextStyle.caption1
+                        )
+                    }
+                }
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This ads support for edge to edge in VMD sample. Also switches a few material imports for m3 in those samples so default theme changed a bit too.

## Motivation and Context

edge-to-edge was not properly supported yet in VMD sample and since now it's pretty much mandatory, it lead to content displaying behind status bar.

## How Has This Been Tested?

| Before | After |
|--------|--------|
| <img width="1080" height="2400" alt="Screenshot_20250930_172247" src="https://github.com/user-attachments/assets/e4462f01-f2df-4a0e-af98-348a28560711" /> | <img width="1080" height="2400" alt="Screenshot_20250930_171006" src="https://github.com/user-attachments/assets/7f2812d6-56ff-405e-a700-686b36b69e8f" /> |

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
