### PR TITLE
In AndroidBluetoothManager, make sure the ScanCallback does not publish a value after is has failed

### DIFF
--- a/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
+++ b/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
@@ -101,7 +101,7 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
 
         val callback = object : ScanCallback() {
             val foundDevice = ConcurrentHashMap<String, BluetoothScanResult>()
-            
+
             @Volatile var failed = false
 
             override fun onBatchScanResults(results: MutableList<ScanResult>?) {

--- a/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
+++ b/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
@@ -101,8 +101,10 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
 
         val callback = object : ScanCallback() {
             val foundDevice = ConcurrentHashMap<String, BluetoothScanResult>()
+            @Volatile var failed = false
 
             override fun onBatchScanResults(results: MutableList<ScanResult>?) {
+                if (failed) return
                 super.onBatchScanResults(results)
                 results?.let {
                     results.forEach {
@@ -113,10 +115,12 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
 
             override fun onScanFailed(errorCode: Int) {
                 super.onScanFailed(errorCode)
+                failed = true
                 devicesPublisher.error = Exception("$errorCode")
             }
 
             override fun onScanResult(callbackType: Int, result: ScanResult?) {
+                if (failed) return
                 super.onScanResult(callbackType, result)
                 result?.let {
                     if (callbackType == ScanSettings.CALLBACK_TYPE_MATCH_LOST) {

--- a/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
+++ b/trikot-bluetooth/bluetooth/src/androidMain/kotlin/com/mirego/trikot/bluetooth/android/AndroidBluetoothManager.kt
@@ -101,6 +101,7 @@ class AndroidBluetoothManager(val context: Context) : BluetoothManager {
 
         val callback = object : ScanCallback() {
             val foundDevice = ConcurrentHashMap<String, BluetoothScanResult>()
+            
             @Volatile var failed = false
 
             override fun onBatchScanResults(results: MutableList<ScanResult>?) {


### PR DESCRIPTION
Provide a fix for a potential race condition in Android's implementation of trikot-bluetooth BluetoothManager.

<!--- Provide a general summary of your changes in the Title above -->

## Description

In AndroidBluetoothManager, in scanForDevices ScanCallback instance, keep track of failure (with a volatile boolean) to avoid trying to publish a value when the other callback's methods are potentially called.

<!--- Describe your changes in detail -->

## Motivation and Context

Trying to push a value on a Publisher after it has been put in a state of error is invalid. However, in this case, the lifecycle of the callback is managed externally (through the CancellableManager passed as parameter). Depending on how it is managed, it may not necessarily be cancelled as soon as an error is caught. Moreover, there is a possible race condition where scanFailed and scanResult (then can be called from different threads) are called within a window smaller than the flow required to cancel.

With this simple volatile boolean switch, we ensure that any result received after a failure is ignored.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
