### PR TITLE
Fix URLSessionTask Cancellable conformance breaking under Xcode 26

### DIFF
--- a/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
+++ b/trikot-viewmodels/swift-extensions/UIImageViewExtensions.swift
@@ -213,13 +213,11 @@ public class DefaultImageViewModelHandler: ImageViewModelHandler {
                     }
                 }
             }
-            cancellableManager.add(cancellable: dataTask)
+            cancellableManager.add { dataTask.cancel() }
             dataTask.resume()
         }
     }
 }
-
-extension URLSessionTask: Cancellable {}
 
 private extension UIImage {
     var cacheCost: Int {


### PR DESCRIPTION
## Problem

`extension URLSessionTask: Cancellable {}` breaks under Xcode 26, even in Swift 5 mode:

```
error: Objective-C method 'cancel' provided by method 'cancel()' does not match the requirement's selector ('cancel_')
```

The Kotlin/Native-generated `Cancellable` protocol requires ObjC selector `cancel_`, while `URLSessionTask.cancel()` has selector `cancel`. Xcode 26 enforces strict ObjC selector matching for protocol conformances and rejects the implicit witness.

The error only surfaces in projects that do **not** include `Trikot/http`. If your project uses `Trikot/http`, the conformance is silently accepted — likely a Swift compiler quirk where ObjC selector validation is affected by compilation unit composition (see Notes). This means most existing projects won't see the error until they drop `Trikot/http` or start a new project without it.

## Fix

Instead of working around the ObjC interop mismatch, we eliminate the conformance entirely by using the closure overload on `CancellableManager`:

```swift
// Before
cancellableManager.add(cancellable: dataTask)

// After
cancellableManager.add { dataTask.cancel() }
```

The empty `extension URLSessionTask: Cancellable {}` is removed along with it. This is consistent with how `KFImageViewModelHandler` already cancels its `URLSessionTask`.

## Notes

The conformance was always semantically broken — the error was just not enforced in earlier Xcode versions. Interestingly, the error only surfaces when `trikot.http` is absent from the consuming project's compilation unit. After ruling out build settings (xcconfig files are identical between configurations), the most likely explanation is a Swift compiler quirk in Xcode 26 where ObjC selector validation on protocol conformances is affected by compilation unit composition.